### PR TITLE
Updated treatment of DS SHA-1 in DNSSEC01

### DIFF
--- a/docs/specifications/tests/DNSSEC-TP/dnssec01.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec01.md
@@ -107,14 +107,14 @@ In other cases the outcome of this Test Case is "pass".
 
 Message                       | Default severity level
 :-----------------------------|:-----------------------------------
+DS_ALGORITHM_DEPRECATED       | ERROR
+DS_ALGORITHM_MISSING          | NOTICE
+DS_ALGORITHM_NOT_DS           | ERROR
+DS_ALGORITHM_OK               | INFO
+DS_ALGORITHM_RESERVED         | ERROR
+DS_ALGO_SHA1_DEPRECATED       | WARNING
 NO_RESPONSE_DS                | WARNING
 UNEXPECTED_RESPONSE_DS        | WARNING
-DS_ALGORITHM_NOT_DS           | ERROR
-DS_ALGORITHM_DEPRECATED       | ERROR
-DS_ALGORITHM_RESERVED         | ERROR
-DS_ALGORITHM_OK               | INFO
-DS_ALGORITHM_MISSING          | NOTICE
-DS_ALGO_SHA1_DEPRECATED       | WARNING
 
 ## Special procedural requirements
 
@@ -130,16 +130,16 @@ Test case is only performed if DS records are found.
 
 None.
 
-[IANA registry]: https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xml
-[RFC 8624]:      https://tools.ietf.org/html/rfc8624#section-3.3
-[Method1]:       ../Methods.md#method-1-obtain-the-parent-domain
-[DNSSEC README]:           ./README.md
-[NO_RESPONSE_DS]:          #outcomes
-[UNEXPECTED_RESPONSE_DS]:  #outcomes
-[DS_ALGORITHM_NOT_DS]:     #outcomes
-[DS_ALGORITHM_DEPRECATED]: #outcomes
-[DS_ALGORITHM_RESERVED]:   #outcomes
-[DS_ALGORITHM_OK]:         #outcomes
-[DS_ALGORITHM_MISSING]:    #outcomes
+[DNSSEC README]:               ./README.md
+[DS_ALGORITHM_DEPRECATED]:     #outcomes
+[DS_ALGORITHM_MISSING]:        #outcomes
+[DS_ALGORITHM_NOT_DS]:         #outcomes
+[DS_ALGORITHM_OK]:             #outcomes
+[DS_ALGORITHM_RESERVED]:       #outcomes
 [DS_ALGO_SHA1_DEPRECATED]:     #outcomes
+[IANA registry]:               https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xml
+[Method1]:                     ../Methods.md#method-1-obtain-the-parent-domain
+[NO_RESPONSE_DS]:              #outcomes
+[RFC 8624]:                    https://tools.ietf.org/html/rfc8624#section-3.3
+[UNEXPECTED_RESPONSE_DS]:      #outcomes
 [Wikipedia]:                   https://en.wikipedia.org/wiki/SHA-1

--- a/docs/specifications/tests/DNSSEC-TP/dnssec01.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec01.md
@@ -15,6 +15,10 @@ If [RFC 8624] and the [IANA registry] disagree on the same DS digest
 algorithm, the RFC takes precedence until the registry has a been 
 updated with a reference to the RFC.
 
+At the time of writing (2020-04-08), algorithm 1 (SHA-1) is still
+in wide use even though it is no longer considered to be secure
+([Wikipedia]).
+
 The table of algorithms below is for reference only and is copied from [IANA 
 registry]. It is here to make it easier to read the steps when symbolic
 names are given. This is only an excerpt from the table. The full table is 
@@ -47,11 +51,13 @@ Algorithm number | Algorithm (or description)
       1. Compare the DS algorithm value with *Algorithm Status*.
       2. If the algortithm value is 0 then output 
          *[DS_ALGORITHM_NOT_DS]*.
-      3. If algortithm value is 1 or 3 then output 
+      3. If algortithm value is 1 then output
+         *[DS_ALGO_SHA1_DEPRECATED]*.
+      4. If algortithm value is 3 then output
          *[DS_ALGORITHM_DEPRECATED]*.
