### PR TITLE
Update consistency01

### DIFF
--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -39,14 +39,14 @@ serial number consistency.
     server IP.
 
  3. If the name server does not respond with a DNS response, emit 
-    *[NO_RESPONSE]* and go to next name server.
+    *[NO_RESPONSE]* and go to next name server IP.
 
  4. If the name server responds with a DNS response but no a SOA record 
     is included, emit *[NO_RESPONSE_SOA_QUERY]* and got to next name 
-    server.
+    server IP.
 
  5. Retrieve the SOA SERIAL from the responses and go to next name server
-    until all name server IPs have been queried.
+    IP until all name server IPs have been queried.
 
  6. If at least one SOA SERIAL has been retrieved and all serial 
     numbers are identical, emit *[ONE_SOA_SERIAL]*.

--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -1,17 +1,17 @@
-## CONSISTENCY01: SOA serial number consistency
+# CONSISTENCY01: SOA serial number consistency
 
-### Test case identifier
+## Test case identifier
 
 **CONSISTENCY01:** SOA serial number consistency
 
-### Objective
+## Objective
 
 For the data served by the authoritative name servers for a designated zone
 to be consistent, all authoritative name servers must serve the same SOA
 record for the designated zone.   
 
-If the serial number (explained in 3.3.13. of [RFC 1035](https://tools.ietf.org/html/rfc1035)) 
-, which is part of the SOA record, is not consistent between authoritative servers, 
+If the serial number (explained in 3.3.13. of [RFC 1035]), 
+which is part of the SOA record, is not consistent between authoritative servers, 
 there is a possibility that the data served is inconsistent. The reasons for this 
 inconsistency may be different - such as misconfiguration, or as a result of slow 
 propagation to the secondary name servers.
@@ -19,34 +19,64 @@ propagation to the secondary name servers.
 The objective of this test is to verify that the serial number is consistent
 between different authoritative name servers.
 
-For reference purposes : [RFC1982](https://tools.ietf.org/html/rfc1982) 
+For reference purposes : [RFC 1982]
 explains the serial number arithmetic, and section 4.3.5 of 
-[RFC 1034](https://tools.ietf.org/html/rfc1035) explains the importance of
+[RFC 1034] explains the importance of
 serial number consistency.
 
-### Inputs
+## Inputs
 
-The domain name to be tested.
+* The domain name to be tested ("child zone")
+* Accepted SOA serial difference, default 0 ("accepted serial difference")
 
-### Ordered description of steps to be taken to execute the test case
+## Ordered description of steps to be taken to execute the test case
 
- 1. Obtain the list of name servers from [Method4] and [Method5].
- 2. Retrieve the SOA RR from all the name servers.
- 3. If the SOA serial number is not the same from all the answers received
-    from step 2, then:
-     1. Check if the difference is minor (An integer should be added to
-        define what is the minor value).
-     2. If the difference is greater than the minor value, then the test
-        case fails.
-     3. If the difference is less than or equal to the minor value,
-        then the test is passed.
+ 1. Obtain the list of name server IPs for the *child zone* from [Method4] 
+    and [Method5].
+ 2. Create an SOA query for *child zone* apex and send it to all name 
+    server IPs.
+ 3. Retrieve the SOA RR from the responses from all name server IPs.
+ 4. If a name server does not respond, emit *NO_RESPONSE*.
+ 5. If a name server does not include a SOA record in the response,
+    emit *NO_RESPONSE_SOA_QUERY*.
+ 6. If all serial numbers are identical, emit *ONE_SOA_SERIAL* and stop
+    processing these steps.
+ 7. If at least two serial numbers are different:
+    1. Order the serial number values from smallest to largest following
+       the arithmetic for serial number.
+       If there is not a single, uniquely defined order of the serial 
+       numbers, emit *SOA_SERIAL_VARIATION* and *MULTIPLE_SOA_SERIALS*, 
+       and end processing these steps.
+    2. If the difference between the first and the last serial number
+       is larger than *accepted serial difference*, using arithemtic
+       for serial number, emit *SOA_SERIAL_VARIATION* and 
+       *MULTIPLE_SOA_SERIALS*, and end processing these steps.
+    3. Emit *MULTIPLE_SOA_SERIALS_OK*.
 
-### Outcome(s)
 
-All authoritative name servers must have consistent serial numbers. If the
-test does not find any inconsistency, then the test case passes.
+## Outcome(s)
 
-### Special procedural requirements	
+The outcome of this Test Case is "fail" if there is at least one message
+with the severity level *ERROR* or *CRITICAL*.
+
+The outcome of this Test Case is "warning" if there is at least one message
+with the severity level *WARNING*, but no message with severity level
+*ERROR* or *CRITICAL*.
+
+In other cases the outcome of this Test Case is "pass".
+
+Message                       | Default severity level (if message is emitted)
+:-----------------------------|:-----------------------------------
+NO_RESPONSE                   | WARNING
+NO_RESPONSE_SOA_QUERY         | DEBUG
+ONE_SOA_SERIAL                | INFO
+MULTIPLE_SOA_SERIALS          | WARNING
+MULTIPLE_SOA_SERIALS_OK       | NOTICE
+SOA_SERIAL                    | INFO
+SOA_SERIAL_VARIATION          | NOTICE
+
+
+## Special procedural requirements	
 
 If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
 result of any test using this transport protocol. Log a message reporting
@@ -56,17 +86,22 @@ A manual inspection of the SOA serial may be needed to determine if the zone
 updates work properly or not, and if the serial values are within a
 reasonable range, then the test is OK.
 
-### Intercase dependencies
+When comparing SOA serial it must be done using the aritmetic defined in
+[RFC 1982].
+
+
+## Intercase dependencies
 
 None
 
--------
+[RFC 1034]: https://tools.ietf.org/html/rfc1035
+
+[RFC 1035]: https://tools.ietf.org/html/rfc1035
+
+[RFC 1982]: https://tools.ietf.org/html/rfc1982 
+
 [Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
+
 [Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 
-Copyright (c) 2013, 2014, 2015, IIS (The Internet Infrastructure Foundation)  
-Copyright (c) 2013, 2014, 2015, AFNIC  
-Creative Commons Attribution 4.0 International License
 
-You should have received a copy of the license along with this
-work.  If not, see <https://creativecommons.org/licenses/by/4.0/>.

--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -26,26 +26,30 @@ serial number consistency.
 
 ## Inputs
 
-* The domain name to be tested ("child zone")
-* Accepted SOA serial difference, default 0 ("accepted serial difference")
+* The domain name to be tested ("Child Zone").
+* Accepted SOA serial difference ("Accepted Serial Difference"). Default value
+  is 0.
 
 ## Ordered description of steps to be taken to execute the test case
 
- 1. Obtain the list of name server IPs for the *child zone* from [Method4] 
+ 1. Obtain the list of name server IPs for the *Child Zone* from [Method4] 
     and [Method5].
 
- 2. Create an SOA query for *child zone* apex and send it to all name 
-    server IPs.
+ 2. Create an SOA query for *Child Zone* apex and send it to each name 
+    server IP.
 
- 3. Retrieve the SOA RR from the responses from all name server IPs.
+ 3. If the name server does not respond with a DNS response, emit 
+    *[NO_RESPONSE]* and go to next name server.
 
- 4. If a name server does not respond, emit *[NO_RESPONSE]*.
+ 4. If the name server responds with a DNS response but no a SOA record 
+    is included, emit *[NO_RESPONSE_SOA_QUERY]* and got to next name 
+    server.
 
- 5. If a name server responds but does not include a SOA record in 
-    the response, emit *[NO_RESPONSE_SOA_QUERY]*.
+ 5. Retrieve the SOA SERIAL from the responses and go to next name server
+    until all name server IPs have been queried.
 
- 6. If at least one SOA record has been retrieved and all serial 
-    numbers are identical, emit *[ONE_SOA_SERIAL]*;
+ 6. If at least one SOA SERIAL has been retrieved and all serial 
+    numbers are identical, emit *[ONE_SOA_SERIAL]*.
 
  7. If at least two serial numbers are different:
     1. Order the serial number values from smallest to largest following
@@ -53,11 +57,11 @@ serial number consistency.
     2. If there is not a single, uniquely defined order of the serial 
        numbers, emit *[SOA_SERIAL_VARIATION]* and *[MULTIPLE_SOA_SERIALS]*.
     3. If the difference between the first and the last serial number
-       is larger than *accepted serial difference*, using arithemtic
+       is larger than *Accepted Serial Difference*, using arithemtic
        for serial number, emit *[SOA_SERIAL_VARIATION]* and 
        *[MULTIPLE_SOA_SERIALS]*.
     4. If the difference between the first and the last serial number
-       is not larger than *accepted serial difference*, using arithemtic
+       is not larger than *Accepted Serial Difference*, using arithemtic
        for serial number, emit *[MULTIPLE_SOA_SERIALS_OK]*.
 
  8. For each found serial number, emit *[SOA_SERIAL]* with the serial
@@ -116,10 +120,16 @@ None
 [Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 
 [NO_RESPONSE]: #outcomes
+
 [NO_RESPONSE_SOA_QUERY]: #outcomes
+
 [ONE_SOA_SERIAL]: #outcomes
+
 [MULTIPLE_SOA_SERIALS]: #outcomes
+
 [MULTIPLE_SOA_SERIALS_OK]: #outcomes
+
 [SOA_SERIAL]: #outcomes
+
 [SOA_SERIAL_VARIATION]: #outcomes
 

--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -26,47 +26,55 @@ serial number consistency.
 
 ## Inputs
 
-* The domain name to be tested ("Child Zone").
-* Accepted SOA serial difference ("Accepted Serial Difference"). Default value
-  is 0.
+* "Child Zone" - The domain name to be tested 
+* "Accepted Serial Difference" - Accepted difference between SOA serial
+  values from SOA records of different name servers for *Child Zone*. 
+  Default value is 0, i.e. no difference.
 
 ## Ordered description of steps to be taken to execute the test case
 
- 1. Obtain the list of name server IPs for the *Child Zone* from [Method4] 
-    and [Method5].
+1. Obtain the list of name server IPs for the *Child Zone* from [Method4] 
+    and [Method5] ("Name Server IP").
 
- 2. Create an SOA query for *Child Zone* apex and send it to each name 
-    server IP.
+2. Create an SOA query for *Child Zone* name (the top of the zone).
 
- 3. If the name server does not respond with a DNS response, emit 
-    *[NO_RESPONSE]* and go to next name server IP.
+3. Create an empty set of pair of retrieved SOA serials and name server
+   name and IP ("SOA Serial Set"). 
 
- 4. If the name server responds with a DNS response but no a SOA record 
-    is included, emit *[NO_RESPONSE_SOA_QUERY]* and go to next name 
-    server IP.
+3. For each name server in *Name Server IP* do:
+    
+    1. Send the SOA query to the name server.
 
- 5. Retrieve the SOA SERIAL from the responses and go to next name server
-    IP until all name server IPs have been queried.
+    2. If the name server does not respond with a DNS response, then 
+       output *[NO_RESPONSE]*.
 
- 6. If at least one SOA SERIAL has been retrieved and all serial 
-    numbers are identical, emit *[ONE_SOA_SERIAL]*.
+    3. Or, if the name server returns a DNS response, but no SOA 
+       record is included, then output *[NO_RESPONSE_SOA_QUERY]*.
 
- 7. If at least two serial numbers are different:
-    1. Order the serial number values from smallest to largest following
-       the arithmetic for serial number.
+    4. Or, retrieve the SOA SERIAL from the response and add it to
+       *SOA Serial Set* (unless it is already there) and update the set
+       with the name server name and IP.
+
+4. If *SOA Serial Set* has exactly one SOA serial value, then output 
+   *[ONE_SOA_SERIAL]*.
+
+5. Or, if *SOA Serial Set* has at least two SOA serials values, then do:
+    1. Order the serial number values from *SOA Serial Set* from smallest 
+       to largest following the arithmetic for serial number, if possible.
     2. If there is not a single, uniquely defined order of the serial 
-       numbers, emit *[SOA_SERIAL_VARIATION]* and *[MULTIPLE_SOA_SERIALS]*.
-    3. If the difference between the first and the last serial number
-       is larger than *Accepted Serial Difference*, using arithmetic
-       for serial number, emit *[SOA_SERIAL_VARIATION]* and 
+       numbers, then output *[SOA_SERIAL_VARIATION]* and 
        *[MULTIPLE_SOA_SERIALS]*.
-    4. If the difference between the first and the last serial number
+    3. Or, if the difference between the first and the last serial number
+       is larger than *Accepted Serial Difference*, using arithmetic
+       for serial number, then output *[SOA_SERIAL_VARIATION]* and 
+       *[MULTIPLE_SOA_SERIALS]*.
+    4. Or, if the difference between the first and the last serial number
        is not larger than *Accepted Serial Difference*, using arithmetic
-       for serial number, emit *[MULTIPLE_SOA_SERIALS_OK]*.
+       for serial number, output *[MULTIPLE_SOA_SERIALS_OK]*.
 
- 8. For each found serial number, emit *[SOA_SERIAL]* with the serial
-    number and a semicolon separated list of name server names and IP
-    address pairs (name/IP).
+6. For each SOA serial value in *SOA Serial Set*, output *[SOA_SERIAL]* 
+   with the serial number and a semicolon separated list of name server 
+   names and IP address pairs (name/IP).
     
 
 ## Outcome(s)

--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -36,22 +36,22 @@ serial number consistency.
  2. Create an SOA query for *child zone* apex and send it to all name 
     server IPs.
  3. Retrieve the SOA RR from the responses from all name server IPs.
- 4. If a name server does not respond, emit *NO_RESPONSE*.
+ 4. If a name server does not respond, emit *[NO_RESPONSE]*.
  5. If a name server does not include a SOA record in the response,
-    emit *NO_RESPONSE_SOA_QUERY*.
- 6. If all serial numbers are identical, emit *ONE_SOA_SERIAL* and stop
+    emit *[NO_RESPONSE_SOA_QUERY]*.
+ 6. If all serial numbers are identical, emit *[ONE_SOA_SERIAL]* and stop
     processing these steps.
  7. If at least two serial numbers are different:
     1. Order the serial number values from smallest to largest following
        the arithmetic for serial number.
        If there is not a single, uniquely defined order of the serial 
-       numbers, emit *SOA_SERIAL_VARIATION* and *MULTIPLE_SOA_SERIALS*, 
+       numbers, emit *[SOA_SERIAL_VARIATION]* and *[MULTIPLE_SOA_SERIALS]*, 
        and end processing these steps.
     2. If the difference between the first and the last serial number
        is larger than *accepted serial difference*, using arithemtic
-       for serial number, emit *SOA_SERIAL_VARIATION* and 
-       *MULTIPLE_SOA_SERIALS*, and end processing these steps.
-    3. Emit *MULTIPLE_SOA_SERIALS_OK*.
+       for serial number, emit *[SOA_SERIAL_VARIATION]* and 
+       *[MULTIPLE_SOA_SERIALS]*, and end processing these steps.
+    3. Emit *[MULTIPLE_SOA_SERIALS_OK]*.
 
 
 ## Outcome(s)
@@ -104,4 +104,11 @@ None
 
 [Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 
+[NO_RESPONSE]: #outcomes
+[NO_RESPONSE_SOA_QUERY]: #outcomes
+[ONE_SOA_SERIAL]: #outcomes
+[MULTIPLE_SOA_SERIALS]: #outcomes
+[MULTIPLE_SOA_SERIALS_OK]: #outcomes
+[SOA_SERIAL]: #outcomes
+[SOA_SERIAL_VARIATION]: #outcomes
 

--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -2,7 +2,7 @@
 
 ## Test case identifier
 
-**CONSISTENCY01:** SOA serial number consistency
+**CONSISTENCY01**
 
 ## Objective
 

--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -33,27 +33,37 @@ serial number consistency.
 
  1. Obtain the list of name server IPs for the *child zone* from [Method4] 
     and [Method5].
+
  2. Create an SOA query for *child zone* apex and send it to all name 
     server IPs.
+
  3. Retrieve the SOA RR from the responses from all name server IPs.
+
  4. If a name server does not respond, emit *[NO_RESPONSE]*.
+
  5. If a name server responds but does not include a SOA record in 
     the response, emit *[NO_RESPONSE_SOA_QUERY]*.
+
  6. If at least one SOA record has been retrieved and all serial 
-    numbers are identical, emit *[ONE_SOA_SERIAL]* and stop
-    processing these steps.
+    numbers are identical, emit *[ONE_SOA_SERIAL]*;
+
  7. If at least two serial numbers are different:
     1. Order the serial number values from smallest to largest following
        the arithmetic for serial number.
-       If there is not a single, uniquely defined order of the serial 
-       numbers, emit *[SOA_SERIAL_VARIATION]* and *[MULTIPLE_SOA_SERIALS]*, 
-       and end processing these steps.
-    2. If the difference between the first and the last serial number
+    2. If there is not a single, uniquely defined order of the serial 
+       numbers, emit *[SOA_SERIAL_VARIATION]* and *[MULTIPLE_SOA_SERIALS]*.
+    3. If the difference between the first and the last serial number
        is larger than *accepted serial difference*, using arithemtic
        for serial number, emit *[SOA_SERIAL_VARIATION]* and 
-       *[MULTIPLE_SOA_SERIALS]*, and end processing these steps.
-    3. Emit *[MULTIPLE_SOA_SERIALS_OK]*.
+       *[MULTIPLE_SOA_SERIALS]*.
+    4. If the difference between the first and the last serial number
+       is not larger than *accepted serial difference*, using arithemtic
+       for serial number, emit *[MULTIPLE_SOA_SERIALS_OK]*.
 
+ 8. For each found serial number, emit *[SOA_SERIAL]* with the serial
+    number and a semicolon separated list of name server names and IP
+    address pairs (name/IP).
+    
 
 ## Outcome(s)
 

--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -42,7 +42,7 @@ serial number consistency.
     *[NO_RESPONSE]* and go to next name server IP.
 
  4. If the name server responds with a DNS response but no a SOA record 
-    is included, emit *[NO_RESPONSE_SOA_QUERY]* and got to next name 
+    is included, emit *[NO_RESPONSE_SOA_QUERY]* and go to next name 
     server IP.
 
  5. Retrieve the SOA SERIAL from the responses and go to next name server
@@ -57,11 +57,11 @@ serial number consistency.
     2. If there is not a single, uniquely defined order of the serial 
        numbers, emit *[SOA_SERIAL_VARIATION]* and *[MULTIPLE_SOA_SERIALS]*.
     3. If the difference between the first and the last serial number
-       is larger than *Accepted Serial Difference*, using arithemtic
+       is larger than *Accepted Serial Difference*, using arithmetic
        for serial number, emit *[SOA_SERIAL_VARIATION]* and 
        *[MULTIPLE_SOA_SERIALS]*.
     4. If the difference between the first and the last serial number
-       is not larger than *Accepted Serial Difference*, using arithemtic
+       is not larger than *Accepted Serial Difference*, using arithmetic
        for serial number, emit *[MULTIPLE_SOA_SERIALS_OK]*.
 
  8. For each found serial number, emit *[SOA_SERIAL]* with the serial
@@ -101,7 +101,7 @@ A manual inspection of the SOA serial may be needed to determine if the zone
 updates work properly or not, and if the serial values are within a
 reasonable range, then the test is OK.
 
-When comparing SOA serial it must be done using the aritmetic defined in
+When comparing SOA serial it must be done using the arithmetic defined in
 [RFC 1982].
 
 

--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -37,9 +37,10 @@ serial number consistency.
     server IPs.
  3. Retrieve the SOA RR from the responses from all name server IPs.
  4. If a name server does not respond, emit *[NO_RESPONSE]*.
- 5. If a name server does not include a SOA record in the response,
-    emit *[NO_RESPONSE_SOA_QUERY]*.
- 6. If all serial numbers are identical, emit *[ONE_SOA_SERIAL]* and stop
+ 5. If a name server responds but does not include a SOA record in 
+    the response, emit *[NO_RESPONSE_SOA_QUERY]*.
+ 6. If at least one SOA record has been retrieved and all serial 
+    numbers are identical, emit *[ONE_SOA_SERIAL]* and stop
     processing these steps.
  7. If at least two serial numbers are different:
     1. Order the serial number values from smallest to largest following


### PR DESCRIPTION
Updated consistency01

* Updated to new format.
* Added explicit messages.
* Added explicit reference to serial number arithmetic.
* Added explicit reference to accepted difference.
* Removed copyright statement.
* Removed description/headline from identifier line.

Changes compared to current implementation (develop branch pre v2018.1):

**In practice no changes.**

The implementation has the accepted serial difference hardcoded to 0, which means that the code will only consider equal or not equal serial number. The requirement for the new message in the specification, *MULTIPLE_SOA_SERIALS_OK*, will never be met.

The way that serial values are compared, when not equal, is not correct in the implementation, but that is only relevant if the accepted serial difference is at least 1.

Also see #617.