### PR TITLE
Create test case consistency06 for SOA MNAME

### DIFF
--- a/docs/specifications/tests/Consistency-TP/README.md
+++ b/docs/specifications/tests/Consistency-TP/README.md
@@ -8,8 +8,8 @@ This document uses the terminology defined in the [Master Test Plan](../MasterTe
 |:--|:-------------------------------------------------------------|:--------------------------------|
 |R33|SOA serial number consistency                                 |[CONSISTENCY01](consistency01.md)|
 |R34|RNAME consistency                                             |[CONSISTENCY02](consistency02.md)|
-|R36|Coherence of SOA with primary nameserver                      |[CONSISTENCY06](consistency06.md)|
 |R70|Coherence of all other SOA-fields where SOA Serial is the same|[CONSISTENCY03](consistency03.md)|
 |R78|All authoritative nameservers reply with same set             |[CONSISTENCY04](consistency04.md)|
 |R83|Consistency between glue and authoritative data               |[CONSISTENCY05](consistency05.md)|
+|R36|Coherence of SOA with primary nameserver                      |[CONSISTENCY06](consistency06.md)|
 

--- a/docs/specifications/tests/Consistency-TP/README.md
+++ b/docs/specifications/tests/Consistency-TP/README.md
@@ -8,16 +8,8 @@ This document uses the terminology defined in the [Master Test Plan](../MasterTe
 |:--|:-------------------------------------------------------------|:--------------------------------|
 |R33|SOA serial number consistency                                 |[CONSISTENCY01](consistency01.md)|
 |R34|RNAME consistency                                             |[CONSISTENCY02](consistency02.md)|
-|R36|Coherence of SOA with primary nameserver                      |[CONSISTENCY03](consistency03.md)|
+|R36|Coherence of SOA with primary nameserver                      |[CONSISTENCY06](consistency06.md)|
 |R70|Coherence of all other SOA-fields where SOA Serial is the same|[CONSISTENCY03](consistency03.md)|
 |R78|All authoritative nameservers reply with same set             |[CONSISTENCY04](consistency04.md)|
 |R83|Consistency between glue and authoritative data               |[CONSISTENCY05](consistency05.md)|
 
--------
-
-Copyright (c) 2013, 2014, 2015, IIS (The Internet Infrastructure Foundation)  
-Copyright (c) 2013, 2014, 2015, AFNIC  
-Creative Commons Attribution 4.0 International License
-
-You should have received a copy of the license along with this
-work.  If not, see <https://creativecommons.org/licenses/by/4.0/>.

--- a/docs/specifications/tests/Consistency-TP/consistency06.md
+++ b/docs/specifications/tests/Consistency-TP/consistency06.md
@@ -36,12 +36,12 @@ operational failures for applications that uses MNAME.
        and save that to compare it with the MNAME from the other name
        servers.
 
- 5. Compare the MNAME fields retreived from all name servers.
+ 4. Compare the MNAME fields retreived from all name servers.
 
- 4. If at least one name server has responded with a SOA record and the 
+ 5. If at least one name server has responded with a SOA record and the 
     MNAME is identical in all SOA records retrieved, emit *[ONE_SOA_MNAME]*.
 
- 5. If MNAME is not identical in all SOA records retrieved, emit 
+ 6. If MNAME is not identical in all SOA records retrieved, emit 
     *[MULTIPLE_SOA_MNAMES]*.
 
 ## Outcome(s)

--- a/docs/specifications/tests/Consistency-TP/consistency06.md
+++ b/docs/specifications/tests/Consistency-TP/consistency06.md
@@ -15,21 +15,29 @@ operational failures for applications that uses MNAME.
 
 ## Inputs
 
-* The domain name to be tested ("child zone")
+* "Child Zone" - The domain name to be tested.
 
 ## Ordered description of steps to be taken to execute the test case
 
- 1. Obtain the list of name server IPs for the *child zone* from [Method4] 
-    and [Method5].
- 2. Create an SOA query for *child zone* apex and send it to all name 
-    server IPs.
- 3. Retrieve the SOA RR from the responses from all name server IPs.
- 4. If a name server does not respond, emit *[NO_RESPONSE]*.
- 5. If a name server responds but does not include a SOA record in 
-    the response, emit *[NO_RESPONSE_SOA_QUERY]*.
- 6. If at least one SOA record has been retrieved and MNAME is 
-    identical in all SOA records emit *[ONE_SOA_MNAME]*.
- 7. If MNAME is not identical in all SOA records emit 
+ 1. Obtain the set of name server IPs for the *Child Zone* from [Method4] 
+    and [Method5] ("Name Server IP").
+
+ 2. Create an SOA query for *Child Zone* apex.
+
+ 3. For each name server in *Name Server IP* do:
+
+    1. Send the query to name server.
+    2. If the name server does not respond with a DNS response, 
+       emit *[NO_RESPONSE]* for that name server and go to next server.
+    3. Retrieve the SOA RR from the response from the name server.
+    4. If the response does not include a SOA record in the ansser section
+       then emit *[NO_RESPONSE_SOA_QUERY]* for that server and go to next
+       server.
+
+ 4. If at least one name server has responded with a SOA record and the 
+    MNAME is identical in all SOA records retrieved, emit *[ONE_SOA_MNAME]*.
+
+ 5. If MNAME is not identical in all SOA records retrieved emit 
     *[MULTIPLE_SOA_MNAMES]*.
 
 ## Outcome(s)

--- a/docs/specifications/tests/Consistency-TP/consistency06.md
+++ b/docs/specifications/tests/Consistency-TP/consistency06.md
@@ -65,14 +65,15 @@ None
 
 [RFC 1035]: https://tools.ietf.org/html/rfc1035
 
-[RFC 1982]: https://tools.ietf.org/html/rfc1982 
-
 [Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
 
 [Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 
 [NO_RESPONSE]: #outcomes
+
 [NO_RESPONSE_SOA_QUERY]: #outcomes
+
 [ONE_SOA_MNAME]: #outcomes
+
 [MULTIPLE_SOA_MNAMES]: #outcomes
 

--- a/docs/specifications/tests/Consistency-TP/consistency06.md
+++ b/docs/specifications/tests/Consistency-TP/consistency06.md
@@ -1,8 +1,8 @@
-# CONSISTENCY02: SOA MNAME consistency
+# CONSISTENCY06: SOA MNAME consistency
 
 ## Test case identifier
 
-**CONSISTENCY02**
+**CONSISTENCY06**
 
 ## Objective
 

--- a/docs/specifications/tests/Consistency-TP/consistency06.md
+++ b/docs/specifications/tests/Consistency-TP/consistency06.md
@@ -29,15 +29,19 @@ operational failures for applications that uses MNAME.
     1. Send the query to name server.
     2. If the name server does not respond with a DNS response, 
        emit *[NO_RESPONSE]* for that name server and go to next server.
-    3. Retrieve the SOA RR from the response from the name server.
-    4. If the response does not include a SOA record in the ansser section
-       then emit *[NO_RESPONSE_SOA_QUERY]* for that server and go to next
-       server.
+    3. If the DNS response does not include a SOA record in the answer 
+       section then emit *[NO_RESPONSE_SOA_QUERY]* for that server and go 
+       to next server.
+    4. Retrieve the MNAME field from the SOA RR from the DNS response
+       and save that to compare it with the MNAME from the other name
+       servers.
+
+ 5. Compare the MNAME fields retreived from all name servers.
 
  4. If at least one name server has responded with a SOA record and the 
     MNAME is identical in all SOA records retrieved, emit *[ONE_SOA_MNAME]*.
 
- 5. If MNAME is not identical in all SOA records retrieved emit 
+ 5. If MNAME is not identical in all SOA records retrieved, emit 
     *[MULTIPLE_SOA_MNAMES]*.
 
 ## Outcome(s)

--- a/docs/specifications/tests/Consistency-TP/consistency06.md
+++ b/docs/specifications/tests/Consistency-TP/consistency06.md
@@ -1,0 +1,78 @@
+# CONSISTENCY02: SOA MNAME consistency
+
+## Test case identifier
+
+**CONSISTENCY02**
+
+## Objective
+
+All authoritative name servers must serve the same SOA record (section
+4.2.1) of [RFC 1034] for the tested domain. As per section 3.3.13 of 
+[RFC 1035] the MNAME field in the SOA RDATA refers to the name of 
+"the name server that was the original or primary source of data 
+for this zone". Inconsistency in MNAME of the domain might result in 
+operational failures for applications that uses MNAME.
+
+## Inputs
+
+* The domain name to be tested ("child zone")
+
+## Ordered description of steps to be taken to execute the test case
+
+ 1. Obtain the list of name server IPs for the *child zone* from [Method4] 
+    and [Method5].
+ 2. Create an SOA query for *child zone* apex and send it to all name 
+    server IPs.
+ 3. Retrieve the SOA RR from the responses from all name server IPs.
+ 4. If a name server does not respond, emit *[NO_RESPONSE]*.
+ 5. If a name server does not include a SOA record in the response,
+    emit *[NO_RESPONSE_SOA_QUERY]*.
+ 6. If MNAME is identical in all SOA records emit *[ONE_SOA_MNAME]*.
+ 7. If MNAME is not identical in all SOA records emit 
+    *[MULTIPLE_SOA_MNAMES]*.
+
+## Outcome(s)
+
+The outcome of this Test Case is "fail" if there is at least one message
+with the severity level *ERROR* or *CRITICAL*.
+
+The outcome of this Test Case is "warning" if there is at least one message
+with the severity level *WARNING*, but no message with severity level
+*ERROR* or *CRITICAL*.
+
+In other cases the outcome of this Test Case is "pass".
+
+Message                       | Default severity level (if message is emitted)
+:-----------------------------|:-----------------------------------
+NO_RESPONSE                   | WARNING
+NO_RESPONSE_SOA_QUERY         | DEBUG
+ONE_SOA_MNAME                 | INFO
+MULTIPLE_SOA_MNAMES           | NOTICE
+
+
+## Special procedural requirements	
+
+If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
+result of any test using this transport protocol. Log a message reporting
+on the ignored result.
+
+## Intercase dependencies
+
+None
+
+
+[RFC 1034]: https://tools.ietf.org/html/rfc1035
+
+[RFC 1035]: https://tools.ietf.org/html/rfc1035
+
+[RFC 1982]: https://tools.ietf.org/html/rfc1982 
+
+[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
+
+[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+
+[NO_RESPONSE]: #outcomes
+[NO_RESPONSE_SOA_QUERY]: #outcomes
+[ONE_SOA_MNAME]: #outcomes
+[MULTIPLE_SOA_MNAMES]: #outcomes
+

--- a/docs/specifications/tests/Consistency-TP/consistency06.md
+++ b/docs/specifications/tests/Consistency-TP/consistency06.md
@@ -25,9 +25,10 @@ operational failures for applications that uses MNAME.
     server IPs.
  3. Retrieve the SOA RR from the responses from all name server IPs.
  4. If a name server does not respond, emit *[NO_RESPONSE]*.
- 5. If a name server does not include a SOA record in the response,
-    emit *[NO_RESPONSE_SOA_QUERY]*.
- 6. If MNAME is identical in all SOA records emit *[ONE_SOA_MNAME]*.
+ 5. If a name server responds but does not include a SOA record in 
+    the response, emit *[NO_RESPONSE_SOA_QUERY]*.
+ 6. If at least one SOA record has been retrieved and MNAME is 
+    identical in all SOA records emit *[ONE_SOA_MNAME]*.
  7. If MNAME is not identical in all SOA records emit 
     *[MULTIPLE_SOA_MNAMES]*.
 


### PR DESCRIPTION
There are test cases for the consistency of all SOA fields except SOA MNAME. This is a new test case under Consistency Test Plan that adds testing for that.