-      4. If algortithm value is 5-255 then output 
+      5. If algortithm value is 5-255 then output
          *[DS_ALGORITHM_RESERVED]*.
-      5. If no message has been outputted for the DS, then 
+      6. If no message has been outputted for the DS, then
          output *[DS_ALGORITHM_OK]*.
    2. If *Undelegated DS* has at least one DS but none with
       algorithm value 2 output *[DS_ALGORITHM_MISSING]*. 
@@ -76,11 +82,13 @@ Algorithm number | Algorithm (or description)
       1. Compare the DS algorithm value with *Algorithm Status*.
       2. If the algortithm value is 0 then output 
          *[DS_ALGORITHM_NOT_DS]*.
-      3. If algortithm value is 1 or 3 then output 
+      3. If algortithm value is 1 then output
+         *[DS_ALGO_SHA1_DEPRECATED]*.
+      4. If algortithm value is 3 then output
          *[DS_ALGORITHM_DEPRECATED]*.
-      4. If algortithm value is 5-255 then output 
+      5. If algortithm value is 5-255 then output
          output *[DS_ALGORITHM_RESERVED]*.
-      5. If no message has been outputted for the DS, then 
+      6. If no message has been outputted for the DS, then
          output *[DS_ALGORITHM_OK]*.
    7. If there was no DS with algorithm value 2 output 
       *[DS_ALGORITHM_MISSING]*. 
@@ -106,6 +114,7 @@ DS_ALGORITHM_DEPRECATED       | ERROR
 DS_ALGORITHM_RESERVED         | ERROR
 DS_ALGORITHM_OK               | INFO
 DS_ALGORITHM_MISSING          | NOTICE
+DS_ALGO_SHA1_DEPRECATED       | WARNING
 
 ## Special procedural requirements
 
@@ -132,3 +141,5 @@ None.
 [DS_ALGORITHM_RESERVED]:   #outcomes
 [DS_ALGORITHM_OK]:         #outcomes
 [DS_ALGORITHM_MISSING]:    #outcomes
+[DS_ALGO_SHA1_DEPRECATED]:     #outcomes
+[Wikipedia]:                   https://en.wikipedia.org/wiki/SHA-1

--- a/docs/specifications/tests/DNSSEC-TP/dnssec01.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec01.md
@@ -39,7 +39,6 @@ Algorithm number | Algorithm (or description)
 * "Algorithm Status" - The status of all DS digest algorithms from
   [RFC 8624] and the [IANA registry].
 * "Test Type" - The test type with value "undelegated" or "normal".
-
 * "Undelegated DS" - The DS record or records submitted
   (only if *Test Type* is undelegated).
 

--- a/docs/specifications/tests/DNSSEC-TP/dnssec01.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec01.md
@@ -5,23 +5,23 @@
 
 ## Objective
 
-The list of allowed Digest Algorithms in a DS record published by 
-the parent is specified by [RFC 8624], section 3.3, and is published 
-in the [IANA registry] of *DS RR Type Digest Algoritms*. No DS 
+The list of allowed Digest Algorithms in a DS record published by
+the parent is specified by [RFC 8624], section 3.3, and is published
+in the [IANA registry] of *DS RR Type Digest Algoritms*. No DS
 Digest Algorithm values, other than those specified in the RFC and
 allocated by IANA, should be used in public DNS.
 
-If [RFC 8624] and the [IANA registry] disagree on the same DS digest 
-algorithm, the RFC takes precedence until the registry has a been 
+If [RFC 8624] and the [IANA registry] disagree on the same DS digest
+algorithm, the RFC takes precedence until the registry has a been
 updated with a reference to the RFC.
 
 At the time of writing (2020-04-08), algorithm 1 (SHA-1) is still
 in wide use even though it is no longer considered to be secure
 ([Wikipedia]).
 
