### PR TITLE
Update GUI release steps by adding nodejs install steps

### DIFF
--- a/docs/internal-documentation/maintenance/ReleaseProcess.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess.md
@@ -124,7 +124,14 @@ respective latest released distribution tarballs from the [ZNMSTR] account on
 ## 8. Produce distribution zip file (Zonemaster-GUI only)
 
 The requirements are nodejs and npm. There are available from the [official website]( https://nodejs.org/en/).
-Minimal version of Nodejs is 6.0 but install the last LTS version available.
+Minimal version of Nodejs is 10.0 but install the last LTS version available.
+
+To build a new development environnement, you need to install nodejs.
+We use [NVM](https://github.com/nvm-sh/nvm), a node version manager.
+
+1. `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash`
+2. `nvm install 13.12.0`
+3. `nvm use 13.12.0`
 
 To build the tarballs, steps are: 
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess.md
@@ -124,7 +124,8 @@ respective latest released distribution tarballs from the [ZNMSTR] account on
 ## 8. Produce distribution zip file (Zonemaster-GUI only)
 
 The requirements are nodejs and npm. There are available from the [official website]( https://nodejs.org/en/).
-Minimal version of Nodejs is 10.0 but install the last LTS version available.
+Minimal version of Nodejs is 10.0 but install the last LTS version available. 
+It was tested on Ubuntu 18.04.
 
 To build a new development environnement, you need to install nodejs.
 We use [NVM](https://github.com/nvm-sh/nvm), a node version manager.


### PR DESCRIPTION
I add my own release steps to manage nodejs version. The version corresponds to my own version of nodejs.
It can be used on any Linux but I personally use it on ubuntu 18.04.