### PR TITLE
Updated Nameserver10 with explanatory note on extended RCODE

### DIFF
--- a/docs/specifications/tests/Nameserver-TP/nameserver10.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver10.md
@@ -10,10 +10,17 @@ EDNS is a mechanism to announce capabilities of a DNS implementation,
 and is now basically required by any new functionality in DNS such as
 DNSSEC ([RFC 6891]).
 
-[RFC 6891, section 6.1.3] states that if a nameserver has implemented 
-EDNS but has not implemented the version level of the request, then it 
+[RFC 6891][RFC 6891#6.1.3], section 6.1.3,
+states that if a nameserver has implemented
+EDNS but has not implemented the version level of the request, then it
 MUST respond with RCODE "BADVERS". Only version "0" has been defined for
 EDNS.
+
+Note that RCODE "BADVERS" is an extended RCODE which is calculated from
+the combination of the normal RCODE field in the DNS package header
+([RFC 1035][RFC 1035#4.1.1], section 4.1.1) and the OPT record
+EXTENDED-RCODE field ([RFC 6891][RFC 6891#6.1.3], section 6.1.3). Also see
+[IANA RCODE Registry].
 
 ## Inputs
 
@@ -21,7 +28,7 @@ EDNS.
 
 ## Ordered description of steps to be taken to execute the test case
 
-1. Created an SOA query for the *Child Zone* with an OPT record with 
+1. Created an SOA query for the *Child Zone* with an OPT record with
    EDNS version set to "1" and no other EDNS options or flags.
 
 2. Obtain the set of name server IP addresses using [Method4] and [Method5]
@@ -33,7 +40,7 @@ EDNS.
    2. If there is no DNS response, output *[NO_RESPONSE]*.
    3. Else, if the DNS response has the RCODE "FORMERR" then output
       *[NO_EDNS_SUPPORT]*.
-   4. Else, if the DNS response has the RCODE "NOERROR" then 
+   4. Else, if the DNS response has the RCODE "NOERROR" then
       output *[UNSUPPORTED_EDNS_VER]*.
    5. Else, if the DNS response meet the following three criteria,
       then just go to the next name server (no error):
@@ -41,7 +48,7 @@ EDNS.
       2. It has EDNS version 0.
       3. The answer section is empty.
    6. Else output *[NS_ERROR]*.
-      
+
 
 ## Outcome(s)
 
@@ -72,12 +79,13 @@ the ignored result.
 None
 
 
-
+[IANA RCODE Registry]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 [Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 [NO_EDNS_SUPPORT]: #outcomes
 [NO_RESPONSE]: #outcomes
 [NS_ERROR]: #outcomes
-[RFC 6891, section 6.1.3]: https://tools.ietf.org/html/rfc6891#section-6.1.3
+[RFC 1035#4.1.1]: https://tools.ietf.org/html/rfc1035#section-4.1.1
+[RFC 6891#6.1.3]: https://tools.ietf.org/html/rfc6891#section-6.1.3
 [RFC 6891]: https://tools.ietf.org/html/rfc6891
 [UNSUPPORTED_EDNS_VER]: #outcomes


### PR DESCRIPTION
Added a short, explanatory note on how extended RCODES are caculated with reference. This resolves #668 and meets the request in issue [480 in zonemaster-engine].

The change in this PR does not have any implications on the implementation.

[480 in zonemaster-engine]: https://github.com/zonemaster/zonemaster-engine/issues/480#issuecomment-456570027