### PR TITLE
Update delegation02

### DIFF
--- a/docs/specifications/tests/Delegation-TP/delegation02.md
+++ b/docs/specifications/tests/Delegation-TP/delegation02.md
@@ -24,7 +24,8 @@ The domain name to be tested.
    [Method2] and the IP addresses for each name using [Method4].
 
 2. If the same IP address is found for two or more name server names, 
-   emit *PARENT_NS_SAME_IP_ADDRESS* for each repeated address.
+   emit *DEL_NS_SAME_IP* for each repeated address, else emit
+   *DEL_DISTINCT_NS_IP*.
 
 3. Obtain the complete set of name server names from the child using 
    [Method3] and the IP addresses for each name using [Method5] for
@@ -32,7 +33,8 @@ The domain name to be tested.
    names only. 
 
 4. If the same IP address is found for two or more name server names, 
-   emit *CHILD_NS_SAME_IP_ADDRESS* for each repeated address.
+   emit *CHILD_NS_SAME_IP* for each repeated address, else emit
+   *CHILD_DISTINCT_NS_IP*.
 
 ## Outcome(s)
 
@@ -45,11 +47,12 @@ with the severity level *WARNING*, but no message with severity level
 
 In other cases the outcome of this Test Case is "pass".
 
-Message                       | Default severity level (if message is emitted)
-:-----------------------------|:-----------------------------------
-PARENT_NS_SAME_IP_ADDRESS     | ERROR
-CHILD_NS_SAME_IP_ADDRESS      | ERROR
-
+Message               | Default severity level (if message is emitted)
+:---------------------|:-----------------------------------
+DEL_NS_SAME_IP        | ERROR
+CHILD_NS_SAME_IP      | ERROR
+DEL_DISTINCT_NS_IP    | INFO
+CHILD_DISTINCT_NS_IP  | INFO
 
 ## Special procedural requirements
 

--- a/docs/specifications/tests/Delegation-TP/delegation02.md
+++ b/docs/specifications/tests/Delegation-TP/delegation02.md
@@ -6,10 +6,10 @@
 
 ## Objective
 
-If the domain have several different name server names used, they can all
+If the domain's name servers use several different names, they can all
 be using the same IP address. This may be due to a configuration error, or
-a workaround to a certain policy restriction. This test case checks that
-the name servers used does not resolve to reuse the same IP addresses.
+a workaround for a certain policy restriction. This test case checks that
+the name servers used do not reuse the same IP addresses.
 
 Section 4.1 of [RFC 1034] says at least
 two name servers must be used for a delegation.
@@ -23,16 +23,16 @@ The domain name to be tested.
 1. Obtain the complete set of name server names from parent using 
    [Method2] and the IP addresses for each name using [Method4].
 
-2. If the same IP address is found for two or more name server names 
-   then emit *PARENT_NS_SAME_IP_ADDRESS* for each repeated address.
+2. If the same IP address is found for two or more name server names, 
+   emit *PARENT_NS_SAME_IP_ADDRESS* for each repeated address.
 
 3. Obtain the complete set of name server names from the child using 
    [Method3] and the IP addresses for each name using [Method5] for
    [in-bailiwick] names and using [Method4] for [out-of-bailiwick] 
-   names only.
+   names only. 
 
-4. If the same IP address is found for two or more name server names 
-   then emit *CHILD_NS_SAME_IP_ADDRESS* for each repeated address.
+4. If the same IP address is found for two or more name server names, 
+   emit *CHILD_NS_SAME_IP_ADDRESS* for each repeated address.
 
 ## Outcome(s)
 

--- a/docs/specifications/tests/Delegation-TP/delegation02.md
+++ b/docs/specifications/tests/Delegation-TP/delegation02.md
@@ -24,8 +24,8 @@ The domain name to be tested.
    [Method2] and the IP addresses for each name using [Method4].
 
 2. If the same IP address is found for two or more name server names, 
-   emit *DEL_NS_SAME_IP* for each repeated address, else emit
-   *DEL_DISTINCT_NS_IP*.
+   emit *[DEL_NS_SAME_IP]* for each repeated address, else emit
+   *[DEL_DISTINCT_NS_IP]*.
 
 3. Obtain the complete set of name server names from the child using 
    [Method3] and the IP addresses for each name using [Method5] for
