### PR TITLE
Ubuntu databases version

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Debian 10        | 10.3            | 11.7
 FreeBSD 11.4     | 10.5.5 (###)    | 12.4
 FreeBSD 12.1     | 10.5.5 (###)    | 12.4
 Ubuntu 16.04     | 10.0            | 9.5
-Ubuntu 18.04     | 10.1            | 10.12
-Ubuntu 20.04     | 10.3 (#)        | 12.4 (#)
+Ubuntu 18.04     | 10.1            | 10.14
+Ubuntu 20.04     | 10.3            | 12.4
 
 ###) The latest stable in the highest release serie. There is no
 default version for MariaDB in FreeBSD.


### PR DESCRIPTION
For Ubuntu 18.04, the version of PostgreSQL is now `10.14`.

And the versions are correct for Ubuntu 20.04.