### PR TITLE
Fix some links

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ Zonemaster repository.
 
 You can follow the project in these two mailing lists:
 
- * [zonemaster-users](http://lists.iis.se/cgi-bin/mailman/listinfo/zonemaster-users)
- * [zonemaster-devel](http://lists.iis.se/cgi-bin/mailman/listinfo/zonemaster-devel)
+ * [zonemaster-users](https://lists.iis.se/cgi-bin/mailman/listinfo/zonemaster-users)
+ * [zonemaster-devel](https://lists.iis.se/cgi-bin/mailman/listinfo/zonemaster-devel)
 
 ## Bug reporting 
 
@@ -192,5 +192,5 @@ contact@zonemaster.net.
 [Zonemaster-CLI]: https://github.com/zonemaster/zonemaster-cli
 [Zonemaster-Backend]: https://github.com/zonemaster/zonemaster-backend
 [Zonemaster-GUI]: https://github.com/zonemaster/zonemaster-gui
-[LDNS]: https://www.nlnetlabs.nl/projects/ldns/
-[CPAN]: http://search.cpan.org/search?query=Zonemaster&mode=dist
+[LDNS]: https://www.nlnetlabs.nl/projects/ldns/about/
+[CPAN]: https://www.cpan.org/

--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -11,7 +11,7 @@ WishList for Version 2.0
 from another program (the library may be useful even if the tool has a
 structured output).
 8. Test suite, as a deliberately broken set of DNS zones, like DNSSEC
-people did <http://www.dnssec-tools.org/testzone/>.
+people did <https://dnssec-tools.org/testzone/>.
 9. Developing a Mobile app
 10. Parallel tests
 11. It would be nice to test if unknown RR types can be queried (Ref :

--- a/docs/design/Implementation Guidelines.md
+++ b/docs/design/Implementation Guidelines.md
@@ -48,14 +48,19 @@ It is recommended, although not required, that each test case be implemented as 
 
 ### Code formatting
 
-The top level of the Zonemaster git repository contains `.perltidyrc`, a config file for [Perl::Tidy](http://search.cpan.org/~shancock/Perl-Tidy-20130922/lib/Perl/Tidy.pod). Please use it before you push, make a pull request or otherwise send code outside of your own repository.
+The top level of the Zonemaster git repository contains `.perltidyrc`, a config file for [Perl::Tidy]. Please use it before you push, make a pull request or otherwise send code outside of your own repository.
 
 ### Code style
 
-The top level of the Zonemaster git repository also contains `.perlcriticrc`, a config file for [Perl::Critic](http://search.cpan.org/~thaljef/Perl-Critic-1.121/lib/Perl/Critic.pm). Strive to make your code free from warnings on at least levels 4 and 5 before you send it out into the world.
+The top level of the Zonemaster git repository also contains `.perlcriticrc`, a config file for [Perl::Critic]. Strive to make your code free from warnings on at least levels 4 and 5 before you send it out into the world.
 
 ### Exposing test metadata
 
 ### Returning information from tests, the practice
 
 (to be continued)
+
+
+
+[Perl::Critic]: https://metacpan.org/pod/Perl::Critic
+[Perl::Tidy]: https://metacpan.org/pod/Perl::Tidy

--- a/docs/design/Profiles.md
+++ b/docs/design/Profiles.md
@@ -23,7 +23,7 @@ requirements and specifications were integrated into a single data structure, al
 
 Zonemaster Engine has an effective profile that guides how it performs its tests and analyzes their results.
 It comes with a sensible default profile while allowing applications to override the default behavior.
-This is described in greater detail in the [Zonemaster::Engine::Config] documentation.
+This is described in greater detail in the [Zonemaster::Engine::Profile] documentation.
 
 
 ## Profiles in Zonemaster Backend
@@ -46,7 +46,7 @@ The available profile choices are configured in a JSON file that maps profile na
 
 
 -------
-[Zonemaster Backend RPC-API]: https://github.com/dotse/zonemaster-backend/blob/master/docs/API.md
-[Zonemaster Backend configuration]: https://github.com/dotse/zonemaster-backend/blob/master/docs/Configuration.md#profiles-section
-[Zonemaster::Engine::Config]: https://metacpan.org/pod/Zonemaster::Engine::Config
+[Zonemaster Backend RPC-API]: https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md
+[Zonemaster Backend configuration]: https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#public-profiles-and-private-profiles-sections
+[Zonemaster::Engine::Profile]: https://metacpan.org/pod/Zonemaster::Engine::Profile
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess.md
@@ -46,8 +46,7 @@ Make sure the Travis configuration for each repo is up to date with the supporte
  * zonemaster-engine - [.travis.yml](https://github.com/zonemaster/zonemaster-engine/blob/master/.travis.yml)
  * zonemaster-cli - [.travis.yml](https://github.com/zonemaster/zonemaster-cli/blob/master/.travis.yml)
  * zonemaster-backend - [.travis.yml](https://github.com/zonemaster/zonemaster-backend/blob/master/.travis.yml)
- * zonemaster-gui - [.travis.yml](https://github.com/zonemaster/zonemaster-gui/blob/master/.travis.yml) --
-   Currently there is no Travis configured for GUI.
+ * zonemaster-gui - Currently there is no Travis configured for GUI.
 
 ## 5. Verify that META.yml has all the correct data
 
@@ -111,8 +110,6 @@ distribution tarball:
 For each component that **is not** to be updated in this release, retreive their
 respective latest released distribution tarballs from the [ZNMSTR account at
 CPAN].
-
-[ZNMSTR account at CPAN]: http://search.cpan.org/~znmstr/
 
 ## 8. Produce distribution zip file (Zonemaster-GUI only)
 
@@ -194,4 +191,4 @@ format as previous releases.
 [latest releases in each branch of Perl]: http://www.cpan.org/src/README.html
 [license string]: https://metacpan.org/pod/CPAN::Meta::Spec#license
 [Versions and releases]: ../../design/Versions%20and%20Releases.md
-
+[ZNMSTR account at CPAN]: https://metacpan.org/author/ZNMSTR

--- a/docs/internal-documentation/maintenance/SupportCriteria.md
+++ b/docs/internal-documentation/maintenance/SupportCriteria.md
@@ -96,9 +96,9 @@ Database engine versions that lack required features cannot be supported.
   * <https://www.freebsd.org/cgi/ports.cgi?stype=name&sektion=databases&query=sqlite3>
 
 * Database engine versions provided by each version of Ubuntu are listed here:
-  * <http://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=mysql-server>
-  * <http://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=postgresql>
-  * <http://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=sqlite3>
+  * <https://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=mysql-server>
+  * <https://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=postgresql>
+  * <https://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=sqlite3>
 
 
 ## Translation locales
@@ -131,7 +131,7 @@ The point release should not be specified.
   * <https://www.freebsd.org/cgi/ports.cgi?stype=name&sektion=lang&query=perl>
 
 * Perl versions provided by each version of Ubuntu are listed here:
-  * <http://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=perl>
+  * <https://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=perl>
 
 
 ## Nice-to-have resources

--- a/docs/internal-documentation/maintenance/SystemTesting.md
+++ b/docs/internal-documentation/maintenance/SystemTesting.md
@@ -94,7 +94,7 @@ The set of configurations must include at least:
 
       3. Follow the [configuration](https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md#configuration) section of the installation guide to the letter.
       4. Follow the [startup](https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md#startup) section of the installation guide to the letter.
-      5. Follow the [post-installation sanity check](https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md#post-installation-sanity-check) section of the installation guide to the letter.
+      5. Follow the [smoke test] section of the installation guide to the letter.
 
    5. Install Zonemaster GUI
       1. Follow the prerequisites section of [installation.md](https://github.com/zonemaster/zonemaster-gui/blob/master/docs/Installation.md)
@@ -202,3 +202,7 @@ This test level validates that each change since last release:
 4. Acceptance testing through Zonemaster GUI
 
    Test each new entry in the Changes file of *Zonemaster GUI*.
+
+
+
+[smoke test]: https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Installation.md#71-smoke-test

--- a/docs/requirements/TestRequirements.md
+++ b/docs/requirements/TestRequirements.md
@@ -139,13 +139,11 @@ Requirements on writing test specifications
 These are some requirements for writing specifications for "Zonemaster":
 
  1. Follow the framework of the IEEE 829-2008.
- 2. The documents must be in 
-    [Markdown Syntax](http://daringfireball.net/projects/markdown/syntax).
+ 2. The documents must be in [GitHub Flavored Markdown].
  3. Keep the columns in the document below 80, preferrably shorter than 74
     columns. (Much easier to see changes in documents using the tools
 	available for diffing).
- 4. Use 
-    [normative language](http://en.wikipedia.org/wiki/Normative#Standards_documents).
+ 4. Use [normative language].
  5. Refer to any reference that is the rationale for implementing the test
     case. If there are no reference to any standards, describe the reason
     for implementing the test. For most references, we use RFCs from IETF.
@@ -164,3 +162,8 @@ These are some requirements for writing specifications for "Zonemaster":
 	to use the same style as used in the other tests.
  10. Make sure to write the tests so that any implementer that implements
     the tests will have the same outcome as any other implementation.
+
+
+
+[GitHub Flavored Markdown]: https://github.github.com/gfm/
+[Normative language]: https://en.wikipedia.org/wiki/Normative#Standards_documents

--- a/docs/requirements/supporting-documents/DNSCheck-Tests.md
+++ b/docs/requirements/supporting-documents/DNSCheck-Tests.md
@@ -1,4 +1,4 @@
-The DNSCheck tests can be found in the [DNSCheck::Test](http://github.com/dotse/dnscheck/tree/master/engine/lib/DNSCheck/Test/) namespace. The following tests are implemented:
+The DNSCheck tests can be found in the [DNSCheck::Test](https://github.com/dotse/dnscheck/tree/master/engine/lib/DNSCheck/Test/) namespace. The following tests are implemented:
 
 ## Address
 Tests for valid (and resonable) IP addresses.
@@ -11,7 +11,7 @@ The following tests are made:
 * Special-Use IPv6 Addresses must not be used.
 * There should exist a PTR record for the address.
 * The hostname(s) pointed to by the PTR record(s) should exist.
-* This test is implemented by [DNSCheck::Test::Address](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Address.pm).
+* This test is implemented by [DNSCheck::Test::Address](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Address.pm).
 
 ## Connectivity
 Test zone connectivity.
@@ -21,7 +21,7 @@ The following tests are made:
  * A name server should not be announced by more than one AS.
  * A name server must be announced.
  * Domain name servers should live in more than one AS.
- * This test is implemented by [DNSCheck::Test::Connectivity](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Connectivity.pm).
+ * This test is implemented by [DNSCheck::Test::Connectivity](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Connectivity.pm).
 
 ## Consistency
 Test the zone for consistency.
@@ -30,7 +30,7 @@ The following tests are made:
 
  * The serial number of the zone must be the same at all listed name servers.
 
-This test is implemented by [DNSCheck::Test::Consistency](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Consistency.pm).
+This test is implemented by [DNSCheck::Test::Consistency](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Consistency.pm).
 
 ## DNSSEC
 Test DNSSEC.
@@ -49,7 +49,7 @@ The following tests are made:
  * At least one DS algorithm should be of type RSA/SHA1.
  * Verify DNSSEC additional processing.
  
-This test is implemented by [DNSCheck::Test::DNSSEC](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/DNSSEC.pm).
+This test is implemented by [DNSCheck::Test::DNSSEC](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/DNSSEC.pm).
 
 ## Delegation
 The following tests are made:
@@ -59,7 +59,7 @@ The following tests are made:
  * At least two NS records at parent.
  * Check for inconsistent glue.
 
-This test is implemented by [DNSCheck::Test::Delegation](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Delegation.pm).
+This test is implemented by [DNSCheck::Test::Delegation](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Delegation.pm).
 
 ## Host
 Test host names and addresses.
@@ -72,7 +72,7 @@ The following tests are made:
  * Hostname must not point to a CNAME.
  * All host addresses (IPv4 and IPv6) must be valid.
 
-This test is implemented by [DNSCheck::Test::Host](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Host.pm).
+This test is implemented by [DNSCheck::Test::Host](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Host.pm).
 
 ## Mail
 Test email addresses.
@@ -84,7 +84,7 @@ The following tests are made:
  * The mail exchanger should be reachable by IPv4.
  * Mail for the email address must be deliverable via SMTP.
 
-This test is implemented by [DNSCheck::Test::Mail](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Mail.pm).
+This test is implemented by [DNSCheck::Test::Mail](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Mail.pm).
 
 ## Nameserver
 Test a single name server for a specific zone.
@@ -97,12 +97,12 @@ The following tests are made:
  * The SOA record for the zone must be fetchable over both UDP and TCP.
  * The nameserver may provide AXFR for the zone.
 
-This test is implemented by [DNSCheck::Test::Nameserver](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Nameserver.pm).
+This test is implemented by [DNSCheck::Test::Nameserver](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Nameserver.pm).
 
 ## SMTP
 Test if an email address is deliverable using SMTP.
 
-This test is implemented by [DNSCheck::Test::SMTP](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/SMTP.pm).
+This test is implemented by [DNSCheck::Test::SMTP].
 
 ## SOA
 Test zone connectivity.
@@ -125,14 +125,18 @@ The following tests are made:
  * SOA 'expire' should be at least 7 times SOA 'refresh'.
  * SOA 'minimum' should be less than 1 day.
 
-This test is implemented by [DNSCheck::Test::SOA](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/SOA.pm).
+This test is implemented by [DNSCheck::Test::SOA](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/SOA.pm).
 
 ## Zone
 Test a zone using all DNSCheck modules.
 
-This test is implemented by [DNSCheck::Test::Zone](http://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Zone.pm).
+This test is implemented by [DNSCheck::Test::Zone](https://github.com/dotse/dnscheck/blob/master/engine/lib/DNSCheck/Test/Zone.pm).
 
 ## Details
 
 * [Detailed list of all possible DNSCheck messages](Detailed-list-of-all-possible-dnscheck-messages.md).
 * [Algorithms used by DNSCheck](Algorithms-used-by-dnscheck.md).
+
+
+
+[DNSCheck::Test::SMTP]: https://github.com/dotse/dnscheck/blob/bbda8eaaf9df1321b4a382d45d0090dabd58a4d0/engine/lib/DNSCheck/Test/SMTP.pm

--- a/docs/specifications/tests/Consistency-TP/consistency05.md
+++ b/docs/specifications/tests/Consistency-TP/consistency05.md
@@ -180,10 +180,10 @@ respected.
 [BASIC01]:                  ../Basic-TP/basic01.md
 [DELEGATION05]:             ../Delegation-TP/delegation05.md
 [Methods]:                  ../Methods.md
-[Method2]:                  ../Methods.md#method-2-delegation-name-servers
-[Method3]:                  ../Methods.md#method-3-in-zone-name-servers
-[Method4]:                  ../Methods.md#method-4-delegation-name-server-addresses
-[Method5]:                  ../Methods.md#method-5-in-zone-addresses-records-of-name-servers
+[Method2]:                  ../Methods.md#method-2-obtain-glue-name-records-from-parent
+[Method3]:                  ../Methods.md#method-3-obtain-name-servers-from-child
+[Method4]:                  ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 [name server requirement]:  https://www.iana.org/help/nameserver-requirements
 [RFC 7719]:                 https://tools.ietf.org/html/rfc7719
 [terminology]:              #terminology

--- a/docs/specifications/tests/Nameserver-TP/nameserver01.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver01.md
@@ -80,22 +80,14 @@ Valid domain names according to the "IDNA 2008 specification" is found in
 [RFC 5890], section 2.3.1, page 7.
  
 
-[RFC 2870]: https://tools.ietf.org/html/rfc2870
-
-[RFC 5358]: https://tools.ietf.org/html/rfc5358
-
-[RFC 5890]: https://tools.ietf.org/html/rfc5890
 
 [D.J. Bernstein]: http://cr.yp.to/djbdns/separation.html
-
-[Method4]: #method-4-delegation-name-server-addresses
-
-[Method5]: #method-5-in-zone-addresses-records-of-name-servers
-
-[NO_RESPONSE]: #outcomes
-
-[IS_A_RECURSOR]: #outcomes
-
-[NO_RECURSOR]: #outcomes
-
 [IDNA 2008 specification]: #terminology
+[IS_A_RECURSOR]: #outcomes
+[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_RECURSOR]: #outcomes
+[NO_RESPONSE]: #outcomes
+[RFC 2870]: https://tools.ietf.org/html/rfc2870
+[RFC 5358]: https://tools.ietf.org/html/rfc5358
+[RFC 5890]: https://tools.ietf.org/html/rfc5890

--- a/docs/specifications/tests/Nameserver-TP/nameserver02.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver02.md
@@ -107,13 +107,14 @@ the ignored result.
 
 None
 
-[RFC 6891]: https://tools.ietf.org/html/rfc6891
-[RFC 6891, section 7]: https://tools.ietf.org/html/rfc6891#section-7
-[RFC 6891, section 6.1.1]: https://tools.ietf.org/html/rfc6891#section-6.1.1
-[Method4]: ../Methods.md#method-4-delegation-name-server-addresses
-[Method5]: ../Methods.md#method-5-in-zone-addresses-records-of-name-servers
-[NO_RESPONSE]: #outcomes
-[NO_EDNS_SUPPORT]: #outcomes
-[BROKEN_EDNS_SUPPORT]: #outcomes
-[NS_ERROR]: #outcomes
 
+
+[BROKEN_EDNS_SUPPORT]: #outcomes
+[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_EDNS_SUPPORT]: #outcomes
+[NO_RESPONSE]: #outcomes
+[NS_ERROR]: #outcomes
+[RFC 6891, section 6.1.1]: https://tools.ietf.org/html/rfc6891#section-6.1.1
+[RFC 6891, section 7]: https://tools.ietf.org/html/rfc6891#section-7
+[RFC 6891]: https://tools.ietf.org/html/rfc6891

--- a/docs/specifications/tests/Nameserver-TP/nameserver10.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver10.md
@@ -72,12 +72,12 @@ the ignored result.
 None
 
 
-[RFC 6891]: https://tools.ietf.org/html/rfc6891
-[RFC 6891, section 6.1.3]: https://tools.ietf.org/html/rfc6891#section-6.1.3
-[Method4]: ../Methods.md#method-4-delegation-name-server-addresses
-[Method5]: ../Methods.md#method-5-in-zone-addresses-records-of-name-servers
-[NO_RESPONSE]: #outcomes
-[NO_EDNS_SUPPORT]: #outcomes
-[UNSUPPORTED_EDNS_VER]: #outcomes
-[NS_ERROR]: #outcomes
 
+[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_EDNS_SUPPORT]: #outcomes
+[NO_RESPONSE]: #outcomes
+[NS_ERROR]: #outcomes
+[RFC 6891, section 6.1.3]: https://tools.ietf.org/html/rfc6891#section-6.1.3
+[RFC 6891]: https://tools.ietf.org/html/rfc6891
+[UNSUPPORTED_EDNS_VER]: #outcomes

--- a/docs/specifications/tests/Nameserver-TP/nameserver11.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver11.md
@@ -74,12 +74,14 @@ the ignored result.
 
 None.
 
-[RFC 6891]: https://tools.ietf.org/html/rfc6891
-[RFC 6891, section 6.1.2]: https://tools.ietf.org/html/rfc6891#section-6.1.2
+
+
 [IANA-DNSSYSTEM-PARAMETERS]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-11
-[Method4]: ../Methods.md#method-4-delegation-name-server-addresses
-[Method5]: ../Methods.md#method-5-in-zone-addresses-records-of-name-servers
-[NO_RESPONSE]: #outcomes
+[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 [NO_EDNS_SUPPORT]: #outcomes
+[NO_RESPONSE]: #outcomes
 [NS_ERROR]: #outcomes
+[RFC 6891, section 6.1.2]: https://tools.ietf.org/html/rfc6891#section-6.1.2
+[RFC 6891]: https://tools.ietf.org/html/rfc6891
 [UNKNOWN_OPTION_CODE]: #outcomes

--- a/docs/specifications/tests/Nameserver-TP/nameserver12.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver12.md
@@ -75,13 +75,15 @@ the ignored result.
 
 None.
 
-[RFC 6891]: https://tools.ietf.org/html/rfc6891
-[RFC 6891, section 6.1.4]: https://tools.ietf.org/html/rfc6891#section-6.1.2
+
+
 [EDNS Header Flags]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-13
-[Method4]: ../Methods.md#method-4-delegation-name-server-addresses
-[Method5]: ../Methods.md#method-5-in-zone-addresses-records-of-name-servers
-[NO_RESPONSE]: #outcomes
-[NO_EDNS_SUPPORT]: #outcomes
-[Z_FLAGS_NOTCLEAR]: #outcomes
-[NS_ERROR]: #outcomes
 [IANA]: https://www.iana.org/
+[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_EDNS_SUPPORT]: #outcomes
+[NO_RESPONSE]: #outcomes
+[NS_ERROR]: #outcomes
+[RFC 6891, section 6.1.4]: https://tools.ietf.org/html/rfc6891#section-6.1.2
+[RFC 6891]: https://tools.ietf.org/html/rfc6891
+[Z_FLAGS_NOTCLEAR]: #outcomes

--- a/docs/specifications/tests/Nameserver-TP/nameserver13.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver13.md
@@ -77,12 +77,13 @@ the ignored result.
 
 None.
 
-[RFC 6891]: https://tools.ietf.org/html/rfc6891
-[RFC 6891, section 7]: https://tools.ietf.org/html/rfc6891#section-7
-[Method4]: ../Methods.md#method-4-delegation-name-server-addresses
-[Method5]: ../Methods.md#method-5-in-zone-addresses-records-of-name-servers
-[NO_RESPONSE]: #outcomes
-[NO_EDNS_SUPPORT]: #outcomes
-[NS_ERROR]: #outcomes
-[MISSING_OPT_IN_TRUNCATED]: #outcomes
 
+
+[MISSING_OPT_IN_TRUNCATED]: #outcomes
+[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_EDNS_SUPPORT]: #outcomes
+[NO_RESPONSE]: #outcomes
+[NS_ERROR]: #outcomes
+[RFC 6891, section 7]: https://tools.ietf.org/html/rfc6891#section-7
+[RFC 6891]: https://tools.ietf.org/html/rfc6891

--- a/docs/specifications/tests/Nameserver-TP/nameserver14.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver14.md
@@ -6,8 +6,8 @@
 
 ### Objective
 
-This test case actually combines the test options in test cases
-[NAMESERVER10](../nameserver10.md) and [NAMESERVER11](../nameserver11.md). 
+This test case actually combines the test options in test cases [NAMESERVER10]
+and [NAMESERVER11].
 
 ### Inputs
 
@@ -76,10 +76,12 @@ None.
 
 [IANA-DNSSYSTEM-PARAMETERS]:
 https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-11
-[Method4]: ../Methods.md#method-4-delegation-name-server-addresses
-[Method5]: ../Methods.md#method-5-in-zone-addresses-records-of-name-servers
-[NO_RESPONSE]: #outcomes
+[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NAMESERVER10]: nameserver10.md
+[NAMESERVER11]: nameserver11.md
 [NO_EDNS_SUPPORT]: #outcomes
+[NO_RESPONSE]: #outcomes
 [NS_ERROR]: #outcomes
 [UNKNOWN_OPTION_CODE]: #outcomes
 [UNSUPPORTED_EDNS_VER]: #outcomes

--- a/docs/specifications/tests/Zone-TP/zone09.md
+++ b/docs/specifications/tests/Zone-TP/zone09.md
@@ -11,7 +11,7 @@ that all domains should have a mailbox named hostmaster@domain.
 
 > For simplicity and regularity, it is strongly recommended that the
 > well known mailbox name HOSTMASTER always be used
-> <HOSTMASTER@domain>.
+> \<HOSTMASTER@domain\>.
 
 It is therefore necessary for any domain to publish an MX record.
 However, SMTP can make a delivery without the MX, using the A or


### PR DESCRIPTION
This fixes most of the broken and/or redirecting links in this repo. Some broken links are not fixed by this PR, but those are covered by #631, #771, #772, #775 and zonemaster/zonemaster-engine#554.

This PR also makes some substantial changes. See the commit message for details.