@@ -33,8 +33,8 @@ The domain name to be tested.
    names only. 
 
 4. If the same IP address is found for two or more name server names, 
-   emit *CHILD_NS_SAME_IP* for each repeated address, else emit
-   *CHILD_DISTINCT_NS_IP*.
+   emit *[CHILD_NS_SAME_IP]* for each repeated address, else emit
+   *[CHILD_DISTINCT_NS_IP]*.
 
 ## Outcome(s)
 
@@ -84,3 +84,10 @@ in [RFC 7719], section 6, page 15.
 
 [out-of-bailiwick]: #terminology
 
+[DEL_NS_SAME_IP]: #outcomes
+
+[CHILD_NS_SAME_IP]: #outcomes
+
+[DEL_DISTINCT_NS_IP]: #outcomes
+
+[CHILD_DISTINCT_NS_IP]: #outcomes

--- a/docs/specifications/tests/Delegation-TP/delegation02.md
+++ b/docs/specifications/tests/Delegation-TP/delegation02.md
@@ -20,22 +20,19 @@ The domain name to be tested.
 
 ## Ordered description of steps to be taken to execute the test case
 
-1. Obtain the complete set of name servers (distinct NS records) from 
-   parent using [Method2].
-2. Obtain the IP addresses for the set of the name servers from parent 
-   using [Method4]. (This should include all IP address
-   for both in-bailiwick and out-of-bailiwick name servers.)
-3. If the same IP address is found for two or more name servers then 
-   emit *PARENT_NS_SAME_IP_ADDRESS* and the IP address.
-4. Repeat step 3 for all IP addresses obtained in step 2.
-5. Obtain the complete set of name servers from the child using 
-   [Method3].
-6. Obtain the IP addresses for the set of the name servers from child 
-   using [Method5] and, for out-of-bailiwick NS, using
-   [Method4].
-7. If the same IP address is found for two or more name servers then 
-   emit *CHILD_NS_SAME_IP_ADDRESS* and the IP address.
-8. Repeat step 7 for all IP addresses obtained in step 6.
+1. Obtain the complete set of name server names from parent using 
+   [Method2] and the IP addresses for each name using [Method4].
+
+2. If the same IP address is found for two or more name server names 
+   then emit *PARENT_NS_SAME_IP_ADDRESS* for each repeated address.
+
+3. Obtain the complete set of name server names from the child using 
+   [Method3] and the IP addresses for each name using [Method5] for
+   [in-bailiwick] names and using [Method4] for [out-of-bailiwick] 
+   names only.
+
+4. If the same IP address is found for two or more name server names 
+   then emit *CHILD_NS_SAME_IP_ADDRESS* for each repeated address.
 
 ## Outcome(s)
 
@@ -63,6 +60,13 @@ None
 None
 
 
+## Terminology
+
+The terms "in-bailiwick" and "out-of-bailiwick" are used as defined
+in [RFC 7719], section 6, page 15.
+
+[RFC 7719]: https://tools.ietf.org/html/rfc7719
+
 [RFC 1034]: https://tools.ietf.org/html/rfc1034
 
 [Method2]:  ../Methods.md#method-2-obtain-glue-name-records-from-parent
@@ -73,11 +77,7 @@ None
 
 [Method5]:  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 
--------
+[in-bailiwick]:     #terminology
 
-Copyright (c) 2013-2018, IIS (The Internet Foundation in Sweden)  
-Copyright (c) 2013-2018, AFNIC  
-Creative Commons Attribution 4.0 International License
+[out-of-bailiwick]: #terminology
 
-You should have received a copy of the license along with this
-work.  If not, see <https://creativecommons.org/licenses/by/4.0/>.

--- a/docs/specifications/tests/Delegation-TP/delegation02.md
+++ b/docs/specifications/tests/Delegation-TP/delegation02.md
@@ -39,10 +39,16 @@ The domain name to be tested.
 
 ## Outcome(s)
 
-The outcome of the test case depends on the highest level of the messages 
-generated.
+The outcome of this Test Case is "fail" if there is at least one message
+with the severity level *ERROR* or *CRITICAL*.
 
