### PR TITLE
Update instruction for merging develop into master

### DIFF
--- a/docs/internal-documentation/maintenance/ReleaseProcess.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess.md
@@ -178,11 +178,25 @@ this.
 
 ## 12. Merge develop branch into master
 
-Merge the develop branch into master on Github.
+Make sure you're up to date and your working directory is completely clean:
 
-### ToDo
+    git fetch origin
+    git status --ignored
 
-Write a detailed instruction with commands.
+> **Note:** To throw away any and all changes to tracked and untracked files you
+> can run `git clean -dfx ; git reset --hard`.
+
+Create a new branch named `merge-develop-into-master` with both master and
+develop as ancestors and with the exact contents from develop:
+
+    git checkout -b merge-develop-into-master origin/develop
+    git reset origin/master
+    git add .
+    git commit -m 'Update master to state of develop'
+    git merge origin/develop
+
+Create a pull request from `merge-develop-into-master` into `master` and have it
+merged through the normal process.
 
 ## 13. Tag the release with git
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess.md
@@ -189,10 +189,16 @@ Make sure you're up to date and your working directory is completely clean:
 Create a new branch named `merge-develop-into-master` with both master and
 develop as ancestors and with the exact contents from develop:
 
+    # We want the contents of the develop branch
     git checkout -b merge-develop-into-master origin/develop
+
+    # But on top of the history of the master branch
     git reset origin/master
-    git add .
-    git commit -m 'Update master to state of develop'
+
+    # With all differences squashed into a single commit
+    git commit -m 'Update master to state of develop' -i .
+
+    # And we want the history of develop merged too
     git merge origin/develop
 
 Create a pull request from `merge-develop-into-master` into `master` and have it


### PR DESCRIPTION
Sometimes we make a mistake and merge a PR into the master branch. When this happens we do two things 1) we make an identical PR into the develop branch and 2) we make a PR with revert commits into the master branch. When we have such revert commits in the master branch we must take care so they don't stay applied on the master branch after we merge develop into master at release time. 

The steps in this PR work for both mis-merged commits that add files, remove files and change files.

Fixes #862.