### PR TITLE
Fix merging develop into master

### DIFF
--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -254,10 +254,10 @@ Create a new branch named `merge-develop-into-master` with both *master* and
     git checkout -b merge-develop-into-master origin/develop
 
     # But on top of the history of the *master* branch
-    git reset origin/master
+    git reset --soft origin/master
 
     # With all differences squashed into a single commit
-    git commit -m 'Update master to state of develop' -i .
+    git commit -m 'Update master to state of develop'
 
     # And we want the history of *develop* merged too
     git merge origin/develop


### PR DESCRIPTION
The current steps to merge develop into master fail when new files have been added since last release. The steps fail because the `git commit --include` command only considers files tracked by the master branch. This leaves untracked files in the working tree that cause the final `git merge` command to fail.

The solution here is to make the `git reset` command keep all changes in the index. This ensures that the `git commit` command includes all the changes. The squashed commit will be complete and the working directory will be clean, clearing the way for the `git merge` command.