### PR TITLE
Update Nameserver02:

### DIFF
--- a/docs/specifications/tests/Nameserver-TP/nameserver02.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver02.md
@@ -1,61 +1,108 @@
-## NAMESERVER02: Test of EDNS0 support
+# NAMESERVER02: Test of EDNS0 support
 
-### Test case identifier
-**NAMESERVER02** Test of EDNS0 support
+## Test case identifier
+*NAMESERVER02**
 
-### Objective
+## Objective
 
 EDNS(0) is a mechanism to announce capabilities of a DNS implementation,
 and is now basically required by any new functionality in DNS such as
-DNSSEC.
-Initially standardized in [RFC 2671](https://tools.ietf.org/search/rfc2671)
-and later updated by [RFC 6891](https://tools.ietf.org/search/rfc6891),
-EDNS(0) is a mechanism to announce capabilities of a DNS implementation.
-This test case checks that all name servers has the capability to do
-EDNS(0).
+DNSSEC. EDNS(0) is standardized in [RFC 6891].
 
-Servers not implementing EDNS(0) returns FORMERR:
+This test case checks that all name servers has the capability to do
+EDNS(0) or if not, correctly replies to queries containing ENDS
+(OPT record).
+
+Servers not supporting EDNS(0) must return FORMERR 
+([RFC 6891, section 7]):
 
 > Responders that choose not to implement the protocol extensions
 > defined in this document MUST respond with a return code (RCODE) of
 > FORMERR to messages containing an OPT record in the additional
 > section and MUST NOT include an OPT record in the response.
 
-### Inputs
+## Inputs
 
-The domain name to be tested.
+* "Child Zone" - The domain name to be tested.
 
-### Ordered description of steps to be taken to execute the test case
+## Ordered description of steps to be taken to execute the test case
 
-1. Retrieve all address records for all the name servers using
-   [Method 4](../Methods.md#method-4-obtain-glue-address-records-from-parent) and
-   [Method 5](../Methods.md#method-5-obtain-the-name-server-address-records-from-child),
-   and do recursive lookups for the name servers that are out of bailiwick.
-2. Send a DNS query to each name server IP address querying the SOA record
-   of the domain name with EDNS0 option of payload size ("bufsize")
+1. Created an SOA query for the *Child Zone* with an OPT record with 
+   ENDS version set to "0" and with EDNS0 option of payload size ("bufsize")
    set to 512.
-3. If any answer from step 2 contains a FORMERR RCODE this test case fails.
-4. If the answer does not contain an OPT RR with EDNS version 0, this test
-   case fails.
 
-### Outcome(s)
+2. Create a second SOA query for the *Child Zone* without any OPT record.
 
-If any name server returns FORMERR for a query using EDNS(0), or if there is
-no OPT RR with EDNS version 0 in it, this test case fails.
+3. Obtain the set of name server IP addresses using [Method4] and [Method5]
+   ("Name Server IP").
 
-### Special procedural requirements
+4. For each name server in *Name Server IP* do:
 
-None.
+   1. Send the SOA query **with** OPT record to the name server and collect 
+      the response.
+   2. If there is no DNS response, then:
+      1. Send the SOA query **without** OPT record to the name server and 
+         collect the response.
+      2. If there is no DNS response, then output *[NO_RESPONSE]* and 
+         go to next server.
+      3. Else (there is a DNS response), then output 
+         *[BROKEN_EDNS_SUPPORT]* and go to next server.
+   3. Else, if the DNS response meet the following two criteria,
+      then output *[NO_EDNS_SUPPORT]*:
+      1. It has the RCODE "FORMERR" 
+      2. It has no OPT record.
+   4. Else, if the DNS response meet the following two criteria,
+      then just go to the next name server (no error):
+      1. It has the RCODE "NOERROR".
+      2. It has OPT record with EDNS version 0.
+   5. Else, if the DNS response meet the following two criteria,
+      then output *[BROKEN_EDNS_SUPPORT]* and go to next server.
+      1. It has the RCODE "NOERROR".
+      2. It has no OPT record.
+   6. Else, if the DNS response meet the following two criteria,
+      then output *[BROKEN_EDNS_SUPPORT]* and go to next server.
+      1. It has the RCODE "NOERROR".
+      2. It has OPT record with EDNS version other than 0.
+   7. Else output *[NS_ERROR]*.
 
-### Intercase dependencies
+## Outcome(s)
 
-None.
+The outcome of this Test Case is "fail" if there is at least one message
+with the severity level *ERROR* or *CRITICAL*.
 
--------
+The outcome of this Test Case is "warning" if there is at least one message
+with the severity level *WARNING*, but no message with severity level
+*ERROR* or *CRITICAL*.
 
-Copyright (c) 2013, 2014, 2015, IIS (The Internet Infrastructure Foundation)  
-Copyright (c) 2013, 2014, 2015, AFNIC  
-Creative Commons Attribution 4.0 International License
+The outcome of this Test case is "pass" in all other cases.
 
-You should have received a copy of the license along with this
-work.  If not, see <https://creativecommons.org/licenses/by/4.0/>.
+Message                           | Default severity level (when message is outputted)
+:---------------------------------|:-----------------------------------
+NO_RESPONSE                       | WARNING
+NO_EDNS_SUPPORT                   | WARNING
+BROKEN_EDNS_SUPPORT               | ERROR
+NS_ERROR                          | WARNING
+
+## Special procedural requirements	
+
+If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
+result of any test using this transport protocol and log a message reporting
+the ignored result.
+
+## Intercase dependencies
+
+None
+
+
+[RFC 6891]: https://tools.ietf.org/html/rfc6891
+[RFC 6891, section 6.1.3]: https://tools.ietf.org/html/rfc6891#section-6.1.3
+[Method4]: ../Methods.md#method-4-delegation-name-server-addresses
+[Method5]: ../Methods.md#method-5-in-zone-addresses-records-of-name-servers
+[NO_RESPONSE]: #outcomes
+[NO_EDNS_SUPPORT]: #outcomes
+[BROKEN_EDNS_SUPPORT]: #outcomes
+[NS_ERROR]: #outcomes
+
+
+[RFC 6891]: https://tools.ietf.org/html/rfc6891
+[RFC 6891, section 7]: https://tools.ietf.org/html/rfc6891#section-7

--- a/docs/specifications/tests/Nameserver-TP/nameserver02.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver02.md
@@ -27,6 +27,9 @@ Servers supporting EDNS(0) must reply with EDNS(0)
 > If an OPT record is present in a received request, compliant
 > responders MUST include an OPT record in their respective responses.
 
+To eliminating the risk of falsely classifying the server as not supporting
+ENDS due e.g. firewall issues, the UDP buffer size is set to 512 bytes 
+(octets).
 
 ## Inputs
 
@@ -36,7 +39,7 @@ Servers supporting EDNS(0) must reply with EDNS(0)
 
 1. Created an SOA query for the *Child Zone* with an OPT record with 
    EDNS version set to "0" and with EDNS(0) option of payload size ("bufsize")
-   set to 512.
+   set to 512 and "DO" bit unset.
 
 2. Create a second SOA query for the *Child Zone* without any OPT record.
 
@@ -58,15 +61,16 @@ Servers supporting EDNS(0) must reply with EDNS(0)
       then output *[NO_EDNS_SUPPORT]*:
       1. It has the RCODE "FORMERR" 
       2. It has no OPT record.
-   4. Else, if the DNS response meet the following two criteria,
+   4. Else, if the DNS response meet the following criteria,
       then just go to the next name server (compliant server):
       1. It has the RCODE "NOERROR".
-      2. It has OPT record with EDNS version 0.
-   5. Else, if the DNS response meet the following two criteria,
+      2. The answer section contains the SOA record for *Child Zone*.
+      3. It has OPT record with EDNS version 0.
+   5. Else, if the DNS response meet the following criteria,
       then output *[BROKEN_EDNS_SUPPORT]* and go to next server.
       1. It has the RCODE "NOERROR".
       2. It has no OPT record.
-   6. Else, if the DNS response meet the following two criteria,
+   6. Else, if the DNS response meet the following criteria,
       then output *[BROKEN_EDNS_SUPPORT]* and go to next server.
       1. It has the RCODE "NOERROR".
       2. It has OPT record with EDNS version other than 0.

--- a/docs/specifications/tests/Nameserver-TP/nameserver02.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver02.md
@@ -1,7 +1,7 @@
 # NAMESERVER02: Test of EDNS0 support
 
 ## Test case identifier
-*NAMESERVER02**
+**NAMESERVER02**
 
 ## Objective
 
@@ -10,7 +10,7 @@ and is now basically required by any new functionality in DNS such as
 DNSSEC. EDNS(0) is standardized in [RFC 6891].
 
 This test case checks that all name servers has the capability to do
-EDNS(0) or if not, correctly replies to queries containing ENDS
+EDNS(0) or if not, correctly replies to queries containing EDNS
 (OPT record).
 
 Servers not supporting EDNS(0) must return FORMERR 
@@ -21,6 +21,13 @@ Servers not supporting EDNS(0) must return FORMERR
 > FORMERR to messages containing an OPT record in the additional
 > section and MUST NOT include an OPT record in the response.
 
+Servers supporting EDNS(0) must reply with EDNS(0)
+([RFC 6891, section 6.1.1]):
+
+> If an OPT record is present in a received request, compliant
+> responders MUST include an OPT record in their respective responses.
+
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -28,7 +35,7 @@ Servers not supporting EDNS(0) must return FORMERR
 ## Ordered description of steps to be taken to execute the test case
 
 1. Created an SOA query for the *Child Zone* with an OPT record with 
-   ENDS version set to "0" and with EDNS0 option of payload size ("bufsize")
+   EDNS version set to "0" and with EDNS(0) option of payload size ("bufsize")
    set to 512.
 
 2. Create a second SOA query for the *Child Zone* without any OPT record.
@@ -52,7 +59,7 @@ Servers not supporting EDNS(0) must return FORMERR
       1. It has the RCODE "FORMERR" 
       2. It has no OPT record.
    4. Else, if the DNS response meet the following two criteria,
-      then just go to the next name server (no error):
+      then just go to the next name server (compliant server):
       1. It has the RCODE "NOERROR".
       2. It has OPT record with EDNS version 0.
    5. Else, if the DNS response meet the following two criteria,
@@ -63,7 +70,8 @@ Servers not supporting EDNS(0) must return FORMERR
       then output *[BROKEN_EDNS_SUPPORT]* and go to next server.
       1. It has the RCODE "NOERROR".
       2. It has OPT record with EDNS version other than 0.
-   7. Else output *[NS_ERROR]*.
+   7. Else output *[NS_ERROR]* (i.e. other erroneous or unexpected 
+      response).
 
 ## Outcome(s)
 
@@ -93,9 +101,9 @@ the ignored result.
 
 None
 
-
 [RFC 6891]: https://tools.ietf.org/html/rfc6891
-[RFC 6891, section 6.1.3]: https://tools.ietf.org/html/rfc6891#section-6.1.3
+[RFC 6891, section 7]: https://tools.ietf.org/html/rfc6891#section-7
+[RFC 6891, section 6.1.1]: https://tools.ietf.org/html/rfc6891#section-6.1.1
 [Method4]: ../Methods.md#method-4-delegation-name-server-addresses
 [Method5]: ../Methods.md#method-5-in-zone-addresses-records-of-name-servers
 [NO_RESPONSE]: #outcomes
@@ -103,6 +111,3 @@ None
 [BROKEN_EDNS_SUPPORT]: #outcomes
 [NS_ERROR]: #outcomes
 
-
-[RFC 6891]: https://tools.ietf.org/html/rfc6891
-[RFC 6891, section 7]: https://tools.ietf.org/html/rfc6891#section-7


### PR DESCRIPTION
* Converted to new format of test case specification.
* Removed license and copyright statement.
* Removed reference to old RFC.
* Included the messages in the specification.
* Included check for name servers that ignore queries with OPT record.
* More explicit checks of name servers without EDNS support.