-Message                       | Default level (if message is emitted)
+The outcome of this Test Case is "warning" if there is at least one message
+with the severity level *WARNING*, but no message with severity level
+*ERROR* or *CRITICAL*.
+
+In other cases the outcome of this Test Case is "pass".
+
+Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------
 PARENT_NS_SAME_IP_ADDRESS     | ERROR
 CHILD_NS_SAME_IP_ADDRESS      | ERROR

--- a/docs/specifications/tests/Delegation-TP/delegation02.md
+++ b/docs/specifications/tests/Delegation-TP/delegation02.md
@@ -11,26 +11,25 @@ be using the same IP address. This may be due to a configuration error, or
 a workaround for a certain policy restriction. This test case checks that
 the name servers used do not reuse the same IP addresses.
 
-Section 4.1 of [RFC 1034] says at least
-two name servers must be used for a delegation.
+Section 4.1 of [RFC 1034] says at least two name servers must be used 
+for a delegation.
 
 ## Inputs
 
-The domain name to be tested.
+"Child Zone" - The domain name to be tested.
 
 ## Ordered description of steps to be taken to execute the test case
 
-1. Obtain the complete set of name server names from parent using 
-   [Method2] and the IP addresses for each name using [Method4].
+1. Obtain the complete set of name server names in the delegation of
+   the *Child Zone* using [Method2] and the IP addresses for each name 
+   using [Method4].
 
 2. If the same IP address is found for two or more name server names, 
    emit *[DEL_NS_SAME_IP]* for each repeated address, else emit
    *[DEL_DISTINCT_NS_IP]*.
 
-3. Obtain the complete set of name server names from the child using 
-   [Method3] and the IP addresses for each name using [Method5] for
-   [in-bailiwick] names and using [Method4] for [out-of-bailiwick] 
-   names only. 
+3. Obtain the complete set of name server names from the *Child Zone* 
+   using [Method3] and the IP addresses for each name using [Method5].
 
 4. If the same IP address is found for two or more name server names, 
    emit *[CHILD_NS_SAME_IP]* for each repeated address, else emit
@@ -63,13 +62,6 @@ None
 None
 
 
-## Terminology
-
-The terms "in-bailiwick" and "out-of-bailiwick" are used as defined
-in [RFC 7719], section 6, page 15.
-
-[RFC 7719]: https://tools.ietf.org/html/rfc7719
-
 [RFC 1034]: https://tools.ietf.org/html/rfc1034
 
 [Method2]:  ../Methods.md#method-2-obtain-glue-name-records-from-parent
@@ -79,10 +71,6 @@ in [RFC 7719], section 6, page 15.
 [Method4]:  ../Methods.md#method-4-obtain-glue-address-records-from-parent
 
 [Method5]:  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-
-[in-bailiwick]:     #terminology
-
-[out-of-bailiwick]: #terminology
 
 [DEL_NS_SAME_IP]: #outcomes
 

--- a/docs/specifications/tests/Delegation-TP/delegation02.md
+++ b/docs/specifications/tests/Delegation-TP/delegation02.md
@@ -1,48 +1,71 @@
-## DELEGATION02: Name servers must have distinct IP addresses
+# DELEGATION02: Name servers must have distinct IP addresses
 
-### Test case identifier
+## Test case identifier
 
 **DELEGATION02:** Name servers must have distinct IP addresses
 
-### Objective
+## Objective
 
 If the domain have several different name server names used, they can all
 be using the same IP address. This may be due to a configuration error, or
 a workaround to a certain policy restriction. This test case checks that
 the name servers used does not resolve to reuse the same IP addresses.
 
