### PR TITLE
Update delegation01

### DIFF
--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -20,45 +20,33 @@ The domain name to be tested ("child zone").
 
 ## Ordered description of steps to be taken to execute the test case
 
-1. Obtain the complete set of the names of the name servers for the *child 
-   zone* (distinct NS records) from parent using [Method2].
-2. If the number of name servers from parent is at least two, emit the
-   *ENOUGH_NS_PARENT*, else emit *NOT_ENOUGH_NS_PARENT*.
-3. Obtain the IP addresses for the set of the name servers from parent 
-   using [Method4].
-4. If there are no name servers from parent resolving to an IPv4 
-   address then emit *NO_IPV4_NS_PARENT*.
-5. If the number of name servers from parent resolving to an IPv4 
-   address is one then emit *NOT_ENOUGH_IPV4_NS_PARENT*.
-6. If the number of name servers from parent resolving to an IPv4 
-   address is at least two then emit *ENOUGH_IPV4_NS_PARENT*.
-7. If there are no name servers from parent resolving to an IPv6 
-   address then emit *NO_IPV6_NS_PARENT*.
-8. If the number of name servers from parent resolving to an IPv6 
-   address is one then emit *NOT_ENOUGH_IPV6_NS_PARENT*.
-9. If the number of name servers from parent resolving to an IPv6 
-   address is at least two then emit *ENOUGH_IPV6_NS_PARENT*.
-10. Obtain the complete set of the names of the name servers for the 
-    *child zone* from the *child zone* using [Method3].
-11. If the number of name servers from child is at least two emit the
-   *ENOUGH_NS_CHILD*, else emit *NOT_ENOUGH_NS_CHILD*.
-12. Obtain the IP addresses for the set of the name servers from 
-    *child zone* using [Method5] and, for 
-    out-of-bailiwick NS, using [Method4].
-13. If there are no name servers from child resolving to an IPv4 
-   address then emit *NO_IPV4_NS_CHILD*.
-14. If the number of name servers from child resolving to an IPv4 
-   address is one then emit *NOT_ENOUGH_IPV4_NS_CHILD*.
-15. If the number of name servers from child resolving to an IPv4 
-   address is two then emit *ENOUGH_IPV4_NS_CHILD*.
-16. If there are no name servers from child resolving to an IPv6 
-   address then emit *NO_IPV6_NS_CHILD*.
-17. If the number of name servers from child resolving to an IPv6 
-   address is one then emit *NOT_ENOUGH_IPV6_NS_CHILD*.
-18. If the number of name servers from child resolving to an IPv6 
-   address is two then emit *ENOUGH_IPV6_NS_CHILD*.
+ 1. Using [Method2], obtain the set of "in-delegation name server names" for the *child zone* (distinct NS records).
+ 2. Count the *in-delegation name server names*:
+    1. If zero or one, emit *NOT_ENOUGH_NS_PARENT*.
+    2. If two or more, emit the *ENOUGH_NS_PARENT*.
+ 3. Using [Method4], obtain the set of "in-delegation glue addresses" for the *child zone*.
+ 4. Count the IPv4 addresses among the *in-delegation glue addresses*:
+    1. If zero, emit *NO_IPV4_NS_PARENT*.
+    2. If one, emit *NOT_ENOUGH_IPV4_NS_PARENT*.
+    3. If two or more, emit *ENOUGH_IPV4_NS_PARENT*.
+ 5. Count the IPv6 addresses among the *in-delegation glue addresses*:
+    1. If zero, emit *NO_IPV6_NS_PARENT*.
+    2. If one, emit *NOT_ENOUGH_IPV6_NS_PARENT*.
+    3. If two or more, emit *ENOUGH_IPV6_NS_PARENT*.
+ 6. Using [Method3], obtain the set of "in-zone name server names".
+ 7. Count the *in-delegation name server addresses*:
+    1. If zero or one, emit *NOT_ENOUGH_NS_CHILD*.
+    2. If two or more, emit *ENOUGH_NS_CHILD*.
+ 8. Using [Method4] and [Method5], obtain the set of "in-zone name server addresses".
+ 9. Count the IPv4 addresses among the *in-zone name server addresses*:
+    1. If zero, emit *NO_IPV4_NS_CHILD*.
+    2. If one, emit *NOT_ENOUGH_IPV4_NS_CHILD*.
+    3. If two or more, emit *ENOUGH_IPV4_NS_CHILD*.
+10. Count the IPv6 addresses among the *in-zone name server addresses*:
+    1. If zero, emit *NO_IPV6_NS_CHILD*.
+    2. If one, emit *NOT_ENOUGH_IPV6_NS_CHILD*.
+    3. If two or more, emit *ENOUGH_IPV6_NS_CHILD*.
 
- 
 ## Outcome(s)
 
 The outcome of this Test Case is "fail" if there is at least one message

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -77,22 +77,22 @@ Else the outcome of this Test Case is "pass".
 
 Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------
-NOT_ENOUGH_NS_DEL             | ERROR
-ENOUGH_NS_DEL                 | INFO
-NO_IPV4_NS_DEL                | ERROR
-NOT_ENOUGH_IPV4_NS_DEL        | ERROR
-ENOUGH_IPV4_NS_DEL            | INFO
-NO_IPV6_NS_DEL                | NOTICE
-NOT_ENOUGH_IPV6_NS_DEL        | NOTICE
-ENOUGH_IPV6_NS_DEL            | INFO
-NOT_ENOUGH_NS_CHILD           | ERROR
-ENOUGH_NS_CHILD               | INFO
-NO_IPV4_NS_CHILD              | ERROR
-NOT_ENOUGH_IPV4_NS_CHILD      | ERROR
 ENOUGH_IPV4_NS_CHILD          | INFO
