### PR TITLE
Update Connectivity03 (v2)

### DIFF
--- a/docs/specifications/tests/Connectivity-TP/connectivity03.md
+++ b/docs/specifications/tests/Connectivity-TP/connectivity03.md
@@ -7,14 +7,14 @@
 ## Objective
 
 The objective in this test is to verify that all IP addresses of the domain's
-authoritative name servers are not announced from the same ASN (autonomous system 
+authoritative name servers are announced from different ASNs (autonomous system 
 number). See [RFC 1930] and [Wikipedia] for an explanation of AS (autonomous 
 system).
 
 This test is done separately on IPv4 and IPv6, and both must match the criterion.
 
-[RFC 2182], section 3.1 clearly specifies that distinct authoritative name 
-servers for a child domain should be placed in different topological and 
+[RFC 2182][RFC 2182#3.1], section 3.1, clearly specifies that distinct authoritative 
+name servers for a child domain should be placed in different topological and 
 geographical locations. The objective is to minimise the likelihood of a single 
 failure disabling all of them. 
 
@@ -33,9 +33,9 @@ failure disabling all of them.
 ## Ordered description of steps to be taken to execute the test case
 
 1. Obtain the total set of IP addresses of the name servers for the 
-   *Child Zone* using [Method4] and [Method5] and do:
-   1. Create a possibly empty set of the IPv4 addresses ("NS IPv4").
-   2. Create a possibly empty set of the IPv6 addresses ("NS IPv6").
+   *Child Zone* using [Method4] and [Method5] and split those IP addresses
+   into one set of IPv4 addresses ("NS IPv4") and one set of IPv6 addresses
+   ("NS IPv6"). (One of two sets may be empty.)
 
 2. For each IP address in the set *NS IPv4* and *NS IPv6*, respectively, 
    determine the ASN set announcing the IP address using either the 
@@ -43,7 +43,7 @@ failure disabling all of them.
    sections below. Create two sets of ASN data ("NS IPv4 ASN" and 
    "NS IPv6 ASN", respectively).
 
-3. For *NS IPv4 ASN* do:
+3. Analyze the *NS IPv4 ASN* set:
    1. If *NS IPv4 ASN* is empty (no IPv4 address) do nothing.
    2. Else, if all IPv4 addresses are announced from one and the same ASN, output
       *[IPV4_ONE_ASN]*.
@@ -51,7 +51,7 @@ failure disabling all of them.
       ASNs, output *[IPV4_SAME_ASN]*.
    4. Else, output *[IPV4_DIFFERENT_ASN]*.
 
-4. For *NS IPv6 ASN* do:
+4. Analyze the *NS IPv6 ASN* set:
    1. If *NS IPv6 ASN* is empty (no IPv6 address) do nothing.
    2. Else, if all IPv6 addresses are announced from one and the same ASN, output
       *[IPV6_ONE_ASN]*.
@@ -103,8 +103,8 @@ origin6.asnlookup.zonemaster.net
 ```
 
 2. Reverse the IP address with the same method as is used for
-   reverse lookup. For description see [RFC 1035], section 3.5, for IPv4 
-   and [RFC 3596], section 2.5, for IPv6.
+   reverse lookup. For description see [RFC 1035][RFC 1035#3.5], section 3.5, 
+   for IPv4 and [RFC 3596][RFC 3596#2.5], section 2.5, for IPv6.
  
 3. Prepend the *expanded base name* with the reversed IP address. For
    description see [IP to ASN Mapping].
@@ -178,27 +178,23 @@ whois -h riswhois.ripe.net " -F -M 192.0.2.10"
 
 None
 
-[RFC 1035]:           https://tools.ietf.org/html/rfc1035
-[RFC 1930]:           https://tools.ietf.org/html/rfc1930
-[RFC 2182]:           https://tools.ietf.org/html/rfc2182#page-4
-[RFC 3596]:           https://tools.ietf.org/html/rfc3596#section-2.5
 
-[Wikipedia]:          https://en.wikipedia.org/wiki/Autonomous_system_(Internet)
-
-[IP to ASN Mapping]:  https://team-cymru.org/IP-ASN-mapping.html#dns
-[RISwhois]:           https://www.ripe.net/analyse/archived-projects/ris-tools-web-interfaces/riswhois
-
-[Method4]:            ../Methods.md#method-4-obtain-glue-address-records-from-parent
-[Method5]:            ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-
-[RIPE database]:      #ripe-asn-lookup
-[Cymru database]:     #cymru-asn-lookup
-
-[EMPTY_ASN_SET]:      #outcomes 
-[ERROR_ASN_DATABASE]: #outcomes 
-[IPV4_ONE_ASN]:       #outcomes 
-[IPV4_SAME_ASN]:      #outcomes 
-[IPV4_DIFFERENT_ASN]: #outcomes 
-[IPV6_ONE_ASN]:       #outcomes 
-[IPV6_SAME_ASN]:      #outcomes 
-[IPV6_DIFFERENT_ASN]: #outcomes 
+[Cymru database]:       #cymru-asn-lookup
+[EMPTY_ASN_SET]:        #outcomes 
+[ERROR_ASN_DATABASE]:   #outcomes 
+[IP to ASN Mapping]:    https://team-cymru.org/IP-ASN-mapping.html#dns
+[IPV4_DIFFERENT_ASN]:   #outcomes 
+[IPV4_ONE_ASN]:         #outcomes 
+[IPV4_SAME_ASN]:        #outcomes 
+[IPV6_DIFFERENT_ASN]:   #outcomes 
+[IPV6_ONE_ASN]:         #outcomes 
+[IPV6_SAME_ASN]:        #outcomes 
+[Method4]:              ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:              ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[RFC 1035#3.5]:         https://tools.ietf.org/html/rfc1035#section-3.5
+[RFC 1930]:             https://tools.ietf.org/html/rfc1930
+[RFC 2182#3.1]:         https://tools.ietf.org/html/rfc2182#section-3.1
+[RFC 3596#2.5]:         https://tools.ietf.org/html/rfc3596#section-2.5
+[RIPE database]:        #ripe-asn-lookup
+[RISwhois]:             https://www.ripe.net/analyse/archived-projects/ris-tools-web-interfaces/riswhois
+[Wikipedia]:            https://en.wikipedia.org/wiki/Autonomous_system_(Internet)

--- a/docs/specifications/tests/Connectivity-TP/connectivity03.md
+++ b/docs/specifications/tests/Connectivity-TP/connectivity03.md
@@ -1,58 +1,204 @@
-## CONNECTIVITY03: AS Diversity
+# CONNECTIVITY03: AS Diversity
 
-### Test case identifier
+## Test case identifier
 
-**CONNECTIVITY03:** AS Diversity
+**CONNECTIVITY03**
 
-### Objective
+## Objective
 
-[RFC 2182](https://tools.ietf.org/html/rfc2182), section 3.1
-clearly specifies that distinct authoritative name servers for a child
-domain should be placed in different topological and geographical locations.
-The objective is to minimise the likelihood of a single failure disabling
-all of them. 
+The objective in this test is to verify that all IP addresses of the domain's
+authoritative name servers are not announced from the same ASN (autonomous system 
+number). See [RFC 1930] and [Wikipedia] for an explanation of AS (autonomous 
+system).
 
-The objective in this test is to check that all IP addresses of the domain's
-authoritative name servers does not belong to the same AS.
+This test is done separately on IPv4 and IPv6, and both must match the criterion.
 
-[missing references to AS numbers, RFC 1930?]
+[RFC 2182], section 3.1 clearly specifies that distinct authoritative name 
+servers for a child domain should be placed in different topological and 
+geographical locations. The objective is to minimise the likelihood of a single 
+failure disabling all of them. 
 
-### Inputs
 
-The domain name to be tested.
+## Inputs
 
-### Ordered description of steps to be taken to execute the test case
+* "Child Zone" - The domain name to be tested.
+* "ASN Database" - The database of ASN data to be used. Possible values
+  are "RIPE" and "Cymru" (the default value).
+* "Cymru Base Name" - If the *ASN Database* is "Cymru", the default value 
+  is "asnlookup.zonemaster.net".
+* "Ris Whois Server" - If the *ASN Database* is "RIPE", the default value 
+  is "riswhois.ripe.net".
 
-1. Obtain the IP addresses of the name servers from [Method4](../Methods.md).
-2. Obtain the list of ASN lookup domains from the configuration of Zonemaster.
-3. For obtaining the AS numbers for IPv6 addresses; first reverse its eight
-4-character hexadecimal numbers and place dots between each. It is important 
-all omitted zeroes are included.  
-3.1. At the end of the reversed IPv6 address, concatenate the string (from
-step 2)  
-3.2 Send a "TXT" query using the string (obtained from Step 3.1)  
-3.3 If there is an ANSWER, then go to step 3.4, else go to the next string
-in the list (from step 2)  
-3.4 The AS number for the IPv6 address is found in the ANSWER for the query 
-4. To obtain the AS numbers for IPv4 addresses; first reverse the four numerical
-octets and place dots between each.  
-4.1. At the end of the reversed IPv4 address concatenate the string (from step 2)  
-4.2 Send a "TXT" query using the string (obtained from Step 4.1)  
-4.3 If there is an ANSWER, go to step 4.4, else go to the next string
-in the list (from step 2)  
-4.4 The AS number for the IPv4 address is found in the ANSWER for the query 
-5. If all the retrieved AS (obtained from step 3.3 and 4.3) are same, then the test
-   fails.
 
-### Outcome(s)
+## Ordered description of steps to be taken to execute the test case
 
-If there is a AS which is different from the other retrieved AS, then the
-test succeeds.
+1. Obtain the total set of IP addresses of the name servers for the 
+   *Child Zone* using [Method4] and [Method5] and do:
+   1. Create a possibly empty set of the IPv4 addresses ("NS IPv4").
+   2. Create a possibly empty set of the IPv6 addresses ("NS IPv6").
 
-### Special procedural requirements
+2. For each IP address in the set *NS IPv4* and *NS IPv6*, respectively, 
+   determine the ASN set announcing the IP address using either the 
+   *[Cymru database]* or the *[RIPE database]* as described in separate 
+   sections below. Create two sets of ASN data ("NS IPv4 ASN" and 
+   "NS IPv6 ASN", respectively).
+
+3. For *NS IPv4 ASN* do:
+   1. If *NS IPv4 ASN* is empty (no IPv4 address) do nothing.
+   2. Else, if all IPv4 addresses are announced from one and the same ASN, output
+      *[IPV4_ONE_ASN]*.
+   3. Else, if all IPv4 addresses are announced from the same set of multiple 
+      ASNs, output *[IPV4_SAME_ASN]*.
+   4. Else, output *[IPV4_DIFFERENT_ASN]*.
+
+4. For *NS IPv6 ASN* do:
+   1. If *NS IPv6 ASN* is empty (no IPv6 address) do nothing.
+   2. Else, if all IPv6 addresses are announced from one and the same ASN, output
+      *[IPV6_ONE_ASN]*.
+   3. Else, if all IPv6 addresses are announced from the same set of multiple 
+      ASNs, output *[IPV6_SAME_ASN]*.
+   4. Else, output *[IPV6_DIFFERENT_ASN]*.
+
+## Outcome(s)
+
+The outcome of this Test Case is "fail" if there is at least one 
+message with the severity level ERROR or CRITICAL.
+
+The outcome of this Test Case is "warning" if there is at least 
+one message with the severity level WARNING, but no message with 
+severity level ERROR or CRITICAL.
+
+In other cases the outcome of this Test Case is "pass".
+
+Message            |Default severity level (if message is outputted)
+:------------------|:------------
+EMPTY_ASN_SET      |ERROR        
+ERROR_ASN_DATABASE |ERROR        
+IPV4_ONE_ASN       |ERROR        
+IPV4_SAME_ASN      |NOTICE       
+IPV4_DIFFERENT_ASN |INFO         
+IPV6_ONE_ASN       |ERROR        
+IPV6_SAME_ASN      |NOTICE       
+IPV6_DIFFERENT_ASN |INFO         
+
+
+## Special procedural requirements
+
+This test case is dependent on one of two possible services that can provide
+ASN lookup, RIPE or Cymru. The service must be available over the network.
+
+
+### Cymru ASN lookup
+
+The Cymru lookup method is described on the Team Cymru [IP to ASN Mapping]
+using DNS lookup.
+
+1. Prepend the *Cymru Base Name* with the label "origin" (IPv4) or 
+   "origin6" (IPv6). Example of expanded basenames 
+   ("expanded base name"):
+   
+```
+origin.asnlookup.zonemaster.net
+origin6.asnlookup.zonemaster.net
+```
+
+2. Reverse the IP address with the same method as is used for
+   reverse lookup. For description see [RFC 1035], section 3.5, for IPv4 
+   and [RFC 3596], section 2.5, for IPv6.
+ 
+3. Prepend the *expanded base name* with the reversed IP address. For
+   description see [IP to ASN Mapping].
+
+4. Send a DNS query for the TXT record of the full name created in step 3.
+
+5. If either the DNS response has RCODE "NXDOMAIN" or the DNS response 
+   has RCODE "NOERROR" but empty answer section, output
+   *[EMPTY_ASN_SET]* and end these steps for Cymru look-up of the specific
+   IP address.
+
+6. If there is no response (timeout) or the DNS response does not have
+   the RCODE "NOERROR", output *[ERROR_ASN_DATABASE]* and 
+   end these steps for Cymru look-up of the specific IP address.
+
+8. The expected response is a non-empty string in the TXT record or 
+   records. See [IP to ASN Mapping] for examples.
+
+9. Do the following:
+
+   1. Split the string or strings into fields.
+   2. If there are multiple strings (TXT records), ignore all strings
+      except for the string with the most specific subnet.
+   3. Extract the ASN or ASNs.
+   4. If it was not possible to extract the ASN or ASNs, output 
+      *[ERROR_ASN_DATABASE]* and end these steps for Cymru look-up of 
+      the specific IP address (the response was malformed).
+
+10. The ASN or ASNs from step 11 is the ASN set for that IP address
+    and is used for the further processing.
+
+
+### RIPE ASN lookup
+
+The RIPE ASN lookup is described on the RIPE [RISwhois] page.
+
+1. Construct a query string by prepending the IP adress with
+   " -F -M ". Using "192.0.2.10" as an example, the query string will
+   be the following (the leading space is intentional)
+   
+   ```
+   " -F -M 192.0.2.10" 
+   ```
+   
+2. Send the query string to the *Ris Whois Server* on port
+   43 with the nicname (whois) protocol. Example of command
+   line command on unix:
+
+```
+whois -h riswhois.ripe.net " -F -M 192.0.2.10"
+```
+
+3. Do the following:
+   1. The non-empty line not prepended with "%" contains the string
+      with data (no or one such line).
+   2. Check if there is no string with data (empty reply). If so, 
+      output *[EMPTY_ASN_SET]* and end these steps for RIPE look-up
+      of the specific IP address.
+   3. If there is no response from the *Ris Whois Server*, output 
+      *[ERROR_ASN_DATABASE]* and end these steps for RIPE look-up
+      of the specific IP address.
+   4. The first field has the ASN or list of ASNs. Split that into ASNs.
+   5. If it was not possible to extrac the ASN or ASNs, output 
+      *[ERROR_ASN_DATABASE]* and end these steps (the response was 
+      malformed).
+
+8. From the ASN or ASNs from step 6 create the ASN set for the IP
+   address and is used for the further processing.
+
+## Intercase dependencies
 
 None
 
-### Intercase dependencies
+[RFC 1035]:           https://tools.ietf.org/html/rfc1035
+[RFC 1930]:           https://tools.ietf.org/html/rfc1930
+[RFC 2182]:           https://tools.ietf.org/html/rfc2182#page-4
+[RFC 3596]:           https://tools.ietf.org/html/rfc3596#section-2.5
 
-None
+[Wikipedia]:          https://en.wikipedia.org/wiki/Autonomous_system_(Internet)
+
+[IP to ASN Mapping]:  https://team-cymru.org/IP-ASN-mapping.html#dns
+[RISwhois]:           https://www.ripe.net/analyse/archived-projects/ris-tools-web-interfaces/riswhois
+
+[Method4]:            ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:            ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+
+[RIPE database]:      #ripe-asn-lookup
+[Cymru database]:     #cymru-asn-lookup
+
+[EMPTY_ASN_SET]:      #outcomes 
+[ERROR_ASN_DATABASE]: #outcomes 
+[IPV4_ONE_ASN]:       #outcomes 
+[IPV4_SAME_ASN]:      #outcomes 
+[IPV4_DIFFERENT_ASN]: #outcomes 
+[IPV6_ONE_ASN]:       #outcomes 
+[IPV6_SAME_ASN]:      #outcomes 
+[IPV6_DIFFERENT_ASN]: #outcomes 


### PR DESCRIPTION
* Adding missing references
* Transformed into new format with more explicit steps
* Messages explicitly defined in specification
* New messages
* Added support for RIPE Ris Whois in addition to Cymru ASN look-up

This PR is the first step to solve issue zonemaster/zonemaster-engine#273.

This PR replaces PR #597.

When this is merged, a new issue must be created in Zonemaster-Engine.