-Section 4.1 of [RFC 1034](https://tools.ietf.org/html/rfc1034) says at least
+Section 4.1 of [RFC 1034] says at least
 to name servers must be used for a delegation.
 
-### Inputs
+## Inputs
 
 The domain name to be tested.
 
-### Ordered description of steps to be taken to execute the test case
+## Ordered description of steps to be taken to execute the test case
 
-1. Obtain the IP addresss of the name servers from the parent using [Method
-4](../Methods.md#method-4-obtain-glue-address-records-from-parent) and the child using
-   [Method 5](../Methods.md#method-5-obtain-the-name-server-address-records-from-child).
-2. If any of the IP addresses resolved in step 1 is not unique, then this
-   test case fails.
+1. Obtain the complete set of name servers (distinct NS records) from 
+   parent using [Method2].
+2. Obtain the IP addresses for the set of the name servers from parent 
+   using [Method4]. (This should include all IP address
+   for both in-bailiwick and out-of-bailiwick name servers.)
+3. If the same IP address is found for two or more name servers then 
+   emit *PARENT_NS_SAME_IP_ADDRESS* and the IP address.
+4. Repeat step 3 for all IP addresses obtained in step 2.
+5. Obtain the complete set of name servers from the child using 
+   [Method3].
+6. Obtain the IP addresses for the set of the name servers from child 
+   using [Method5] and, for out-of-bailiwick NS, using
+   [Method4].
+7. If the same IP address is found for two or more name servers then 
+   emit *CHILD_NS_SAME_IP_ADDRESS* and the IP address.
+8. Repeat step 7 for all IP addresses obtained in step 6.
 
-### Outcome(s)
+## Outcome(s)
 
-If all the IP addresses used by the name servers for the domain are unique,
-then the test succeeds.
+The outcome of the test case depends on the highest level of the messages 
+generated.
 
-### Special procedural requirements
+Message                       | Default level (if message is emitted)
+:-----------------------------|:-----------------------------------
+PARENT_NS_SAME_IP_ADDRESS     | ERROR
+CHILD_NS_SAME_IP_ADDRESS      | ERROR
+
+
+## Special procedural requirements
 
 None 
 
-### Intercase dependencies
+## Intercase dependencies
 
 None
 
+
+[RFC 1034]: https://tools.ietf.org/html/rfc1034
+[Method2]:  ../Methods.md#method-2-obtain-glue-name-records-from-parent
+[Method3]:  ../Methods.md#method-3-obtain-name-servers-from-child
+[Method4]:  ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 -------
 
-Copyright (c) 2013, 2014, 2015, IIS (The Internet Infrastructure Foundation)  
-Copyright (c) 2013, 2014, 2015, AFNIC  
+Copyright (c) 2013-2018, IIS (The Internet Foundation in Sweden)  
+Copyright (c) 2013-2018, AFNIC  
 Creative Commons Attribution 4.0 International License
 
 You should have received a copy of the license along with this

--- a/docs/specifications/tests/Delegation-TP/delegation02.md
+++ b/docs/specifications/tests/Delegation-TP/delegation02.md
@@ -12,7 +12,7 @@ a workaround to a certain policy restriction. This test case checks that
 the name servers used does not resolve to reuse the same IP addresses.
 
 Section 4.1 of [RFC 1034] says at least
-to name servers must be used for a delegation.
+two name servers must be used for a delegation.
 
 ## Inputs
 

--- a/docs/specifications/tests/Delegation-TP/delegation02.md
+++ b/docs/specifications/tests/Delegation-TP/delegation02.md
@@ -58,10 +58,15 @@ None
 
 
 [RFC 1034]: https://tools.ietf.org/html/rfc1034
+
 [Method2]:  ../Methods.md#method-2-obtain-glue-name-records-from-parent
+
 [Method3]:  ../Methods.md#method-3-obtain-name-servers-from-child
+
 [Method4]:  ../Methods.md#method-4-obtain-glue-address-records-from-parent
+
 [Method5]:  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+
 -------
 
 Copyright (c) 2013-2018, IIS (The Internet Foundation in Sweden)  


### PR DESCRIPTION
Updated delegation02:
* Updated to new format.
* Updated what IP addresses that are fetched.
* Added explicit messages to the test case specification.
* Added default level of the messages.
* Specification mixed parent and child, which are kept separated.
* Message  SAME_IP_ADDRESS is split into two messages, DEL_NS_SAME_IP  and CHILD_NS_SAME_IP, respectively.
* Message DISTINCT_IP_ADDRESS is split into two messages, DEL_DISTINCT_NS_IP and CHILD_DISTINCT_NS_IP, respectively.