-NO_IPV6_NS_CHILD              | NOTICE
-NOT_ENOUGH_IPV6_NS_CHILD      | NOTICE
+ENOUGH_IPV4_NS_DEL            | INFO
 ENOUGH_IPV6_NS_CHILD          | INFO
+ENOUGH_IPV6_NS_DEL            | INFO
+ENOUGH_NS_CHILD               | INFO
+ENOUGH_NS_DEL                 | INFO
+NO_IPV4_NS_CHILD              | ERROR
+NO_IPV6_NS_CHILD              | NOTICE
+NO_IPV4_NS_DEL                | ERROR
+NO_IPV6_NS_DEL                | NOTICE
+NOT_ENOUGH_IPV4_NS_CHILD      | ERROR
+NOT_ENOUGH_IPV6_NS_CHILD      | ERROR
+NOT_ENOUGH_IPV4_NS_DEL        | ERROR
+NOT_ENOUGH_IPV6_NS_DEL        | ERROR
+NOT_ENOUGH_NS_CHILD           | ERROR
+NOT_ENOUGH_NS_DEL             | ERROR
 
 
 ## Special procedural requirements

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -49,19 +49,16 @@ The domain name to be tested ("Child Zone").
     1. If zero or one, emit *NOT_ENOUGH_NS_CHILD*.
     2. If two or more, emit *ENOUGH_NS_CHILD*.
 
- 8. Using [Method5], obtain the IP addresses for the [in-bailiwick] name servers 
-    from the *Child Zone* for the *Child Zone*.
+ 8. Using [Method5], obtain the IP addresses for the name servers from 
+    the *Child Zone* for the *Child Zone*.
 
- 9. Using [Method4], obtain the IP addresses for the [out-of-bailiwick] name 
-    servers for the *Child Zone*.
-
-10. Count the number of name server names that resolve into at least one IPv4 
+ 9. Count the number of name server names that resolve into at least one IPv4 
     address:
     1. If zero, emit *NO_IPV4_NS_CHILD*.
     2. If one, emit *NOT_ENOUGH_IPV4_NS_CHILD*.
     3. If two or more, emit *ENOUGH_IPV4_NS_CHILD*.
 
-11. Count the number of name server names that resolve into at least one IPv6 
+10. Count the number of name server names that resolve into at least one IPv6 
     address:
     1. If zero, emit *NO_IPV6_NS_CHILD*.
     2. If one, emit *NOT_ENOUGH_IPV6_NS_CHILD*.
@@ -106,12 +103,6 @@ None
 
 None
 
-## Terminology
-
-The terms "in-bailiwick" and "out-of-bailiwick" are used as defined
-in [RFC 7719], section 6, page 15.
-
-
 [RFC 1034]: https://tools.ietf.org/html/rfc1034
 
 [RFC 7719]: https://tools.ietf.org/html/rfc7719
@@ -124,7 +115,4 @@ in [RFC 7719], section 6, page 15.
 
 [Method5]:  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 
-[in-bailiwick]:     #terminology
-
-[out-of-bailiwick]: #terminology
 

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -1,10 +1,10 @@
-## DELEGATION01: Minimum number of name servers   
+# DELEGATION01: Minimum number of name servers   
 
-### Test case identifier
+## Test case identifier
 
 **DELEGATION01:** Minimum number of name servers
 
-### Objective
+## Objective
 
 Section 4.1 of [RFC 1034] specifies that there must be at least minimum two name servers 
 for a domain. This test is done to verify this condition.
@@ -14,46 +14,46 @@ test case has been extended to test for for two name servers that resolv into IP
 and IPv6 addresses respectively.
 
 
-### Inputs
+## Inputs
 
 The domain name to be tested.
 
-### Ordered description of steps to be taken to execute the test case
+## Ordered description of steps to be taken to execute the test case
 
 1. Obtain the complete set of name servers (distinct NS records) from 
    parent using [Method2](../Methods.md).
 2. If the number of name servers from parent is at least two emit the
-   message **ENOUGH_NS_PARENT** else emit the message 
-   **NOT_ENOUGH_NS_PARENT**.
+   message *ENOUGH_NS_PARENT* else emit  
+   *NOT_ENOUGH_NS_PARENT*.
 3. Obtain the IP addresses for the set of the name servers from parent 
    using [Method4](../Methods.md).
 4. If the number of name servers from parent resolving to an IPv4 
-   address is none then emit the message **NO_IPV4_NS_PARENT**, else 
-   if it is one emit **NOT_ENOUGH_IPV4_NS_PARENT** else emit
-   **ENOUGH_IPV4_NS_PARENT**.
+   address is none then emit  *NO_IPV4_NS_PARENT*, else 
+   if it is one emit *NOT_ENOUGH_IPV4_NS_PARENT* else emit
+   *ENOUGH_IPV4_NS_PARENT*.
 5. If the number of name servers from parent resolving to an IPv6 
-   address is none then emit the message **NO_IPV6_NS_PARENT**, else 
-   if it is one emit **NOT_ENOUGH_IPV6_NS_PARENT** else emit
-   **ENOUGH_IPV6_NS_PARENT**.
+   address is none then emit  *NO_IPV6_NS_PARENT*, else 
+   if it is one emit *NOT_ENOUGH_IPV6_NS_PARENT* else emit
+   *ENOUGH_IPV6_NS_PARENT*.
 6. Obtain the complete set of name servers from the child using 
    [Method3](../Methods.md).
 7. If the number of name servers from child is at least two emit the
