### PR TITLE
Updated "dotse" to "zonemaster" in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ installation instructions from the links above.
 
 ## Versions
 
-Go to the [release list](https://github.com/dotse/zonemaster/releases) 
+Go to the [release list](https://github.com/zonemaster/zonemaster/releases) 
 of this repository to find the 
-[latest version](https://github.com/dotse/zonemaster/releases/latest) of 
+[latest version](https://github.com/zonemaster/zonemaster/releases/latest) of 
 Zonemaster and the versions of the specific components. Be
 sure to read the release note of each component before installing or
 upgrading.
@@ -153,14 +153,14 @@ please search for the problem in the issue tracker in the relevant repository.
 If you find an open issue covering your issue, please add
 a comment with any additional information.
 
-* [Issues in Zonemaster::LDNS](https://github.com/dotse/zonemaster-ldns/issues)
-* [Issues in Zonemaster::Engine](https://github.com/dotse/zonemaster-engine/issues)
-* [Issues in Zonemaster::CLI](https://github.com/dotse/zonemaster-cli/issues)
-* [Issues in Zonemaster::Backend](https://github.com/dotse/zonemaster-backend/issues)
+* [Issues in Zonemaster::LDNS](https://github.com/zonemaster/zonemaster-ldns/issues)
+* [Issues in Zonemaster::Engine](https://github.com/zonemaster/zonemaster-engine/issues)
+* [Issues in Zonemaster::CLI](https://github.com/zonemaster/zonemaster-cli/issues)
+* [Issues in Zonemaster::Backend](https://github.com/zonemaster/zonemaster-backend/issues)
 * [Issues in zonemaster::GUI](https://github.com/zonemaster/zonemaster-gui/issues)
 
 If you cannot determine which repository to create the issue in, please select the main [Zonemaster] 
-repository (i.e. [general issues in Zonemaster](https://github.com/dotse/zonemaster/issues)).
+repository (i.e. [general issues in Zonemaster](https://github.com/zonemaster/zonemaster/issues)).
 
 
 ## Notable bugs and issues
@@ -173,11 +173,11 @@ None.
 For contacting the Zonemaster project, please send an e-mail to
 contact@zonemaster.net.
 
-[Zonemaster]: https://github.com/dotse/zonemaster
-[Zonemaster-LDNS]: https://github.com/dotse/zonemaster-ldns
-[Zonemaster-Engine]: https://github.com/dotse/zonemaster-engine 
-[Zonemaster-CLI]: https://github.com/dotse/zonemaster-cli
-[Zonemaster-Backend]: https://github.com/dotse/zonemaster-backend
+[Zonemaster]: https://github.com/zonemaster/zonemaster
+[Zonemaster-LDNS]: https://github.com/zonemaster/zonemaster-ldns
+[Zonemaster-Engine]: https://github.com/zonemaster/zonemaster-engine 
+[Zonemaster-CLI]: https://github.com/zonemaster/zonemaster-cli
+[Zonemaster-Backend]: https://github.com/zonemaster/zonemaster-backend
 [Zonemaster-GUI]: https://github.com/zonemaster/zonemaster-gui
 [LDNS]: https://www.nlnetlabs.nl/projects/ldns/
 [CPAN]: http://search.cpan.org/search?query=Zonemaster&mode=dist

--- a/docs/design/Versions and Releases.md
+++ b/docs/design/Versions and Releases.md
@@ -5,20 +5,20 @@
 This document is intended to specify the semantics of the versions numbers used for the Zonemaster Product and its
 components. There are two different version schema, one for the Zonemaster Product, and one for its components.
 
-The main Zonemaster Repository ([zonemaster](https://github.com/dotse/zonemaster)) stores the specifications
+The main Zonemaster Repository ([zonemaster](https://github.com/zonemaster/zonemaster)) stores the specifications
 and documentation for the Zonemaster Product. There is no direct Perl code for Zonemaster in that repository. The Zonemaster
 components are part of the Zonemaster Product, but stored in separate repositories 
-([zonemaster-ldns](https://github.com/dotse/zonemaster-ldns), 
-[zonemaster-engine](https://github.com/dotse/zonemaster-engine),
-[zonemaster-cli](https://github.com/dotse/zonemaster-cli),
-[zonemaster-backend](https://github.com/dotse/zonemaster-backend) and 
-[zonemaster-gui](https://github.com/dotse/zonemaster-gui)). In each component repository the main Perl module of 
+([zonemaster-ldns](https://github.com/zonemaster/zonemaster-ldns), 
+[zonemaster-engine](https://github.com/zonemaster/zonemaster-engine),
+[zonemaster-cli](https://github.com/zonemaster/zonemaster-cli),
+[zonemaster-backend](https://github.com/zonemaster/zonemaster-backend) and 
+[zonemaster-gui](https://github.com/zonemaster/zonemaster-gui)). In each component repository the main Perl module of 
 the component can be found:
-* [Zonemaster::LDNS](https://github.com/dotse/zonemaster-ldns/blob/master/lib/Zonemaster/LDNS.pm)
-* [Zonemaster::Engine](https://github.com/dotse/zonemaster-engine/blob/master/lib/Zonemaster/Engine.pm)
-* [Zonemaster::CLI](https://github.com/dotse/zonemaster-cli/blob/master/lib/Zonemaster/CLI.pm)
-* [Zonemaster::Backend](https://github.com/dotse/zonemaster-backend/blob/master/lib/Zonemaster/Backend.pm)
-* [Zonemaster::GUI](https://github.com/dotse/zonemaster-gui/blob/master/lib/Zonemaster/GUI.pm)
+* [Zonemaster::LDNS](https://github.com/zonemaster/zonemaster-ldns/blob/master/lib/Zonemaster/LDNS.pm)
+* [Zonemaster::Engine](https://github.com/zonemaster/zonemaster-engine/blob/master/lib/Zonemaster/Engine.pm)
+* [Zonemaster::CLI](https://github.com/zonemaster/zonemaster-cli/blob/master/lib/Zonemaster/CLI.pm)
+* [Zonemaster::Backend](https://github.com/zonemaster/zonemaster-backend/blob/master/lib/Zonemaster/Backend.pm)
+* [Zonemaster::GUI](https://github.com/zonemaster/zonemaster-gui/blob/master/lib/Zonemaster/GUI.pm)
 
 This document also discusses how the Zonemaster project intend to do new relases.
 
@@ -39,7 +39,7 @@ the "I" must be updated in the product version.
 A specific version of the Zonemaster Product will, besides specifications and other documents, include a specific
 version of each of the Zonemaster components. The specifications and other documents are stored in the main
 repository, and the version is defined in Git by a tag on the last commit. The included versions of the components is
-defined by the [Changes](https://github.com/dotse/zonemaster/blob/master/Changes) file.
+defined by the [Changes](https://github.com/zonemaster/zonemaster/blob/master/Changes) file.
 
 ## Version Number Syntax for Zonemaster components
 

--- a/docs/internal-documentation/distrib-testing/Centos-preparation.md
+++ b/docs/internal-documentation/distrib-testing/Centos-preparation.md
@@ -38,6 +38,6 @@
 ## Preparing to install the repositories
 
 1. Follow the steps (1-7) of the [release
-process](https://github.com/dotse/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess.md) to prepare the tarballs in a separate machine 
+process](https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess.md) to prepare the tarballs in a separate machine 
 
 2. Install the modules as per the respective installation instructions

--- a/docs/internal-documentation/distrib-testing/Debian-Preparation.md
+++ b/docs/internal-documentation/distrib-testing/Debian-Preparation.md
@@ -44,7 +44,7 @@
 ## Preparing to install the repositories
 
 1. Follow the steps (1-7) of the [release
-process](https://github.com/dotse/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess.md)
+process](https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess.md)
 to prepare the tarballs in a separate machine
 
 2. Install the modules as per the respective installation instructions

--- a/docs/internal-documentation/functional-tests/Behavior-TP/behavior04.md
+++ b/docs/internal-documentation/functional-tests/Behavior-TP/behavior04.md
@@ -19,7 +19,7 @@ as of not we do not have different profiles to test.
 This issues has been moved to post release 1.0
 
 Further information on the reason to move to post release 1.0 can be found here :
-https://github.com/dotse/zonemaster/issues/167.
+https://github.com/zonemaster/zonemaster/issues/167.
 
 
 

--- a/docs/internal-documentation/functional-tests/Restriction-TP/restriction03.md
+++ b/docs/internal-documentation/functional-tests/Restriction-TP/restriction03.md
@@ -20,5 +20,5 @@ domain names which is not in the LDH format.
 ### Result
 
 The engine does not capture the restriction for LDH and the explanation is
-provided here : https://github.com/dotse/zonemaster/issues/153 
+provided here : https://github.com/zonemaster/zonemaster/issues/153 
 

--- a/docs/internal-documentation/maintenance/ReleasePlan.md
+++ b/docs/internal-documentation/maintenance/ReleasePlan.md
@@ -3,7 +3,7 @@
 ## Scope
 This document outlines the release management process. The 
 [Release Process document](
-https://github.com/dotse/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess.md) outlines the
+https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/ReleaseProcess.md) outlines the
 release process steps.
 
 ## Release features
@@ -27,7 +27,7 @@ released. Such a release of the Zonemaster product, could include a mixture of m
 the components.
 
 ### Version numbering policy
-See [Versions and Releases](https://github.com/dotse/zonemaster/blob/master/docs/design/Versions%20and%20Releases.md) for how to number each release.
+See [Versions and Releases](https://github.com/zonemaster/zonemaster/blob/master/docs/design/Versions%20and%20Releases.md) for how to number each release.
 
 ## Release process
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess.md
@@ -6,21 +6,21 @@ Release process
 Any changes since the last release must be documented in the Changes files.
 Please refer to any Github issues related to the change by the issue number.
 
- * zonemaster-ldns - [Changes](https://github.com/dotse/zonemaster-ldns/blob/master/Changes)
- * zonemaster-engine - [Changes](https://github.com/dotse/zonemaster-engine/blob/master/Changes)
- * zonemaster-cli - [Changes](https://github.com/dotse/zonemaster-cli/blob/master/Changes)
- * zonemaster-backend - [Changes](https://github.com/dotse/zonemaster-backend/blob/master/Changes)
- * zonemaster-gui - [Changes](https://github.com/dotse/zonemaster-gui/blob/master/Changes)
+ * zonemaster-ldns - [Changes](https://github.com/zonemaster/zonemaster-ldns/blob/master/Changes)
+ * zonemaster-engine - [Changes](https://github.com/zonemaster/zonemaster-engine/blob/master/Changes)
+ * zonemaster-cli - [Changes](https://github.com/zonemaster/zonemaster-cli/blob/master/Changes)
+ * zonemaster-backend - [Changes](https://github.com/zonemaster/zonemaster-backend/blob/master/Changes)
+ * zonemaster-gui - [Changes](https://github.com/zonemaster/zonemaster-gui/blob/master/Changes)
 
 ## 2. Set all version numbers
 
 The version numbers can be found in these Perl modules:
 
- * zonemaster-ldns - [LDNS.pm](https://github.com/dotse/zonemaster-ldns/blob/master/lib/Zonemaster/LDNS.pm)
- * zonemaster-engine - [Engine.pm](https://github.com/dotse/zonemaster-engine/blob/master/lib/Zonemaster/Engine.pm)
- * zonemaster-cli - [CLI.pm](https://github.com/dotse/zonemaster-cli/blob/master/lib/Zonemaster/CLI.pm)
- * zonemaster-backend - [Backend.pm](https://github.com/dotse/zonemaster-backend/blob/master/lib/Zonemaster/Backend.pm)
- * zonemaster-gui - [GUI.pm](https://github.com/dotse/zonemaster-gui/blob/master/lib/Zonemaster/GUI.pm)
+ * zonemaster-ldns - [LDNS.pm](https://github.com/zonemaster/zonemaster-ldns/blob/master/lib/Zonemaster/LDNS.pm)
+ * zonemaster-engine - [Engine.pm](https://github.com/zonemaster/zonemaster-engine/blob/master/lib/Zonemaster/Engine.pm)
+ * zonemaster-cli - [CLI.pm](https://github.com/zonemaster/zonemaster-cli/blob/master/lib/Zonemaster/CLI.pm)
+ * zonemaster-backend - [Backend.pm](https://github.com/zonemaster/zonemaster-backend/blob/master/lib/Zonemaster/Backend.pm)
+ * zonemaster-gui - [GUI.pm](https://github.com/zonemaster/zonemaster-gui/blob/master/lib/Zonemaster/GUI.pm)
 
 ## 3. Update prerequisites
 
@@ -31,11 +31,11 @@ Make sure the [declaration of prerequisites] is up to date with regard to
 
 Make sure the Travis configuration for each repo is up to date with the supported Perl versions.
 
- * zonemaster-ldns - [.travis.yml](https://github.com/dotse/zonemaster-ldns/blob/master/.travis.yml)
- * zonemaster-engine - [.travis.yml](https://github.com/dotse/zonemaster-engine/blob/master/.travis.yml)
- * zonemaster-cli - [.travis.yml](https://github.com/dotse/zonemaster-cli/blob/master/.travis.yml)
- * zonemaster-backend - [.travis.yml](https://github.com/dotse/zonemaster-backend/blob/master/.travis.yml)
- * zonemaster-gui - [.travis.yml](https://github.com/dotse/zonemaster-gui/blob/master/.travis.yml)
+ * zonemaster-ldns - [.travis.yml](https://github.com/zonemaster/zonemaster-ldns/blob/master/.travis.yml)
+ * zonemaster-engine - [.travis.yml](https://github.com/zonemaster/zonemaster-engine/blob/master/.travis.yml)
+ * zonemaster-cli - [.travis.yml](https://github.com/zonemaster/zonemaster-cli/blob/master/.travis.yml)
+ * zonemaster-backend - [.travis.yml](https://github.com/zonemaster/zonemaster-backend/blob/master/.travis.yml)
+ * zonemaster-gui - [.travis.yml](https://github.com/zonemaster/zonemaster-gui/blob/master/.travis.yml)
 
 ## 5. Verify that META.yml has all the correct data
 
@@ -180,7 +180,7 @@ Write a description how to set release in Github to get a nice presentation.
 If there are no more components to release, go to the Zonemaster repository an
 make a release.
 
-https://github.com/dotse/zonemaster/wiki/Zonemaster-Distribution-Releases
+https://github.com/zonemaster/zonemaster/wiki/Zonemaster-Distribution-Releases
 
 To see tags for a repository:
 

--- a/docs/internal-documentation/maintenance/SystemTesting.md
+++ b/docs/internal-documentation/maintenance/SystemTesting.md
@@ -53,12 +53,12 @@ The set of configurations must include at least:
       1. Allocate a machine with the architecture specified by the configuration.
       2. Follow the preparation document for the operating system specified by the configuration.
          * CentOS-Preparation.md (unavailable at this time)
-         * [Debian-Preparation.md](https://github.com/dotse/zonemaster/blob/master/docs/internal-documentation/distrib-testing/Debian-Preparation.md)
-         * [FreeBSD-Preparation.md](https://github.com/dotse/zonemaster/blob/master/docs/internal-documentation/distrib-testing/FreeBSD-Preparation.md)
+         * [Debian-Preparation.md](https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/distrib-testing/Debian-Preparation.md)
+         * [FreeBSD-Preparation.md](https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/distrib-testing/FreeBSD-Preparation.md)
          * Ubuntu-Preparation.md (unavailable at this time)
 
    2. Install Zonemaster LDNS
-      1. Make sure the requirements for IDN support in [the IDN section](https://github.com/dotse/zonemaster-ldns/blob/master/README.md#idn) section are satisfied.
+      1. Make sure the requirements for IDN support in [the IDN section](https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md#idn) section are satisfied.
       2. Make sure that OpenSSL is installed.
       3. Install the preliminary distribution tarball for zonemaster-ldns.
 
@@ -75,29 +75,29 @@ The set of configurations must include at least:
          The output from command should be "1".
 
    3. Install Zonemaster Engine
-      1. Install dependencies according to the [installation instruction](https://github.com/dotse/zonemaster-engine/blob/master/docs/Installation.md).
+      1. Install dependencies according to the [installation instruction](https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md).
       2. Install the preliminary distribution tarball for zonemaster-engine.
 
          ```sh
          sudo cpanm Zonemaster-Engine-${ENGINE_VERSION}.tar.gz
          ```
 
-      3. Follow the [post-installation sanity check](https://github.com/dotse/zonemaster-engine/blob/master/docs/Installation.md#post-installation-sanity-check) section of the installation guide to the letter.
+      3. Follow the [post-installation sanity check](https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md#post-installation-sanity-check) section of the installation guide to the letter.
 
    4. Install Zonemaster Backend
-      1. Install dependencies according to the [installation instruction](https://github.com/dotse/zonemaster-backend/blob/master/docs/Installation.md).
+      1. Install dependencies according to the [installation instruction](https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md).
       2. Install the preliminary distribution tarball for zonemaster-backend.
 
          ```sh
          sudo cpanm Zonemaster-Backend-${BACKEND_VERSION}.tar.gz
          ```
 
-      3. Follow the [configuration](https://github.com/dotse/zonemaster-backend/blob/master/docs/Installation.md#configuration) section of the installation guide to the letter.
-      4. Follow the [startup](https://github.com/dotse/zonemaster-backend/blob/master/docs/Installation.md#startup) section of the installation guide to the letter.
-      5. Follow the [post-installation sanity check](https://github.com/dotse/zonemaster-backend/blob/master/docs/Installation.md#post-installation-sanity-check) section of the installation guide to the letter.
+      3. Follow the [configuration](https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md#configuration) section of the installation guide to the letter.
+      4. Follow the [startup](https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md#startup) section of the installation guide to the letter.
+      5. Follow the [post-installation sanity check](https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md#post-installation-sanity-check) section of the installation guide to the letter.
 
    5. Install Zonemaster GUI
-      1. Follow the prerequisites section of [installation.md](https://github.com/dotse/zonemaster-gui/blob/master/docs/Installation.md)
+      1. Follow the prerequisites section of [installation.md](https://github.com/zonemaster/zonemaster-gui/blob/master/docs/Installation.md)
          to the letter.
       2. Install the preliminary distribution tarball for zonemaster-backend.
 
@@ -105,10 +105,10 @@ The set of configurations must include at least:
          sudo cpanm Zonemaster-GUI-${GUI_VERSION}.tar.gz
          ```
 
-      3. Follow the configuration, startup and sanity check sections of [installation.md](https://github.com/dotse/zonemaster-gui/blob/master/docs/Installation.md)
+      3. Follow the configuration, startup and sanity check sections of [installation.md](https://github.com/zonemaster/zonemaster-gui/blob/master/docs/Installation.md)
          to the letter.
 
-         *The following should be put into a sanity check section of [installation.md](https://github.com/dotse/zonemaster-gui/blob/master/docs/Installation.md).*
+         *The following should be put into a sanity check section of [installation.md](https://github.com/zonemaster/zonemaster-gui/blob/master/docs/Installation.md).*
 
          > ```
          > http://localhost/
@@ -118,7 +118,7 @@ The set of configurations must include at least:
          > Zonemaster logotype.
 
    6. Install Zonemaster CLI
-      1. Follow the prerequisites section of [installation.md](https://github.com/dotse/zonemaster-cli/blob/master/docs/Installation.md)
+      1. Follow the prerequisites section of [installation.md](https://github.com/zonemaster/zonemaster-cli/blob/master/docs/Installation.md)
          to the letter.
       2. Install the preliminary distribution tarball for zonemaster-backend.
 
@@ -126,10 +126,10 @@ The set of configurations must include at least:
          sudo cpanm Zonemaster-CLI-${CLI_VERSION}.tar.gz
          ```
 
-      3. Follow the configuration and sanity check sections of [installation.md](https://github.com/dotse/zonemaster-cli/blob/master/docs/Installation.md)
+      3. Follow the configuration and sanity check sections of [installation.md](https://github.com/zonemaster/zonemaster-cli/blob/master/docs/Installation.md)
          to the letter.
 
-         *The following should be put into a sanity check section of [installation.md](https://github.com/dotse/zonemaster-cli/blob/master/docs/Installation.md).*
+         *The following should be put into a sanity check section of [installation.md](https://github.com/zonemaster/zonemaster-cli/blob/master/docs/Installation.md).*
 
          > ```
          > zonemaster-cli --version

--- a/docs/internal-documentation/maintenance/TechnicalMaintenancePlan.md
+++ b/docs/internal-documentation/maintenance/TechnicalMaintenancePlan.md
@@ -157,7 +157,9 @@ The software that runs the ASN Lookup service is rbldnsd, and the software itsel
 
 ### Github
 
-The Github repository is a service run by the GitHub company. However, our repository for the Zonemaster software is belongning to the "dotse"-organization within GitHub, and the "dotse" organization is being managed by people from IIS. The Zonemaster repository is a separate source code versioning repository under "dotse", and is being separately managed by its own repository managers.
+The Github repository is a service run by the GitHub company. However, our repositories for the 
+Zonemaster software belong to the Zonemaster organization within GitHub, and the Zonemaster 
+organization is being managed by people from Afnic and IIS. 
 
 The role of the repository manager is to add and remove members who have (write-)access the repository, the issues and the wiki.
 

--- a/docs/internal-documentation/requirements/GUI-Functional-Test-Requirements.md
+++ b/docs/internal-documentation/requirements/GUI-Functional-Test-Requirements.md
@@ -17,14 +17,14 @@ Security and Performance testing are not included.
 
 |Req| Test requirement                           |How Verified|Status|
 |:--|:-------------------------------------------|------------|------|
-|GR01|Supports Swedish language|[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR01-test-swedish-language.js)| KO - noJS |
-|GR02|Supports French language|[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR02-test-french-language.js)| KO - noJS|
-|GR03|Supports English language |[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR03-english-language-support.js)| Ok |
-|GR04|On launching the URL opens with a default simple view | [Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR04-main-page.js)| OK |
+|GR01|Supports Swedish language|[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR01-test-swedish-language.js)| KO - noJS |
+|GR02|Supports French language|[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR02-test-french-language.js)| KO - noJS|
+|GR03|Supports English language |[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR03-english-language-support.js)| Ok |
+|GR04|On launching the URL opens with a default simple view | [Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR04-main-page.js)| OK |
 |GR05|The simple view should look the same in latest version of different browsers such as Firefox, Internet Explorer, Chrome, Safari etc.   | ToDo |
-|GR06|The simple view should support an advanced view expanding when the checkbox is enabled|[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR06-basic-view-advanced-options.js)|K0 - No advance option in the "nojs" |
-|GR07|The advanced view should support the possibility of enabling or disabling IPv4 or IPv6 |[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR07-advanced-checkbox-verification.js)|OK|
-|GR08|The advanced view should support the possibility of choosing a profile from multiple profiles|[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR08-advanced-profile-verification.js)|OK|            
+|GR06|The simple view should support an advanced view expanding when the checkbox is enabled|[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR06-basic-view-advanced-options.js)|K0 - No advance option in the "nojs" |
+|GR07|The advanced view should support the possibility of enabling or disabling IPv4 or IPv6 |[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR07-advanced-checkbox-verification.js)|OK|
+|GR08|The advanced view should support the possibility of choosing a profile from multiple profiles|[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR08-advanced-profile-verification.js)|OK|            
 |GR09|The advanced view should look the same in latest version of different browsers such as Firefox, Internet Explorer, Chrome, Safari etc.   |   ToDo         |
 |GR11|The undelegated view must inherit all of the advanced view options |Manually|OK|
 |GR12|The undelegated view should look the same in latest version of different browsers such as Firefox, Internet Explorer, Chrome, Safari etc.   | ToDo    |
@@ -34,16 +34,16 @@ Security and Performance testing are not included.
 |GR16|All menus should be clickable in latest version of different browsers such as Firefox, IE, Chrome, Safari etc. |  ToDo  |
 |GR17|All buttons should be clickable in latest version of different browsers such as Firefox, IE, Chrome, Safari etc. |  ToDo      |
 |GR18|All appropriate fields (both simple and undelegated) should be writable |Manually|OK|
-|GR19|Capable to enable and disable checkboxes in advanced option|[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR19-advanced-checkbox-verification.js)|OK|
-|GR20|Capable to select one of the drop down menu in the advanced option|[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR19-advanced-checkbox-verification.js)|OK|
-|GR21|Check the existence of broken links|[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR21-check-broken-links.js)|OK|
-|GR22|Check the display of appropriate content on clicking each link |[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR22-link-content.js)|OK|
+|GR19|Capable to enable and disable checkboxes in advanced option|[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR19-advanced-checkbox-verification.js)|OK|
+|GR20|Capable to select one of the drop down menu in the advanced option|[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR19-advanced-checkbox-verification.js)|OK|
+|GR21|Check the existence of broken links|[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR21-check-broken-links.js)|OK|
+|GR22|Check the display of appropriate content on clicking each link |[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR22-link-content.js)|OK|
 |GR23|Check the tool displays the client IP address  |Manually|OK|
 |GR24|Able to specify delegation parameters  |Manually|OK|
 |GR25|Able to specify to stop the test on a fatal error | For release 1.1 |Wishlist|
 |GR26|Check all the terms (such as menus, input fields) are appropriate   | Manually |OK|
-|GR27|Afnic and IIS logo in the main page|[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR27-logo-verification.js)|KO|   
-|GR28|Check the existence of correct title for the web site|[Script](https://github.com/dotse/zonemaster-gui/blob/master/FunctionalTests/GR27-logo-verification.js)|OK|
+|GR27|Afnic and IIS logo in the main page|[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR27-logo-verification.js)|KO|   
+|GR28|Check the existence of correct title for the web site|[Script](https://github.com/zonemaster/zonemaster-gui/blob/master/FunctionalTests/GR27-logo-verification.js)|OK|
 |FR01|Identifies the preference of connected user's language |Manually|OK|
 |FR02|Presence of a default fallback language |Manually|OK|
 |FR03|Support IDN2.0 domains as input |Manually|OK|
@@ -57,7 +57,7 @@ Security and Performance testing are not included.
 |FR11|For delegated zones, the GUI should be able to run tests by just providing the domain name |Manually|OK|
 |FR12|For undelegated zones, the GUI should be able to run the test with atleast one name server as input |Manually|OK|
 |FR13|For undelegated zones, the user must be able to submit one or more DS record(s) for use with DNSSEC | Manually |OK |
-|FR14|Verify the GUI runs with different test profiles|Manually| KO - No test profiles created (Issue <https://github.com/dotse/zonemaster/issues/167>)|
+|FR14|Verify the GUI runs with different test profiles|Manually| KO - No test profiles created (Issue <https://github.com/zonemaster/zonemaster/issues/167>)|
 |FR15|Should be able to export the result in HTML format|Manually|KO|
 |FR16|Should be able to export the result in TEXT format|Manually|OK|
 |FR17|Should be able to show a progress bar with a rough estimate of the total test progress|Manually|OK|

--- a/docs/specifications/test-types/README.md
+++ b/docs/specifications/test-types/README.md
@@ -1,4 +1,4 @@
-![Zonemaster](https://github.com/dotse/zonemaster/blob/master/docs/images/zonemaster_logo_black.png)
+![Zonemaster](https://github.com/zonemaster/zonemaster/blob/master/docs/images/zonemaster_logo_black.png)
 ==========
 
 ### Purpose of this directory

--- a/docs/specifications/tests/DNSSEC-TP/dnssec12.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec12.md
@@ -13,10 +13,10 @@ Test for DNSSEC Algorithm Completeness (DS->DNSKEY->RRSIG)
 
 See issues [#588], [#528], [#529] and [#231].
 
-[#588]: https://github.com/dotse/zonemaster/issues/588
-[#528]: https://github.com/dotse/zonemaster/issues/528
-[#529]: https://github.com/dotse/zonemaster/issues/529
-[#231]: https://github.com/dotse/zonemaster/issues/231
+[#588]: https://github.com/zonemaster/zonemaster/issues/588
+[#528]: https://github.com/zonemaster/zonemaster/issues/528
+[#529]: https://github.com/zonemaster/zonemaster/issues/529
+[#231]: https://github.com/zonemaster/zonemaster/issues/231
 
 
 ### Inputs

--- a/utils/README.md
+++ b/utils/README.md
@@ -22,7 +22,7 @@ Level Zone-TP
 
 This tools creates a map between the Zonemaster requirements and
 implemented test case. It is used in the Makefile in
-docs/specifications/tests to create the [Report](https://github.com/dotse/zonemaster/blob/master/docs/specifications/tests/Report.md)
+docs/specifications/tests to create the [Report](https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/Report.md)
 on implemented test requirements.
 
 
@@ -31,7 +31,7 @@ on implemented test requirements.
 This tools creates a map between the Zonemaster log message
 identifiers and the test specification that implements the test code
 for that message. Also used in the Makefile in
-docs/specifications/tests to create the [TestMessages.md](https://github.com/dotse/zonemaster/blob/master/docs/specifications/tests/TestMessages.md)
+docs/specifications/tests to create the [TestMessages.md](https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/TestMessages.md)
 file.
 
 


### PR DESCRIPTION
In all Github links "dotse/zonemaster" has been replaced by "zonemaster/zonemaster" as a consequence of transfer of the repos from dotse to Zonemaster.