### PR TITLE
Updated DNSSEC13

### DIFF
--- a/docs/specifications/tests/DNSSEC-TP/dnssec13.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec13.md
@@ -5,7 +5,7 @@
 
 ## Objective
 
-From RFC [6840], section 5.11:
+From [RFC 6840][RFC 6840#section-5.11], section 5.11:
 
 > The DS RRset and DNSKEY RRset are used to signal which
 > algorithms are used to sign a zone. [...] The zone MUST
@@ -40,14 +40,16 @@ been created by a DNSKEY from the zone's DNSKEY RRset.
 4. Retrieve all name server IP addresses for the
    *Child Zone* using [Method4] and [Method5] ("NS IP").
 
-5. Repeat the following steps for each name server IP address in *NS IP*:
+5. Create an empty set of DNSKEY key tag and algorithm number,
+   "Unsupported Algorithm".
+
+6. Repeat the following steps for each name server IP address in *NS IP*:
 
    1. Send the DNSKEY query over UDP.
-      1. If no DNS response is returned, then output
-         *[NO_RESPONSE]* and go to next name server IP address.
+      1. If no DNS response is returned, then go to next name
+         server IP address.
       2. Else, if the DNS response contains no DNSKEY record in the
-         answer section, then output *[NO_RESPONSE_RRSET]* and go to
-         the next name server IP address.
+         answer section, then go to the next name server IP address.
       3. Else, do:
          1. Extract all DNSKEY records ("DNSKEY Records").
          2. Extract the algorithm numbers from each DNSKEY record
@@ -65,15 +67,18 @@ been created by a DNSKEY from the zone's DNSKEY RRset.
             1. If the key ID from the RRSIG is not a member of the
                set *DNSKEY Key ID*, then output
                *[RRSIG_NOT_MATCH_DNSKEY]* and go to next RRSIG.
-            2. If the RRSIG cannot be verified by the DNSKEY from
+            2. If the Zonemaster installation does not have support for
+               the algorithm that created the RRSIG, then add the
+               DNSKEY key tag and algorithm to the
+               *Unsupported Algorithm* set.
+            3. If the RRSIG cannot be verified by the DNSKEY from
                *DNSKEY Record* with the matching RRSIG key ID, then
                output *[RRSIG_BROKEN]*.
    2. Send the SOA query over UDP.
-      1. If no DNS response is returned, then output
-         *[NO_RESPONSE]* and go to next name server IP address.
+      1. If no DNS response is returned go to the next name server
+         IP address.
       2. Else, if the DNS response contains no SOA record in the
-         answer section, then output *[NO_RESPONSE_RRSET]* and go to
-         the next name server IP address.
+         answer section, then go to the next name server IP address.
       3. Else, do:
          1. Extract all RRSIG records from the response.
          2. If there is no RRSIG for SOA, then output
@@ -86,15 +91,18 @@ been created by a DNSKEY from the zone's DNSKEY RRset.
             1. If the key ID from the RRSIG is not a member of the
                set *DNSKEY Key ID*, then output
                *[RRSIG_NOT_MATCH_DNSKEY]* and go to next RRSIG.
-            2. If the RRSIG cannot be verified by the DNSKEY from
+            2. If the Zonemaster installation does not have support for
+               the algorithm that created the RRSIG, then add the
+               DNSKEY key tag and algorithm to the
+               *Unsupported Algorithm* set.
+            3. If the RRSIG cannot be verified by the DNSKEY from
                *DNSKEY Record* with the matching RRSIG key ID, then
                output *[RRSIG_BROKEN]*.
    3. Send the NS query over UDP.
-      1. If no DNS response is returned, then output
-         *[NO_RESPONSE]* and go to next name server IP address.
+      1. If no DNS response is returned, then go to next name server
+         IP address.
       2. Else, if the DNS response contains no NS record in the
-         answer section, then output *[NO_RESPONSE_RRSET]* and go to
-         next name server IP address.
+         answer section, then go to next name server IP address.
       3. Else, do:
          1. Extract all RRSIG records from the response.
          2. If there is no RRSIG for NS, then output
@@ -107,36 +115,33 @@ been created by a DNSKEY from the zone's DNSKEY RRset.
             1. If the key ID from the RRSIG is not a member of the
                set *DNSKEY Key ID*, then output
                *[RRSIG_NOT_MATCH_DNSKEY]* and go to next RRSIG.
-            2. If the RRSIG cannot be verified by the DNSKEY from
+            2. If the Zonemaster installation does not have support for
+               the algorithm that created the RRSIG, then add the
+               DNSKEY key tag and algorithm to the
+               *Unsupported Algorithm* set.
+            3. If the RRSIG cannot be verified by the DNSKEY from
                *DNSKEY Record* with the matching RRSIG key ID, then
                output *[RRSIG_BROKEN]*.
-6. If *DNSKEY Algorithm* is non-empty for at least some name server IP
-   addresses in *NS IP* and none of the following messages were
-   outputted, then output *[ALL_ALGO_SIGNED]*:
-   * *[ALGO_NOT_SIGNED_RRSET]*
-   * *[NO_RESPONSE_RRSET]*
-   * *[RRSET_NOT_SIGNED]*
-   * *[RRSIG_BROKEN]*
-   * *[RRSIG_NOT_MATCH_DNSKEY]*
 
+7. If the *Unsupported Algorithm* set is non-empty, then for each
+   DNSKEY key tag output *[DS13_ALGO_NOT_SUPPORTED_BY_ZM]* and print
+   algorithm and DNSKEY key tag.
 
 ## Outcome(s)
 
 The outcome of this Test Case is "fail" if there is at least one message
-with the severity level *ERROR* or *CRITICAL*.
+with the [severity level] *ERROR* or *CRITICAL*.
 
 The outcome of this Test Case is "warning" if there is at least one message
-with the severity level *WARNING*, but no message with severity level
+with the [severity level] *WARNING*, but no message with severity level
 *ERROR* or *CRITICAL*.
 
 In other cases the outcome of this Test Case is "pass".
 
-Message                       | Default severity level
+Message                       | Default [severity level]
 :-----------------------------|:-----------------------------------
 ALGO_NOT_SIGNED_RRSET         | WARNING
-ALL_ALGO_SIGNED               | INFO
-NO_RESPONSE                   | WARNING
-NO_RESPONSE_RRSET             | ERROR
+DS13_ALGO_NOT_SUPPORTED_BY_ZM | NOTICE
 RRSET_NOT_SIGNED              | ERROR
 RRSIG_BROKEN                  | ERROR
 RRSIG_NOT_MATCH_DNSKEY        | ERROR
@@ -152,20 +157,29 @@ See the [DNSSEC README] document about DNSSEC algorithms.
 
 Test case is only performed if DNSKEY records are found.
 
+It is assumed that [DNSSEC08] and [DNSSEC09] have reported on any
+unexpected errors on retreiving the DNSKEY records and SOA record,
+respectively, from *Child Zone*.
+
+It is assumed that there are no unexpected errors on retreiving the
+NS records from *Child Zone* that have not been reported by
+[Basic04], [DNSSEC08] and [DNSSEC08].
+
 ## Intercase dependencies
 
 None.
 
-[6840]:    https://tools.ietf.org/html/rfc6840#section-5.11
-[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
-[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-
-[ALGO_NOT_SIGNED_RRSET]:      #outcomes
-[ALL_ALGO_SIGNED]:            #outcomes
-[DNSSEC README]:              ./README.md
-[NO_RESPONSE]:                #outcomes
-[NO_RESPONSE_RRSET]:          #outcomes
-[RRSET_NOT_SIGNED]:           #outcomes
-[RRSIG_BROKEN]:               #outcomes
-[RRSIG_NOT_MATCH_DNSKEY]:     #outcomes
+[ALGO_NOT_SIGNED_RRSET]:                      #outcomes
+[Basic04]:                                    ../Basic-TP/basic014.md
+[DNSSEC README]:                              README.md
+[DNSSEC08]:                                   dnssec08.md
+[DNSSEC09]:                                   dnssec09.md
+[DS13_ALGO_NOT_SUPPORTED_BY_ZM]:              #outcomes
+[Method4]:                                    ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                                    ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[RFC 6840#section-5.11]:                      https://tools.ietf.org/html/rfc6840#section-5.11
+[RRSET_NOT_SIGNED]:                           #outcomes
+[RRSIG_BROKEN]:                               #outcomes
+[RRSIG_NOT_MATCH_DNSKEY]:                     #outcomes
+[Severity Level]:                             ../SeverityLevelDefinitions.md
 


### PR DESCRIPTION
* Removed messages for no response and similar problem
  when retreiving NS, SOA and DNSKEY records because
  they are already reported by other test cases.
* Added special messages when the Zonemaster implementation
  does not support the algorithm (resolves #832).
* Added references to other test cases that does relevant
  reporting.
* Removed the "all is fine" message since it is too complex
  and not needed.
* Introduced new logic that avoids reporting the same issue
  more than once.

When this has been merge, an issue must be created in Zonemaster-Engine to have the implementation updated.