-The table of algorithms below is for reference only and is copied from [IANA 
+The table of algorithms below is for reference only and is copied from [IANA
 registry]. It is here to make it easier to read the steps when symbolic
-names are given. This is only an excerpt from the table. The full table is 
+names are given. This is only an excerpt from the table. The full table is
 available at [IANA registry].
 
 Algorithm number | Algorithm (or description)
@@ -36,12 +36,12 @@ Algorithm number | Algorithm (or description)
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
-* "Algorithm Status" - The status of all DS digest algorithms from 
+* "Algorithm Status" - The status of all DS digest algorithms from
   [RFC 8624] and the [IANA registry].
 * "Test Type" - The test type with value "undelegated" or "normal".
 
 * "Undelegated DS" - The DS record or records submitted
-  (only if *Test Type* is undelegated).  
+  (only if *Test Type* is undelegated).
 
 ## Ordered description of steps to be taken to execute the test case
 
@@ -49,7 +49,7 @@ Algorithm number | Algorithm (or description)
 
    1. For each *Undelegated DS* do:
       1. Compare the DS algorithm value with *Algorithm Status*.
-      2. If the algortithm value is 0 then output 
+      2. If the algortithm value is 0 then output
          *[DS_ALGORITHM_NOT_DS]*.
       3. If algortithm value is 1 then output
          *[DS_ALGO_SHA1_DEPRECATED]*.
@@ -60,7 +60,7 @@ Algorithm number | Algorithm (or description)
       6. If no message has been outputted for the DS, then
          output *[DS_ALGORITHM_OK]*.
    2. If *Undelegated DS* has at least one DS but none with
-      algorithm value 2 output *[DS_ALGORITHM_MISSING]*. 
+      algorithm value 2 output *[DS_ALGORITHM_MISSING]*.
    3. End the steps.
 
 2. Create a DS query with DO flag set for the name of the
@@ -72,15 +72,15 @@ Algorithm number | Algorithm (or description)
 4. For each IP address in *Parent NS IP* do:
    1. Send the DS query over UDP and collect the response.
    2. If there is no DNS response, then output *[NO_RESPONSE_DS]*.
-   3. Else, if the RCODE is not NOERROR, then output 
+   3. Else, if the RCODE is not NOERROR, then output
       *[UNEXPECTED_RESPONSE_DS]*.
    4. Else, go to next IP address if there is no DS in the
       response.
-   5. Else, extract all DS records from the DNS response 
+   5. Else, extract all DS records from the DNS response
       ("DS Records").
    6. For each DS in *DS Records*, do:
       1. Compare the DS algorithm value with *Algorithm Status*.
-      2. If the algortithm value is 0 then output 
+      2. If the algortithm value is 0 then output
          *[DS_ALGORITHM_NOT_DS]*.
       3. If algortithm value is 1 then output
          *[DS_ALGO_SHA1_DEPRECATED]*.
@@ -90,8 +90,8 @@ Algorithm number | Algorithm (or description)
          output *[DS_ALGORITHM_RESERVED]*.
       6. If no message has been outputted for the DS, then
          output *[DS_ALGORITHM_OK]*.
-   7. If there was no DS with algorithm value 2 output 
-      *[DS_ALGORITHM_MISSING]*. 
+   7. If there was no DS with algorithm value 2 output
+      *[DS_ALGORITHM_MISSING]*.
 
 
 ## Outcome(s)


### PR DESCRIPTION
ERROR was felt to be too harsh due to the wide use, and due to the
fact that SHA-1 based DNSSEC algorithms only create WARNING as
default. Secondly, IANA still lists SHA-1 as algorithm to be used for DS.

Commit 1: Updated the treatment of algo 1 (SHA-1)
* Add an initial comment on the status of SHA-1
* Created new message tag
* Set default level to WARNING (instead of ERROR)

Commit 2: Removed trailing spaces

Commit 3:
* Sorted message tags in table.
* Sorted link list.
* Updated indentation in link list.

When this PR has been approved and merged, a new issue will be created in Zonemaster-Engine for the implementation to be updated.