-   message **ENOUGH_NS_CHILD** else emit the message 
-   **NOT_ENOUGH_NS_CHILD**.
+   message *ENOUGH_NS_CHILD* else emit  
+   *NOT_ENOUGH_NS_CHILD*.
 8. Obtain the IP addresses for the set of the name servers from child 
    using [Method5](../Methods.md) and, for out-of-bailiwick NS, using
    [Method4](../Methods.md).
 9. If the number of name servers from child resolving to an IPv4 
-   address is none then emit the message **NO_IPV4_NS_CHILD**, else 
-   if it is one emit **NOT_ENOUGH_IPV4_NS_CHILD** else emit
-   **ENOUGH_IPV4_NS_CHILD**.
+   address is none then emit  *NO_IPV4_NS_CHILD*, else 
+   if it is one emit *NOT_ENOUGH_IPV4_NS_CHILD* else emit
+   *ENOUGH_IPV4_NS_CHILD*.
 9. If the number of name servers from child resolving to an IPv6 
-   address is none then emit the message **NO_IPV6_NS_CHILD**, else 
-   if it is one emit **NOT_ENOUGH_IPV6_NS_CHILD** else emit
-   **ENOUGH_IPV6_NS_CHILD**.
+   address is none then emit  *NO_IPV6_NS_CHILD*, else 
+   if it is one emit *NOT_ENOUGH_IPV6_NS_CHILD* else emit
+   *ENOUGH_IPV6_NS_CHILD*.
 
  
-### Outcome(s)
+## Outcome(s)
 
 The outcome of the test case depends on the highest level of the messages 
 generated.
@@ -78,11 +78,11 @@ NOT_ENOUGH_IPV6_NS_CHILD      | NOTICE
 ENOUGH_IPV6_NS_CHILD          | INFO
 
 
-### Special procedural requirements
+## Special procedural requirements
 
 None 
 
-### Intercase dependencies
+## Intercase dependencies
 
 None
 

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -6,9 +6,13 @@
 
 ### Objective
 
