### PR TITLE
Update prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ architecture listed below.
 * Debian 9
 * FreeBSD 11.2
 * FreeBSD 12.0
-* Ubuntu 14.04
 * Ubuntu 16.04
 * Ubuntu 18.04
 
@@ -54,13 +53,13 @@ architecture listed below.
 
 Operating System | MySQL    | PostgreSQL
 ---------------- | ---------| -----------
-CentOS 7         | 5.6      |   9.3
-Debian 8         | 5.5      |   9.4
-Debian 9         | 10.1 (*) |   9.6
-FreeBSD 11.2     | 5.6      |   9.5
-FreeBSD 12.0     | 5.6      |   9.5
-Ubuntu 16.04     | 5.7      |   9.5
-Ubuntu 18.04     | 5.7      |  10.3
+CentOS 7         | 5.6      | 9.3
+Debian 8         | 5.5      | 9.4
+Debian 9         | 10.1 (*) | 9.6
+FreeBSD 11.2     | 5.6      | 9.5
+FreeBSD 12.0     | 5.6      | 9.5
+Ubuntu 16.04     | 5.7      | 9.5
+Ubuntu 18.04     | 5.7      | 10
 
 *) MariaDB, not MySQL
 

--- a/docs/internal-documentation/maintenance/SupportCriteria.md
+++ b/docs/internal-documentation/maintenance/SupportCriteria.md
@@ -85,6 +85,7 @@ Database engine versions that lack required features cannot be supported.
   * http://mirror.centos.org/centos/7/os/x86_64/Packages/
 
 * Database engine versions provided by each version of Debian are listed here:
+  * <https://packages.debian.org/search?searchon=names&keywords=mariadb-server>
   * <https://packages.debian.org/search?searchon=names&keywords=mysql-server>
   * <https://packages.debian.org/search?searchon=names&keywords=postgresql>
   * <https://packages.debian.org/search?searchon=names&keywords=sqlite3>


### PR DESCRIPTION
Our installation instruction for Ubuntu is agnostic about the (minor) version of Postgresql to install and what version actually get depends on the configuration of APT. For the sake of simplicity this PR updates to the specify the major version (like the package we prescribe https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=postgresql&searchon=names).

I'm also adding a link to conveniently look up the supported version of MariaDB for Debian.

I missed one mention of Ubuntu 14.04 in #751.