### PR TITLE
Update DNSSEC02 (algorithm not supported)

### DIFF
--- a/docs/specifications/tests/DNSSEC-TP/dnssec02.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec02.md
@@ -85,7 +85,9 @@ the DNSKEY record that the DS points at does not have that flag set
          then output *[DNSKEY_KSK_NOT_SEP]*.
       6. Find the equivalent RRSIG in *DNSKEY RRSIG* by key ID (key tag).
       7. If matching RRSIG is not found, output *[NO_MATCHING_RRSIG]*.
-      8. If the RRSIG values (algorithm and signature) do not match
+      8. If the Zonemaster installation does not have support for the algorithm
+         that created the RRSIG, then output *[DS02_ALGO_NOT_SUPPORTED_BY_ZM]*.
+      9. Else, if the RRSIG values (algorithm and signature) do not match
          the DNSKEY then output *[BROKEN_RRSIG]*.
 
 8. If no message, besides possibly *[NO_RESPONSE]* or 
@@ -110,6 +112,7 @@ BROKEN_DS                     | ERROR
 BROKEN_RRSIG                  | ERROR
 DNSKEY_KSK_NOT_SEP            | NOTICE
 DNSKEY_NOT_ZONE_SIGN          | ERROR
+DS02_ALGO_NOT_SUPPORTED_BY_ZM | NOTICE
 DS_MATCHES                    | INFO
 NO_MATCHING_DNSKEY            | ERROR
 NO_MATCHING_RRSIG             | ERROR
@@ -139,6 +142,7 @@ None.
 [BROKEN_RRSIG]:            #outcomes
 [DNSKEY_KSK_NOT_SEP]:      #outcomes
 [DNSKEY_NOT_ZONE_SIGN]:    #outcomes
+[DS02_ALGO_NOT_SUPPORTED_BY_ZM]: #outcomes
 [DS_MATCHES]:              #outcomes
 [NO_MATCHING_DNSKEY]:      #outcomes
 [NO_MATCHING_RRSIG]:       #outcomes


### PR DESCRIPTION
Added special message when algorithm is not supported by Zonemaster. This will resolve #832 for DNSSEC02.

When this is merged, the implementation must be updated.