-Section 4.1 of [RFC 1034](https://tools.ietf.org/html/rfc1034) specifies that
-there must be at least minimum two name servers for a domain. This test is
-done to verify this condition
+Section 4.1 of [RFC 1034] specifies that there must be at least minimum two name servers 
+for a domain. This test is done to verify this condition.
+
+The RFC ([RFC 1034]) pre-dates IPv6. Sinces IPv4 and IPv6 work as separate networks, this
+test case has been extended to test for for two name servers that resolv into IPv4 addresses
+and IPv6 addresses respectively.
+
 
 ### Inputs
 
@@ -16,20 +20,55 @@ The domain name to be tested.
 
 ### Ordered description of steps to be taken to execute the test case
 
-1. Obtain the complete set of name servers from parent using
-   [Method2](../Methods.md).
-2. If the number of name servers (distinct NS records) returned in previous step is less than two, the
-   record as an error.
-3. Obtain the complete set of name servers from the child 
-   using [Method3](../Methods.md).
-4. If the number of name servers (distinct NS records) returned in the previous step is less than two, the
-   record as an error.
-5. If an error was recorded in step 2 or step 4, then the test case fails.
+1. Obtain the complete set of name servers (distinct NS records) from 
+   parent using [Method2](../Methods.md).
+2. If the number of name servers from parent is at least two emit the
+   message **ENOUGH_NS_PARENT** else emit the message 
+   **NOT_ENOUGH_NS_PARENT**.
+3. Obtain the IP addresses for the set of the name servers from parent 
+   using [Method4](../Methods.md).
+4. If the number of name servers from parent resolving to an IPv4 
+   address is at least two **ENOUGH_IPV4_NS_PARENT** else emit the
+   message **NOT_ENOUGH_IPV4_NS_PARENT**.
+5. If the number of name servers from parent resolving to an IPv6 
+   address is at least two **ENOUGH_IPV6_NS_PARENT** else emit the
+   message **NOT_ENOUGH_IPV6_NS_PARENT**.
+6. Obtain the complete set of name servers from the child using 
+   [Method3](../Methods.md).
+7. If the number of name servers from child is at least two emit the
+   message **ENOUGH_NS_CHILD** else emit the message 
+   **NOT_ENOUGH_NS_CHILD**.
+8. Obtain the IP addresses for the set of the name servers from child 
+   using [Method5](../Methods.md) and, for out-of-bailiwick NS, using
+   [Method4](../Methods.md).
+9. If the number of name servers from child resolving to an IPv4 
+   address is at least two **ENOUGH_IPV4_NS_CHILD** else emit the
+   message **NOT_ENOUGH_IPV4_NS_CHILD**.
+10. If the number of name servers from child resolving to an IPv6 
+    address is at least two **ENOUGH_IPV6_NS_CHILD** else emit the
+    message **NOT_ENOUGH_IPV6_NS_CHILD**.
+
  
 ### Outcome(s)
 
-If the total amount of name servers used for the domain are two or more,
-then the test case succeeds.
+The outcome of the test case depends on the highest level of the messages 
+generated.
+
+Message                       | Default level (if message is emitted)
+:-----------------------------|:-----------------------------------
+ENOUGH_NS_PARENT              | INFO
+NOT_ENOUGH_NS_PARENT          | ERROR
+ENOUGH_IPV4_NS_PARENT         | INFO
+NOT_ENOUGH_IPV4_NS_PARENT     | ERROR
+ENOUGH_IPV6_NS_PARENT         | INFO
+NOT_ENOUGH_IPV6_NS_PARENT     | NOTICE
+ENOUGH_NS_CHILD               | INFO
+NOT_ENOUGH_NS_CHILD           | ERROR
+ENOUGH_IPV4_NS_CHILD          | INFO
+NOT_ENOUGH_IPV4_NS_CHILD      | ERROR
+ENOUGH_IPV6_NS_CHILD          | INFO
+NOT_ENOUGH_IPV6_NS_CHILD      | NOTICE
+
 
 ### Special procedural requirements
 
@@ -39,10 +78,13 @@ None
 
 None
 
+
+[RFC 1034]: https://tools.ietf.org/html/rfc1034
+
 -------
 
-Copyright (c) 2013-2017, IIS (The Internet Foundation in Sweden )  
-Copyright (c) 2013-2017, AFNIC  
+Copyright (c) 2013-2018, IIS (The Internet Foundation in Sweden )  
+Copyright (c) 2013-2018, AFNIC  
 Creative Commons Attribution 4.0 International License
 
 You should have received a copy of the license along with this

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -28,11 +28,13 @@ The domain name to be tested.
 3. Obtain the IP addresses for the set of the name servers from parent 
    using [Method4](../Methods.md).
 4. If the number of name servers from parent resolving to an IPv4 
-   address is at least two **ENOUGH_IPV4_NS_PARENT** else emit the
-   message **NOT_ENOUGH_IPV4_NS_PARENT**.
+   address is none then emit the message **NO_IPV4_NS_PARENT**, else 
+   if it is one emit **NOT_ENOUGH_IPV4_NS_PARENT** else emit
+   **ENOUGH_IPV4_NS_PARENT**.
 5. If the number of name servers from parent resolving to an IPv6 
-   address is at least two **ENOUGH_IPV6_NS_PARENT** else emit the
-   message **NOT_ENOUGH_IPV6_NS_PARENT**.
+   address is none then emit the message **NO_IPV6_NS_PARENT**, else 
+   if it is one emit **NOT_ENOUGH_IPV6_NS_PARENT** else emit
+   **ENOUGH_IPV6_NS_PARENT**.
 6. Obtain the complete set of name servers from the child using 
    [Method3](../Methods.md).
 7. If the number of name servers from child is at least two emit the
@@ -42,11 +44,13 @@ The domain name to be tested.
    using [Method5](../Methods.md) and, for out-of-bailiwick NS, using
    [Method4](../Methods.md).
 9. If the number of name servers from child resolving to an IPv4 
-   address is at least two **ENOUGH_IPV4_NS_CHILD** else emit the
-   message **NOT_ENOUGH_IPV4_NS_CHILD**.
-10. If the number of name servers from child resolving to an IPv6 
-    address is at least two **ENOUGH_IPV6_NS_CHILD** else emit the
-    message **NOT_ENOUGH_IPV6_NS_CHILD**.
+   address is none then emit the message **NO_IPV4_NS_CHILD**, else 
+   if it is one emit **NOT_ENOUGH_IPV4_NS_CHILD** else emit
+   **ENOUGH_IPV4_NS_CHILD**.
+9. If the number of name servers from child resolving to an IPv6 
+   address is none then emit the message **NO_IPV6_NS_CHILD**, else 
+   if it is one emit **NOT_ENOUGH_IPV6_NS_CHILD** else emit
+   **ENOUGH_IPV6_NS_CHILD**.
 
  
 ### Outcome(s)
@@ -56,18 +60,22 @@ generated.
 
 Message                       | Default level (if message is emitted)
 :-----------------------------|:-----------------------------------
-ENOUGH_NS_PARENT              | INFO
 NOT_ENOUGH_NS_PARENT          | ERROR
-ENOUGH_IPV4_NS_PARENT         | INFO
+ENOUGH_NS_PARENT              | INFO
+NO_IPV4_NS_PARENT             | ERROR
 NOT_ENOUGH_IPV4_NS_PARENT     | ERROR
-ENOUGH_IPV6_NS_PARENT         | INFO
+ENOUGH_IPV4_NS_PARENT         | INFO
+NO_IPV6_NS_PARENT             | NOTICE
 NOT_ENOUGH_IPV6_NS_PARENT     | NOTICE
-ENOUGH_NS_CHILD               | INFO
+ENOUGH_IPV6_NS_PARENT         | INFO
 NOT_ENOUGH_NS_CHILD           | ERROR
-ENOUGH_IPV4_NS_CHILD          | INFO
+ENOUGH_NS_CHILD               | INFO
+NO_IPV4_NS_CHILD              | ERROR
 NOT_ENOUGH_IPV4_NS_CHILD      | ERROR
-ENOUGH_IPV6_NS_CHILD          | INFO
+ENOUGH_IPV4_NS_CHILD          | INFO
+NO_IPV6_NS_CHILD              | NOTICE
 NOT_ENOUGH_IPV6_NS_CHILD      | NOTICE
+ENOUGH_IPV6_NS_CHILD          | INFO
 
 
 ### Special procedural requirements

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -21,26 +21,26 @@ The domain name to be tested ("Child Zone").
 ## Ordered description of steps to be taken to execute the test case
 
  1. Using [Method2], obtain the complete set of names of the name servers 
-    from parent for the *Child Zone* (distinct NS records).
+    from the delegation of the *Child Zone*.
 
  2. Count the name server names:
-    1. If zero or one, emit *NOT_ENOUGH_NS_PARENT*.
-    2. If two or more, emit *ENOUGH_NS_PARENT*.
+    1. If zero or one, emit *NOT_ENOUGH_NS_DEL*.
+    2. If two or more, emit *ENOUGH_NS_DEL*.
 
- 3. Using [Method4], obtain the IP addresses for the set of name servers 
-    from the parent for the *Child Zone*.
+ 3. Using [Method4], obtain the IP addresses for the name servers of the 
+    delegation of the *Child Zone*.
 
  4. Count the number of name server names that resolve into at least one IPv4 
     address:
-    1. If zero, emit *NO_IPV4_NS_PARENT*.
-    2. If one, emit *NOT_ENOUGH_IPV4_NS_PARENT*.
-    3. If two or more, emit *ENOUGH_IPV4_NS_PARENT*.
+    1. If zero, emit *NO_IPV4_NS_DEL*.
+    2. If one, emit *NOT_ENOUGH_IPV4_NS_DEL*.
+    3. If two or more, emit *ENOUGH_IPV4_NS_DEL*.
 
  5. Count the number of name server names that resolve into at least one IPv6 
     address:
-    1. If zero, emit *NO_IPV6_NS_PARENT*.
-    2. If one, emit *NOT_ENOUGH_IPV6_NS_PARENT*.
-    3. If two or more, emit *ENOUGH_IPV6_NS_PARENT*.
+    1. If zero, emit *NO_IPV6_NS_DEL*.
+    2. If one, emit *NOT_ENOUGH_IPV6_NS_DEL*.
+    3. If two or more, emit *ENOUGH_IPV6_NS_DEL*.
 
  6. Using [Method3], obtain the complete set of names of the name servers
     from the *Child Zone* for the *Child Zone*. 
@@ -77,14 +77,14 @@ Else the outcome of this Test Case is "pass".
 
 Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------
-NOT_ENOUGH_NS_PARENT          | ERROR
-ENOUGH_NS_PARENT              | INFO
-NO_IPV4_NS_PARENT             | ERROR
-NOT_ENOUGH_IPV4_NS_PARENT     | ERROR
-ENOUGH_IPV4_NS_PARENT         | INFO
-NO_IPV6_NS_PARENT             | NOTICE
-NOT_ENOUGH_IPV6_NS_PARENT     | NOTICE
-ENOUGH_IPV6_NS_PARENT         | INFO
+NOT_ENOUGH_NS_DEL             | ERROR
+ENOUGH_NS_DEL                 | INFO
+NO_IPV4_NS_DEL                | ERROR
+NOT_ENOUGH_IPV4_NS_DEL        | ERROR
+ENOUGH_IPV4_NS_DEL            | INFO
+NO_IPV6_NS_DEL                | NOTICE
+NOT_ENOUGH_IPV6_NS_DEL        | NOTICE
+ENOUGH_IPV6_NS_DEL            | INFO
 NOT_ENOUGH_NS_CHILD           | ERROR
 ENOUGH_NS_CHILD               | INFO
 NO_IPV4_NS_CHILD              | ERROR

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -27,8 +27,8 @@ The domain name to be tested ("Child Zone").
     1. If zero or one, emit *NOT_ENOUGH_NS_PARENT*.
     2. If two or more, emit *ENOUGH_NS_PARENT*.
 
- 3. Obtain the IP addresses for the set of name servers from the parent for the 
-    *Child Zone*.
+ 3. Using [Method4], obtain the IP addresses for the set of name servers 
+    from the parent for the *Child Zone*.
 
  4. Count the number of name server names that resolve into at least one IPv4 
     address:
@@ -49,10 +49,10 @@ The domain name to be tested ("Child Zone").
     1. If zero or one, emit *NOT_ENOUGH_NS_CHILD*.
     2. If two or more, emit *ENOUGH_NS_CHILD*.
 
- 8. Using [Method4], obtain the IP addresses for the [in-bailiwick] name servers 
+ 8. Using [Method5], obtain the IP addresses for the [in-bailiwick] name servers 
     from the *Child Zone* for the *Child Zone*.
 
- 9. Using [Method5], obtain the IP addresses for the [out-of-bailiwick] name 
+ 9. Using [Method4], obtain the IP addresses for the [out-of-bailiwick] name 
     servers for the *Child Zone*.
 
 10. Count the number of name server names that resolve into at least one IPv4 
@@ -76,7 +76,7 @@ The outcome of this Test Case is "warning" if there is at least one message
 with the severity level *WARNING*, but no message with severity level
 *ERROR* or *CRITICAL*.
 
-In other cases the outcome of this Test Case is "pass".
+Else the outcome of this Test Case is "pass".
 
 Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -16,49 +16,61 @@ and IPv6 addresses respectively.
 
 ## Inputs
 
-The domain name to be tested.
+The domain name to be tested ("child zone").
 
 ## Ordered description of steps to be taken to execute the test case
 
-1. Obtain the complete set of name servers (distinct NS records) from 
-   parent using [Method2](../Methods.md).
-2. If the number of name servers from parent is at least two emit the
-   message *ENOUGH_NS_PARENT* else emit  
-   *NOT_ENOUGH_NS_PARENT*.
+1. Obtain the complete set of the names of the name servers for the *child 
+   zone* (distinct NS records) from parent using [Method2].
+2. If the number of name servers from parent is at least two, emit the
+   *ENOUGH_NS_PARENT*, else emit *NOT_ENOUGH_NS_PARENT*.
 3. Obtain the IP addresses for the set of the name servers from parent 
-   using [Method4](../Methods.md).
-4. If the number of name servers from parent resolving to an IPv4 
-   address is none then emit  *NO_IPV4_NS_PARENT*, else 
-   if it is one emit *NOT_ENOUGH_IPV4_NS_PARENT* else emit
-   *ENOUGH_IPV4_NS_PARENT*.
-5. If the number of name servers from parent resolving to an IPv6 
-   address is none then emit  *NO_IPV6_NS_PARENT*, else 
-   if it is one emit *NOT_ENOUGH_IPV6_NS_PARENT* else emit
-   *ENOUGH_IPV6_NS_PARENT*.
-6. Obtain the complete set of name servers from the child using 
-   [Method3](../Methods.md).
-7. If the number of name servers from child is at least two emit the
-   message *ENOUGH_NS_CHILD* else emit  
-   *NOT_ENOUGH_NS_CHILD*.
-8. Obtain the IP addresses for the set of the name servers from child 
-   using [Method5](../Methods.md) and, for out-of-bailiwick NS, using
-   [Method4](../Methods.md).
-9. If the number of name servers from child resolving to an IPv4 
-   address is none then emit  *NO_IPV4_NS_CHILD*, else 
-   if it is one emit *NOT_ENOUGH_IPV4_NS_CHILD* else emit
-   *ENOUGH_IPV4_NS_CHILD*.
-9. If the number of name servers from child resolving to an IPv6 
-   address is none then emit  *NO_IPV6_NS_CHILD*, else 
-   if it is one emit *NOT_ENOUGH_IPV6_NS_CHILD* else emit
-   *ENOUGH_IPV6_NS_CHILD*.
+   using [Method4].
+4. If there are no name servers from parent resolving to an IPv4 
+   address then emit *NO_IPV4_NS_PARENT*.
+5. If the number of name servers from parent resolving to an IPv4 
+   address is one then emit *NOT_ENOUGH_IPV4_NS_PARENT*.
+6. If the number of name servers from parent resolving to an IPv4 
+   address is at least two then emit *ENOUGH_IPV4_NS_PARENT*.
+7. If there are no name servers from parent resolving to an IPv6 
+   address then emit *NO_IPV6_NS_PARENT*.
+8. If the number of name servers from parent resolving to an IPv6 
+   address is one then emit *NOT_ENOUGH_IPV6_NS_PARENT*.
+9. If the number of name servers from parent resolving to an IPv6 
+   address is at least two then emit *ENOUGH_IPV6_NS_PARENT*.
+10. Obtain the complete set of the names of the name servers for the 
+    *child zone* from the *child zone* using [Method3].
+11. If the number of name servers from child is at least two emit the
+   *ENOUGH_NS_CHILD*, else emit *NOT_ENOUGH_NS_CHILD*.
+12. Obtain the IP addresses for the set of the name servers from 
+    *child zone* using [Method5] and, for 
+    out-of-bailiwick NS, using [Method4].
+13. If there are no name servers from child resolving to an IPv4 
+   address then emit *NO_IPV4_NS_CHILD*.
+14. If the number of name servers from child resolving to an IPv4 
+   address is one then emit *NOT_ENOUGH_IPV4_NS_CHILD*.
+15. If the number of name servers from child resolving to an IPv4 
+   address is two then emit *ENOUGH_IPV4_NS_CHILD*.
+16. If there are no name servers from child resolving to an IPv6 
+   address then emit *NO_IPV6_NS_CHILD*.
+17. If the number of name servers from child resolving to an IPv6 
+   address is one then emit *NOT_ENOUGH_IPV6_NS_CHILD*.
+18. If the number of name servers from child resolving to an IPv6 
+   address is two then emit *ENOUGH_IPV6_NS_CHILD*.
 
  
 ## Outcome(s)
 
-The outcome of the test case depends on the highest level of the messages 
-generated.
+The outcome of this Test Case is "fail" if there is at least one message
+with the severity level *ERROR* or *CRITICAL*.
 
-Message                       | Default level (if message is emitted)
+The outcome of this Test Case is "warning" if there is at least one message
+with the severity level *WARNING*, but no message with severity level
+*ERROR* or *CRITICAL*.
+
+In other cases the outcome of this Test Case is "pass".
+
+Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------
 NOT_ENOUGH_NS_PARENT          | ERROR
 ENOUGH_NS_PARENT              | INFO
@@ -88,6 +100,15 @@ None
 
 
 [RFC 1034]: https://tools.ietf.org/html/rfc1034
+
+[Method2]:  ../Methods.md#method-2-obtain-glue-name-records-from-parent
+
+[Method3]:  ../Methods.md#method-3-obtain-name-servers-from-child
+
+[Method4]:  ../Methods.md#method-4-obtain-glue-address-records-from-parent
+
+[Method5]:  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+
 
 -------
 

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -6,63 +6,63 @@
 
 ## Objective
 
-Section 4.1 of [RFC 1034] specifies that there must be at least minimum two name servers 
+Section 4.1 of [RFC 1034] specifies that there must be a minimum of two name servers 
 for a domain. This test is done to verify this condition.
 
-The RFC ([RFC 1034]) pre-dates IPv6. Sinces IPv4 and IPv6 work as separate networks, this
-test case has been extended to test for for two name servers that resolv into IPv4 addresses
+The RFC ([RFC 1034]) predates IPv6. Since IPv4 and IPv6 work as separate networks, this
+test case has been extended to test for two name servers that resolve into IPv4 addresses
 and IPv6 addresses respectively.
 
 
 ## Inputs
 
-The domain name to be tested ("child zone").
+The domain name to be tested ("Child Zone").
 
 ## Ordered description of steps to be taken to execute the test case
 
- 1. Using [Method2], obtain the complete set of the names of the name servers 
-    from parent for the *child zone* (distinct NS records).
+ 1. Using [Method2], obtain the complete set of names of the name servers 
+    from parent for the *Child Zone* (distinct NS records).
 
  2. Count the name server names:
     1. If zero or one, emit *NOT_ENOUGH_NS_PARENT*.
     2. If two or more, emit *ENOUGH_NS_PARENT*.
 
- 3. Obtain the IP addresses for the set of the name servers from parent for the 
-    *child zone*.
+ 3. Obtain the IP addresses for the set of name servers from the parent for the 
+    *Child Zone*.
 
  4. Count the number of name server names that resolve into at least one IPv4 
-    addresse:
+    address:
     1. If zero, emit *NO_IPV4_NS_PARENT*.
     2. If one, emit *NOT_ENOUGH_IPV4_NS_PARENT*.
     3. If two or more, emit *ENOUGH_IPV4_NS_PARENT*.
 
  5. Count the number of name server names that resolve into at least one IPv6 
-    addresse:
+    address:
     1. If zero, emit *NO_IPV6_NS_PARENT*.
     2. If one, emit *NOT_ENOUGH_IPV6_NS_PARENT*.
     3. If two or more, emit *ENOUGH_IPV6_NS_PARENT*.
 
- 6. Using [Method3], obtain the complete set of the names of the name servers
-    from the *child zone* for the *child zone*.
+ 6. Using [Method3], obtain the complete set of names of the name servers
+    from the *Child Zone* for the *Child Zone*. 
 
  7. Count the name server names:
     1. If zero or one, emit *NOT_ENOUGH_NS_CHILD*.
     2. If two or more, emit *ENOUGH_NS_CHILD*.
 
  8. Using [Method4], obtain the IP addresses for the in-bailiwick name servers 
-    from the *child zone* for the *child zone*. 
+    from the *Child Zone* for the *Child Zone*. **(Suggest that we find a more common word than "bailiwick" to raise readability.)**
 
  9. Using [Method5], obtain the IP addresses for the out-of-bailiwick name 
-    servers for the *child zone*.
+    servers for the *Child Zone*. **(Suggest that we find a more common word than "bailiwick" to raise readability.)**
 
 10. Count the number of name server names that resolve into at least one IPv4 
-    addresse:
+    address:
     1. If zero, emit *NO_IPV4_NS_CHILD*.
     2. If one, emit *NOT_ENOUGH_IPV4_NS_CHILD*.
     3. If two or more, emit *ENOUGH_IPV4_NS_CHILD*.
 
 11. Count the number of name server names that resolve into at least one IPv6 
-    addresse:
+    address:
     1. If zero, emit *NO_IPV6_NS_CHILD*.
     2. If one, emit *NOT_ENOUGH_IPV6_NS_CHILD*.
     3. If two or more, emit *ENOUGH_IPV6_NS_CHILD*.

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -20,29 +20,49 @@ The domain name to be tested ("child zone").
 
 ## Ordered description of steps to be taken to execute the test case
 
- 1. Using [Method2], obtain the set of "in-delegation name server names" for the *child zone* (distinct NS records).
- 2. Count the *in-delegation name server names*:
+ 1. Using [Method2], obtain the complete set of the names of the name servers 
+    from parent for the *child zone* (distinct NS records).
+
+ 2. Count the name server names:
     1. If zero or one, emit *NOT_ENOUGH_NS_PARENT*.
-    2. If two or more, emit the *ENOUGH_NS_PARENT*.
- 3. Using [Method4], obtain the set of "in-delegation glue addresses" for the *child zone*.
- 4. Count the IPv4 addresses among the *in-delegation glue addresses*:
+    2. If two or more, emit *ENOUGH_NS_PARENT*.
+
+ 3. Obtain the IP addresses for the set of the name servers from parent for the 
+    *child zone*.
+
+ 4. Count the number of name server names that resolve into at least one IPv4 
+    addresse:
     1. If zero, emit *NO_IPV4_NS_PARENT*.
     2. If one, emit *NOT_ENOUGH_IPV4_NS_PARENT*.
     3. If two or more, emit *ENOUGH_IPV4_NS_PARENT*.
- 5. Count the IPv6 addresses among the *in-delegation glue addresses*:
+
+ 5. Count the number of name server names that resolve into at least one IPv6 
+    addresse:
     1. If zero, emit *NO_IPV6_NS_PARENT*.
     2. If one, emit *NOT_ENOUGH_IPV6_NS_PARENT*.
     3. If two or more, emit *ENOUGH_IPV6_NS_PARENT*.
- 6. Using [Method3], obtain the set of "in-zone name server names".
- 7. Count the *in-delegation name server addresses*:
+
+ 6. Using [Method3], obtain the complete set of the names of the name servers
+    from the *child zone* for the *child zone*.
+
+ 7. Count the name server names:
     1. If zero or one, emit *NOT_ENOUGH_NS_CHILD*.
     2. If two or more, emit *ENOUGH_NS_CHILD*.
- 8. Using [Method4] and [Method5], obtain the set of "in-zone name server addresses".
- 9. Count the IPv4 addresses among the *in-zone name server addresses*:
+
+ 8. Using [Method4], obtain the IP addresses for the in-bailiwick name servers 
+    from the *child zone* for the *child zone*. 
+
+ 9. Using [Method5], obtain the IP addresses for the out-of-bailiwick name 
+    servers for the *child zone*.
+
+10. Count the number of name server names that resolve into at least one IPv4 
+    addresse:
     1. If zero, emit *NO_IPV4_NS_CHILD*.
     2. If one, emit *NOT_ENOUGH_IPV4_NS_CHILD*.
     3. If two or more, emit *ENOUGH_IPV4_NS_CHILD*.
-10. Count the IPv6 addresses among the *in-zone name server addresses*:
+
+11. Count the number of name server names that resolve into at least one IPv6 
+    addresse:
     1. If zero, emit *NO_IPV6_NS_CHILD*.
     2. If one, emit *NOT_ENOUGH_IPV6_NS_CHILD*.
     3. If two or more, emit *ENOUGH_IPV6_NS_CHILD*.

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -2,7 +2,7 @@
 
 ## Test case identifier
 
-**DELEGATION01:** Minimum number of name servers
+**DELEGATION01**
 
 ## Objective
 
@@ -49,11 +49,11 @@ The domain name to be tested ("Child Zone").
     1. If zero or one, emit *NOT_ENOUGH_NS_CHILD*.
     2. If two or more, emit *ENOUGH_NS_CHILD*.
 
- 8. Using [Method4], obtain the IP addresses for the in-bailiwick name servers 
-    from the *Child Zone* for the *Child Zone*. **(Suggest that we find a more common word than "bailiwick" to raise readability.)**
+ 8. Using [Method4], obtain the IP addresses for the [in-bailiwick] name servers 
+    from the *Child Zone* for the *Child Zone*.
 
- 9. Using [Method5], obtain the IP addresses for the out-of-bailiwick name 
-    servers for the *Child Zone*. **(Suggest that we find a more common word than "bailiwick" to raise readability.)**
+ 9. Using [Method5], obtain the IP addresses for the [out-of-bailiwick] name 
+    servers for the *Child Zone*.
 
 10. Count the number of name server names that resolve into at least one IPv4 
     address:
@@ -106,8 +106,15 @@ None
 
 None
 
+## Terminology
+
+The terms "in-bailiwick" and "out-of-bailiwick" are used as defined
+in [RFC 7719], section 6, page 15.
+
 
 [RFC 1034]: https://tools.ietf.org/html/rfc1034
+
+[RFC 7719]: https://tools.ietf.org/html/rfc7719
 
 [Method2]:  ../Methods.md#method-2-obtain-glue-name-records-from-parent
 
@@ -117,12 +124,7 @@ None
 
 [Method5]:  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 
+[in-bailiwick]:     #terminology
 
--------
+[out-of-bailiwick]: #terminology
 
-Copyright (c) 2013-2018, IIS (The Internet Foundation in Sweden )  
-Copyright (c) 2013-2018, AFNIC  
-Creative Commons Attribution 4.0 International License
-
-You should have received a copy of the license along with this
-work.  If not, see <https://creativecommons.org/licenses/by/4.0/>.

--- a/docs/specifications/tests/Delegation-TP/delegation01.md
+++ b/docs/specifications/tests/Delegation-TP/delegation01.md
@@ -83,16 +83,16 @@ ENOUGH_IPV6_NS_CHILD          | INFO
 ENOUGH_IPV6_NS_DEL            | INFO
 ENOUGH_NS_CHILD               | INFO
 ENOUGH_NS_DEL                 | INFO
-NO_IPV4_NS_CHILD              | ERROR
-NO_IPV6_NS_CHILD              | NOTICE
-NO_IPV4_NS_DEL                | ERROR
-NO_IPV6_NS_DEL                | NOTICE
 NOT_ENOUGH_IPV4_NS_CHILD      | ERROR
-NOT_ENOUGH_IPV6_NS_CHILD      | ERROR
 NOT_ENOUGH_IPV4_NS_DEL        | ERROR
+NOT_ENOUGH_IPV6_NS_CHILD      | ERROR
 NOT_ENOUGH_IPV6_NS_DEL        | ERROR
 NOT_ENOUGH_NS_CHILD           | ERROR
 NOT_ENOUGH_NS_DEL             | ERROR
+NO_IPV4_NS_CHILD              | ERROR
+NO_IPV4_NS_DEL                | ERROR
+NO_IPV6_NS_CHILD              | NOTICE
+NO_IPV6_NS_DEL                | NOTICE
 
 
 ## Special procedural requirements


### PR DESCRIPTION
Updated DELEGATION01:
* Added test for number of NS with IPv4.
* Added test for number of NS with IPv6.
* Added the messages to the Test Case definition.
* Added default levels of messages.
* Messages ENOUGH_NS_GLUE, NOT_ENOUGH_NS_GLUE, ENOUGH_NS and NOT_ENOUGH_NS renamed to ENOUGH_NS_PARENT, NOT_ENOUGH_NS_PARENT, ENOUGH_NS_CHILD and NOT_ENOUGH_NS_CHILD, respectively.
* Added logic to count the numer of name servers with IPv4 resolution and IPv6 resolution, respectively.
* The following messages are new: NO_IPV4_NS_PARENT, NOT_ENOUGH_IPV4_NS_PARENT, ENOUGH_IPV4_NS_PARENT, 
NO_IPV6_NS_PARENT, NOT_ENOUGH_IPV6_NS_PARENT, ENOUGH_IPV6_NS_PARENT, 
NO_IPV4_NS_CHILD, NOT_ENOUGH_IPV4_NS_CHILD, ENOUGH_IPV4_NS_CHILD, 
NO_IPV6_NS_CHILD, NOT_ENOUGH_IPV6_NS_CHILD and ENOUGH_IPV6_NS_CHILD.

