### PR TITLE
Revert "Add a note to ignore warnings about missing .mo files."

### DIFF
--- a/docs/internal-documentation/maintenance/ReleaseProcess.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess.md
@@ -73,10 +73,6 @@ Generate Makefile, META.yml and others.
 > **Note:** Ignore the warning from the above command about the missing
 > META.yml. The META.yml is created by the same command at a later stage.
 
-> **Note:** For Zonemaster-Engine ignore the warning from the above command
-> about the missing .mo files. These files are created when running `make all`
-> below.
-
 > **Note:** For Zonemaster-LDNS ignore the above command may generate warnings
 > for lots of missing ldns source files.
 > The ldns sources are fetched by the same command at a later stage.


### PR DESCRIPTION
This reverts commit 90c1ac430d68ae9dda9b0abf1b608a32b23fc886.

#861 was intended to revert all of #856, but it didn't include all of the commits. This brings the state of the master branch into complete sync with what was released.