### PR TITLE
Contact and mailing lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,13 @@ The following issues covers the limitions above:
 Limitations in the support of DNSSEC algorithm 15 is described above.
 
 
-## Contact
+## Contact and mailing lists
 
-For contacting the Zonemaster project, please send an e-mail to
-contact@zonemaster.net.
+See our [contact and mailing lists] page for contact information and
+information on mailing lists.
 
+
+[contact and mailing lists]:    docs/contact-and-mailing-lists.md
 [CPAN]:                         https://www.cpan.org/
 [LDNS]:                         https://www.nlnetlabs.nl/projects/ldns/about/
 [OpenSSL]:                      https://www.openssl.org/

--- a/docs/contact-and-mailing-lists.md
+++ b/docs/contact-and-mailing-lists.md
@@ -1,0 +1,71 @@
+# Contact and Mailing lists
+
+## Mailing lists
+
+The Zonemaster project offer two public mailing lists with
+different goals:
+
+* zonemaster-announce
+* zonemaster-users
+
+### zonemaster-announce
+
+The goal of `zonemaster-announce` is to provide a low-volume
+mailing list for announcements from the Zonemaster project. Mainly
+it is used to announce that a new Zonemaster release has been
+published, but also to report on severe security problems.
+
+The members of the list are not able to post any messages to the
+list. This if for one-way communication only.
+
+To sign-up on the list, go to
+https://lists.iis.se/mailman/listinfo/zonemaster-announce
+
+### zonemaster-users
+
+The goal of `zonemaster-users` is to provide a forum for discussions
+between and questions from Zonemaster users. The users in this sense
+are mainly those that have installed some part of the code. That
+could either be for evaluation on a small virtual server or a
+full-fledged installation of all parts for public use or anything
+in between.
+
+The members of the Zonemaster working group are also on list and can
+reply to questions and participate in discussions.
+
+The members of the list can post messages to the list, but those
+must of course be relevant and respectful.
+
+To sign-up on the list, go to
+https://lists.iis.se/mailman/listinfo/zonemaster-users
+
+## Questions on problems with a domain name
+
+If you have problem with your domain name, we can unfortunately not
+help you solving the issue. Zonemaster can hopefully point out what
+is wrong, but to have that issue resolved, you have to turn to
+your DNS operator.
+
+If Zonemaster do not report when there is a DNS error, or if
+Zonemaster falsely reports an error, then we are very interested
+to hear from you.
+
+## Contacting the Zonemaster project
+
+The best way to contact the Zonemaster project, besides using the
+mailing list, is to create an issue in the Github issue tracker
+for the Zonemaster repositories. That could be pure questions, but also
+bug reports or suggestions for improvements.
+
+* [Issues in Zonemaster::LDNS](https://github.com/zonemaster/zonemaster-ldns/issues)
+* [Issues in Zonemaster::Engine](https://github.com/zonemaster/zonemaster-engine/issues)
+* [Issues in Zonemaster::CLI](https://github.com/zonemaster/zonemaster-cli/issues)
+* [Issues in Zonemaster::Backend](https://github.com/zonemaster/zonemaster-backend/issues)
+* [Issues in zonemaster::GUI](https://github.com/zonemaster/zonemaster-gui/issues)
+
+If you cannot determine which repository to create the issue in, please
+select the main Zonemaster repository (i.e.
+[general issues in Zonemaster](https://github.com/zonemaster/zonemaster/issues)).
+
+If you cannot use any of the methods above, due to the subject matter, please
+send an e-mail to zonemaster@zonemaster.net.


### PR DESCRIPTION
* Public information on mailing lists
* Updated contact information

A new page with mailing list and contact information is created. The main README has been updated to point to that page.

The mail address has been changed.

One idea is that the new page should be linked to from GUI instead of the mail address there.