### PR TITLE
Drop support for Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ Operating System | MySQL    | PostgreSQL
 CentOS 7         | 5.6      |   9.3
 Debian 8         | 5.5      |   9.4
 Debian 9         | 10.1 (*) |   9.6
-FreeBSD 11.2     | 5.6      |   9.5      
-FreeBSD 12.0     | 5.6      |   9.5      
-Ubuntu 14.04     | 5.5      |   9.3
+FreeBSD 11.2     | 5.6      |   9.5
+FreeBSD 12.0     | 5.6      |   9.5
 Ubuntu 16.04     | 5.7      |   9.5
 Ubuntu 18.04     | 5.7      |  10.3
 
@@ -73,12 +72,11 @@ introduced in PostgreSQL version 9.3, and earlier versions are as such not suppo
 
 Operating System | Perl
 ---------------- | ----
-CentOS 7         | 5.16                        
+CentOS 7         | 5.16
 Debian 8         | 5.20
 Debian 9         | 5.24
 FreeBSD 11.2     | 5.28
 FreeBSD 12.0     | 5.28
-Ubuntu 14.04     | 5.18
 Ubuntu 16.04     | 5.22
 Ubuntu 18.04     | 5.26
 

--- a/docs/internal-documentation/maintenance/SupportCriteria.md
+++ b/docs/internal-documentation/maintenance/SupportCriteria.md
@@ -36,7 +36,7 @@ fixed for the lifetime of the Zonemaster version.
 
 ### Criteria
 
-Minor version/point releases should be specified. Patch levels should not be specified.
+Minor version/point release/patch level should not be specified.
 
 Operating system versions without long term support form their vendor should not be supported.
 
@@ -49,26 +49,19 @@ Operating system specific guidelines:
 * CentOS:
   * Base Distributions are listed here:
     <https://en.wikipedia.org/wiki/CentOS#End-of-support_schedule>
-  * The current minor releases are listed at:
-    <https://wiki.centos.org/Download>
 
 * Debian:
   * Current versions of "stable" and "oldstable" are listed here:
     <https://wiki.debian.org/DebianReleases#Current_Releases.2FRepositories>
-  * The current point releases are listed here:
-    <https://wiki.debian.org/DebianReleases/PointReleases>
 
 * FreeBSD:
   * Supported releases are listed here:
     <https://www.freebsd.org/security/>
   * FreeBSD 10: Releases that are supported by FreeBSD and being "extended" are supported by Zonemaster.
   * FreeBSD 11: Latest release version is supported.
-  * Patch level should not be specified.
 
 * Ubuntu:
   * LTS releases are listed here:
-    <https://wiki.ubuntu.com/Releases>
-  * The supported patch level is the one specified at:
     <https://wiki.ubuntu.com/Releases>
 
 
@@ -138,3 +131,10 @@ The point release should not be specified.
 
 * Perl versions provided by each version of Ubuntu are listed here:
   * <http://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=perl>
+
+
+## Nice-to-have resources
+
+* [CentOS minor releases](https://wiki.centos.org/Download)
+* [Debian point releases](https://wiki.debian.org/DebianReleases/PointReleases)
+* [Ubuntu patch levels](https://wiki.ubuntu.com/Releases)


### PR DESCRIPTION
~At the moment we're supporting three versions of Ubuntu. If we drop support for Ubuntu HWE we can drop support for old Ubuntu versions slightly earlier. I feel that supporting regular LTS versions is enough. Do you guys agree?~

It seems I misread the Ubuntu releases documentation. 14.04 HWE is already in EoL. So I removed the reference to HWE from the support criteria documentation, and after discussions with @matsduf I also updated the instructions to align them with how we've been working lately.