### PR TITLE
Create DNSSEC16 (Validate CDS) and DNSSEC17 (Validate CDNSKEY)

### DIFF
--- a/docs/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -49,9 +49,9 @@ DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed wi
 
 1.  Create the following empty sets:
     1.  Name server IP address and associated CDS RRset and its RRSIG
-        records ("CDS RRsets"). RRSIG records may be absent.
+        records ("CDS RRsets"). The set of RRSIG records may be empty.
     2.  Name server IP address and associated DNSKEY RRset and its 
-        RRsig records ("DNSKEY RRsets"). RRSIG records may be absent.
+        RRSIG records ("DNSKEY RRsets"). The set of RRSIG records may be empty.
     3.  Name server IP address ("No DNSKEY RRset").
     4.  Name server IP address ("Mixed Delete CDS").
     5.  Name server IP address ("Delete CDS").
@@ -107,15 +107,16 @@ DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed wi
 7.  For each name server IP in the *CDS RRsets* set do:
 
     1. If the CDS RRset is non-empty, get the RRset and its RRSIG
-       records, else go to next name server IP address.
+       records, else go to next name server IP address. The set of the RRSIG
+       records may be empty.
     2. If any CDS record is a "delete" CDS, then do:
        1. If there is more than a single CDS record then add the name
           server IP to the *Mixed Delete CDS* set.
        2. Else, add the name server IP address to the *Delete CDS*
           set.
        3. Go to next name server IP.
-    3. Get the DNSKEY and its RRSIG records, if any, from the
-       *DNSKEY RRsets* for the same name server IP.
+    3. Get the DNSKEY and its RRSIG records from the *DNSKEY RRsets* for the same
+       name server IP. The set of RRSIG records may be empty.
     4. If there are no DNSKEY records, then do:
        1. Add name server IP address to the *No DNSKEY RRset* set.
        2. Go to next name server IP.

--- a/docs/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -41,7 +41,7 @@ DS16_CDS_WITHOUT_DNSKEY              | ERROR   | CDS RRset exists, but no DNSKEY
 DS16_CDS_INVALID_RRSIG               | ERROR   | CDS RRset is signed with an invalid RRSIG.
 DS16_CDS_MATCHES_NO_DNSKEY           | WARNING | CDS record does not match any DNSKEY in DNSKEY RRset.
 DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY    | ERROR   | CDS RRset is signed but not by a key in DNSKEY RRset.
-DS16_DELETE_CDS                      | INFO    | CDS RRset have a "delete" CDS record as a single record.
+DS16_DELETE_CDS                      | INFO    | CDS RRset has a "delete" CDS record as a single record.
 DS16_DNSKEY_NOT_SIGNED_BY_CDS        | WARNING | DNSKEY RRset is not signed by the key or keys that the CDS records point to.
 DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed with normal CDS record.
 
@@ -178,7 +178,7 @@ The outcome of this Test Case is "fail" if there is at least one message
 with the severity level *[ERROR]* or *[CRITICAL]*.
 
 The outcome of this Test Case is "warning" if there is at least one message
-with the [severity level] *[WARNING]*, but no message with severity level
+with the severity level *[WARNING]*, but no message with severity level
 *ERROR* or *CRITICAL*.
 
 In other cases, no message or only messages with severity level 

--- a/docs/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -1,0 +1,340 @@
+# DNSSEC16: Validate CDS and CDNSKEY
+
+## Test case identifier
+**DNSSEC16**
+
+## Objective
+
+CDS and CDNSKEY record types are defined in [RFC 7344] and [RFC 8878].
+Both record types are optional in a zone. The objective of this test
+case is to verify that they are they are valid. This Test case is
+only relevant if the zone has either CDS or CDNSKEY record or both.
+
+If an CDS record is included in the zone, the corresponding CDNSKEY
+record should also be included ([RFC 7344][RFC 7344, section 4],
+section 4).
+
+The CNS and CDNSKEY RRsets should be consistent between all name
+servers for the zone in question.
+
+If there are both CDS RRs and CDNSKEY RRs in the zone they must match
+in content ([RFC 7344][RFC 7344, section 4], section 4). It means that
+both must be derived from the same DNSKEY or both being "delete" CDS
+and CDNSKEY.
+
+If a name server has issues covered by [Basic04] (basic name server
+issues) no messages will be outputted from this test case.
+
+It is assumed that the Child Zone has been tested by [DNSSEC15] and
+that the servers give the same responses.
+
+## Inputs
+
+* "Child Zone" - The domain name to be tested.
+
+## Summary
+* If no CDS or CDNSKEY is found, the test case is nor run.
+* [ERROR] message if there is no DNSKEY RRset.
+* [WARNING] message if a CDS record does not match any
+  DNSKEY in DNSKEY RRset (except for "delete" CDS).
+* [WARNING] message if a CDNSKEY record does not match any
+  DNSKEY in DNSKEY RRset (except for "delete" CDNSKEY).
+* [ERROR] message if CDS RRset is not signed.
+* [ERROR] message if CDNSKEY RRset is not signed.
+* [ERROR] message if CDS RRset is signed with an invalid RRSIG.
+* [ERROR] message if CDNSKEY RRset signed with an invalid RRSIG.
+* [ERROR] message if CDS RRset is signed but not by a key in DNSKEY
+  RRset.
+* [ERROR] message if CDNSKEY RRset is signed but not by a key in DNSKEY
+  RRset.
+* [WARNING] message if CDS RRset is signed by a key in the DNSKEY RRset
+  but not with one that has signed the DNSKEY RRset.
+* [WARNING] message if CDNSKEY RRset is signed by a key in the DNSKEY
+  RRset but not with one that has signed the DNSKEY RRset.
+* [INFO] message if CDS RRset have a "delete" CDS record as a single
+  record.
+* [INFO] message if CDNSKEY RRset have a "delete" CDNSKEY record as a
+  single record.
+* [ERROR] message if "delete" CDS record is mixed with normal CDS
+  record.
+* [ERROR] message if "delete" CDNSKEY record is mixed with normal
+  CDNSKEY record.
+
+## Ordered description of steps to be taken to execute the test case
+
+1.  Create a CDS query with EDNS enabled and the DO bit set for the
+    apex of the *Child Zone*.
+
+2.  Create a CDNSKEY query with EDNS enabled and the DO bit set for
+    the apex of the *Child Zone*.
+
+3.  Create a DNSKEY query with EDNS enabled and the DO bit set for
+    the apex of the *Child Zone*.
+
+4.  Retrieve all name server IP addresses for the *Child Zone* using
+    [Get-Del-NS-IPs] and [Get-Zone-NS-IPs] ("NS IP").
+
+5.  Create the following empty sets:
+    1.  Name server IP address and associated CDS RRset and its RRSIG
+        records ("CDS RRsets"). A name server IP can hold an empty 
+        RRset or no RRSIG records.
+    2.  Name server IP address and associated CDNSKEY RRset and its
+        RRSIG redords ("CDNSKEY RRsets"). A name server IP can hold an
+        empty RRset or no RRSIG records.
+    3.  Name server IP address and associated DNSKEY RRset and its 
+        RRsig records ("DNSKEY RRsets"). A name server IP can hold an empty
+        RRset or no RRSIG records.
+    4.  Name server IP address ("No DNSKEY RRset").
+    5.  Name server IP address ("Mixed Delete CDS").
+    6.  Name server IP address ("Delete CDS").
+    7.  Name server IP address and associated CDS key tag 
+        ("No Match CDS With DNSKEY").
+    8.  Name server IP address ("CDS Not Signed").
+    9.  Name server IP address and key tag 
+        ("CDS Signed Unknown DNSKEY").
+    10. Name server IP address and key tag ("CDS Invalid RRSIG").
+    11. Name server IP address and key tag
+        ("CDS RRSIG Not Signed DNSKEY").
+    12. Name server IP address ("Mixed Delete CDNSKEY").
+    13. Name server IP address ("Delete CDNSKEY").
+    14. Name server IP address and associated CDNSKEY key tag 
+        ("No Match CDNSKEY With DNSKEY").
+    15. Name server IP address ("CDNSKEY Not Signed").
+    16. Name server IP address and key tag 
+        ("CDNSKEY Signed Unknown DNSKEY").
+    17. Name server IP address and key tag ("CDNSKEY Invalid RRSIG").
+    18. Name server IP address and key tag
+        ("CDNSKEY RRSIG Not Signed DNSKEY").
+
+6.  Repeat the following steps for each name server IP address in 
+    *NS IP*:
+
+    1. Send the CDS query over UDP to the name server IP address.
+       1. If no DNS response is returned, then go to next name server 
+          IP.
+       2. Else, if AA bit is not set in the DNS response, then go to
+          next name server IP.
+       3. Else, if the RCODE in the DNS response is not *NOERROR*, then
+          go to next name server IP.
+       4. Else, if the DNS response contains at least one CDS record
+          in the answer section, then add the name server IP and the
+          CDS RRset to the *CDS RRsets* set. Also include any assciated
+          RRSIG records.
+    2. Send the CDNSKEY query over UDP to the name server IP address.
+       1. If no DNS response is returned, then go to next name server
+          IP.
+       2. Else, if AA bit is not set in the DNS response, then go to
+          next name server IP.
+       3. Else, if the RCODE in the DNS response is not *NOERROR*, then
+          go to next name server IP.
+       4. Else, if the DNS response contains at least one CDNSKEY
+          record in the answer section, then add the name server IP and
+          the CDNSKEY RRset from the answer section to the 
+          *CDNSKEY RRsets* set. Also include any assciated RRSIG records.
+    3. Send the DNSKEY query over UDP to the name server IP address.
+       1. If no DNS response is returned, then go to next name server
+          IP.
+       2. Else, if AA bit is not set in the DNS response, then go to
+          next name server IP.
+       3. Else, if the RCODE in the DNS response is not *NOERROR*, then
+          go to next name server IP.
+       4. Else, if the DNS response contains at least one DNSKEY
+          record in the answer section, then add the name server IP and
+          the CDNSKEY RRset from the answer section to the 
+          *DNSKEY RRsets* set. Also include any assciated RRSIG records.
+    4. Go to next name server IP.
+
+7.  If neither of the *CDS RRsets* and *CDNSKEY RRsets* sets,
+    respectively, has any RRset then terminate this test case.
+
+8.  For each name server IP in the *CDS RRsets* set do:
+
+    1. Extract the CDS and its RRSIG records, if any.
+    2. If any CDS record is a "delete" CDS, then do:
+       1. If there is more than a single CDS record then add the name
+          server IP to the *Mixed Delete CDS* set.
+       2. Else, add the name server IP address to the *Delete CDS*
+          set.
+       2. Go to next name server IP.
+    3. Extract the DNSKEY and its RRSIG records, if any, from the 
+       *DNSKEY RRsets* for the same name server IP.
+    4. If there are no DNSKEY records, then do:
+       1. Add name server IP address to the *No DNSKEY RRset* set.
+       2. Go to next name server IP.
+    5. Repeat the following steps for each CDS record:
+       1. Compare the key tag from the CDS record with the caculated
+          key tags for the DNSKEY records.
+       2. If the CDS record does not match any DNSKEY record then add
+          the name server IP address and key tag to 
+          *No Match CDS With DNSKEY*.
+    6. If there are no RRSIG records for the CDS RRset, then add the
+       name server IP address to the *CDS Not Signed* set.
+    7. Else, for each RRSIG (CDS) do:
+       1. If the key tag of the RRSIG does not match any DNSKEY then
+          add the name server IP address and key tag to the
+          *CDS Signed Unknown DNSKEY* set.
+       2. Else, if the RRSIG cannot be validated by the DNSKEY it
+          refers to by key tag, then add the name server IP and RRSIG
+          key tag to the *CDS Invalid RRSIG* set.
+       3. Else, if there is no RRSIG (DNSKEY) created by the same
+          DNSKEY then add the name serve IP address and the DNSKEY key
+          tag to the *CDS RRSIG Not Signed DNSKEY* set.
+    8. Go to next name server IP address.
+
+9.  For each name server IP in the *CDNSKEY RRsets* set do:
+
+    1. Extract the CDNSKEY and its RRSIG records, if any.
+    2. If any CDNSKEY record is a "delete" CDNSKEY, then do:
+       1. If there is more than a single CDNSKEY record then add the
+          name server IP to the *Mixed Delete CDNSKEY* set.
+       2. Else, add the name server IP address to the *Delete CDNSKEY*
+          set.
+       2. Go to next name server IP.
+    3. Extract the DNSKEY and its RRSIG records, if any, from the 
+       *DNSKEY RRsets* for the same name server IP.
+    4. If there are no DNSKEY records, then do:
+       1. Add name server IP address to the *No DNSKEY RRset* set
+          (duplicates not possible).
+       2. Go to next name server IP.
+    5. Repeat the following steps for each CDNSKEY record:
+       1. Compare the CDNSKEY record with the DNSKEY records.
+       2. If the CDNSKEY record does not match any DNSKEY record then
+          add the name server IP address and key tag to 
+          *No Match CDNSKEY With DNSKEY*.
+    6. If there are no RRSIG records for the CDNSKEY RRset, then add
+       the name server IP address to the *CDNSKEY Not Signed* set.
+    7. Else, for each RRSIG (CDNSKEY) do:
+       1. If the key tag of the RRSIG does not match any DNSKEY then
+          add the name server IP address and key tag to the
+          *CDNSKEY Signed Unknown DNSKEY* set.
+       2. Else, if the RRSIG cannot be validated by the DNSKEY it
+          refers to by key tag, then add the name server IP and RRSIG
+          key tag to the *CDNSKEY Invalid RRSIG* set.
+       3. Else, if there is no RRSIG (DNSKEY) created by the same
+          DNSKEY then add the name serve IP address and the DNSKEY key
+          tag to the *CDNSKEY RRSIG Not Signed DNSKEY* set.
+    8. Go to next name server IP address.
+
+10. If the *No DNSKEY RRset* set is non-empty, then output
+    *[DS16_CDS_CDNSKEY_WITHOUT_DNSKEY]* with all name server IP addresses
+    in the set.
+
+11. If the *Mixed Delete CDS* set or the *Mixed Delete CDNSKEY* set is
+    non-empty, then output *[DS16_MIXED_DELETE_CDS_CDNSKEY]* with all
+    name server IP addresses in the two sets.
+
+12. If the *Delete CDS* set is non-empty, then output
+    *[DS16_DELETE_CDS]* with all name server IP addresses.
+
+13. If the *Delete CDNSKEY* set is non-empty then output
+    *[DS16_DELETE_CDNSKEY]* with all name server IP addresses.
+
+14. If the *No Match CDS With DNSKEY* set is non-empty then for each
+    key tag in the set output *[DS16_CDS_MATCHES_NO_DNSKEY]* with the
+    CDS key tag and the name server IP addresses in the set per key
+    tag.
+
+15. If the *No Match CDNSKEY With DNSKEY* set is non-empty then for
+    each key tag in the set output *[DS16_CDNSKEY_MATCHES_NO_DNSKEY]*
+    with the CDNSKEY key tag and the name server IP addresses in the
+    set per key tag.
+
+16. If the *CDS Not Signed* set or the *CDNSKEY Not Signed* set is
+    non-empty then output *[DS16_CDS_CDNSKEY_UNSIGNED]* with all
+    name server IP addresses in the two sets.
+
+17. If the *CDS Signed Unknown DNSKEY* set is non-empty then output
+    *[DS16_CDS_SIGNED_UNKNOWN_DNSKEY]* with the name server IP
+    addresses in the set.
+
+18. If the *CDNSKEY Signed Unknown DNSKEY* set is non-empty then
+    output *[DS16_CDNSKEY_SIGNED_UNKNOWN_DNSKEY]* with the name server
+    IP addresses in the set.
+
+19. If the *CDS Invalid RRSIG* set is non-empty then for each key tag
+    in the set output *[DS16_CDS_INVALID_RRSIG]* with the RRSIG key
+    tag and the name server IP addresses in the set per key tag.
+
+20. If the *CDNSKEY Invalid RRSIG* set is non-empty then for each key
+    tag in the set output *[DS16_CDNSKEY_INVALID_RRSIG]* with the RRSIG
+    key tag and the name server IP addresses in the set per key tag.
+
+21. If the *CDS RRSIG Not Signed DNSKEY* set is non-empty then for
+    each key tag in the set output *[DS16_CDS_RRSIG_NOT_SIGNED_DNSKEY]*
+    with the RRSIG key tag and the name server IP addresses in the set
+    per key tag.
+
+21. If the *CDNSKEY RRSIG Not Signed DNSKEY* set is non-empty then for
+    each key tag in the set output 
+    *[DS16_CDNSKEY_RRSIG_NOT_SIGNED_DNSKEY]* with the RRSIG key tag and
+    the name server IP addresses in the set per key tag.
+
+## Outcome(s)
+
+The outcome of this Test Case is "fail" if there is at least one message
+with the [severity level] *ERROR* or *CRITICAL*.
+
+The outcome of this Test Case is "warning" if there is at least one message
+with the [severity level] *WARNING*, but no message with severity level
+*ERROR* or *CRITICAL*.
+
+In other cases the outcome of this Test Case is "pass".
+
+Message                              | Default [severity level]
+:------------------------------------|:-----------------------------------
+DS16_CDNSKEY_INVALID_RRSIG           | ERROR
+DS16_CDNSKEY_MATCHES_NO_DNSKEY       | WARNING
+DS16_CDNSKEY_RRSIG_NOT_SIGNED_DNSKEY | WARNING
+DS16_CDNSKEY_SIGNED_UNKNOWN_DNSKEY   | ERROR
+DS16_CDS_CDNSKEY_UNSIGNED            | ERROR
+DS16_CDS_CDNSKEY_WITHOUT_DNSKEY      | ERROR
+DS16_CDS_INVALID_RRSIG               | ERROR
+DS16_CDS_MATCHES_NO_DNSKEY           | WARNING
+DS16_CDS_RRSIG_NOT_SIGNED_DNSKEY     | WARNING
+DS16_CDS_SIGNED_UNKNOWN_DNSKEY       | ERROR
+DS16_DELETE_CDNSKEY                  | INFO
+DS16_DELETE_CDS                      | INFO
+DS16_MIXED_DELETE_CDS_CDNSKEY        | ERROR
+
+
+
+## Special procedural requirements
+
+If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
+result of any test using this transport protocol. Log a message reporting
+the ignored protocol.
+
+## Intercase dependencies
+
+None.
+
+
+[Basic04]:                               ../Basic-TP/basic04.md
+[DNSSEC15]:                              dnssec15.md
+[DS16_CDNSKEY_INVALID_RRSIG]:            #outcomes
+[DS16_CDNSKEY_MATCHES_NO_DNSKEY]:        #outcomes
+[DS16_CDNSKEY_RRSIG_NOT_SIGNED_DNSKEY]:  #outcomes
+[DS16_CDNSKEY_SIGNED_UNKNOWN_DNSKEY]:    #outcomes
+[DS16_CDS_CDNSKEY_UNSIGNED]:             #outcomes
+[DS16_CDS_CDNSKEY_WITHOUT_DNSKEY]:       #outcomes
+[DS16_CDS_INVALID_RRSIG]:                #outcomes
+[DS16_CDS_MATCHES_NO_DNSKEY]:            #outcomes
+[DS16_CDS_RRSIG_NOT_SIGNED_DNSKEY]:      #outcomes
+[DS16_CDS_SIGNED_UNKNOWN_DNSKEY]:        #outcomes
+[DS16_DELETE_CDNSKEY]:                   #outcomes
+[DS16_DELETE_CDS]:                       #outcomes
+[DS16_MIXED_DELETE_CDS_CDNSKEY]:         #outcomes
+[ERROR]:                                 #outcomes
+[Get-Del-NS-IPs]:                        https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/MethodsNT.md#method-get-delegation-ns-ip-addresses
+[Get-Zone-NS-IPs]:                       https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/MethodsNT.md#method-get-zone-ns-ip-addresses
+[INFO]:                                  #outcomes
+[NOTICE]:                                #outcomes
+[RFC 7344, section 4]:                   https://tools.ietf.org/html/rfc7344#section-4
+[RFC 7344]:                              https://tools.ietf.org/html/rfc7344
+[RFC 8878]:                              https://tools.ietf.org/html/rfc8078
+[Severity Level]:                        ../SeverityLevelDefinitions.md
+[WARNING]:                               #outcomes
+
+
+
+

--- a/docs/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -1,4 +1,4 @@
-# DNSSEC16: Validate CDS and CDNSKEY
+# DNSSEC16: Validate CDS
 
 ## Test case identifier
 **DNSSEC16**
@@ -7,20 +7,9 @@
 
 CDS and CDNSKEY record types are defined in [RFC 7344] and [RFC 8078].
 Both record types are optional in a zone. The objective of this test
-case is to verify that they are are valid. This Test case is
-only relevant if the zone has either CDS or CDNSKEY record or both.
-
-If a CDS record is included in the zone, the corresponding CDNSKEY
-record should also be included ([RFC 7344][RFC 7344, section 4],
-section 4).
-
-The CNS and CDNSKEY RRsets should be consistent between all name
-servers for the zone in question.
-
-If there are both CDS RRs and CDNSKEY RRs in the zone they must match
-in content ([RFC 7344][RFC 7344, section 4], section 4). It means that
-both must be derived from the same DNSKEY or both being "delete" CDS
-and CDNSKEY.
+case is to verify that the CDS RRset is valid. This test case is
+only relevant if the zone has at least on CDS record. For tests of the
+CDNSKEY, see test case [DNSSEC17].
 
 ## Scope
 
@@ -28,10 +17,11 @@ It is assumed that *Child Zone* has been tested by [Basic04]. This test
 case will just ignore non-responsive name servers or name servers not
 giving a correct DNS response for an authoritative name server.
 
-It is assumed that *Child Zone* has been tested by [DNSSEC15] and
-that the servers give the same responses. Running this test case
-without running [DNSSEC15], before or after, can give an incomplete
-report of CDS and CDNSKEY status of *Child Zone*.
+It is assumed that *Child Zone* has been tested or will be tested by 
+[DNSSEC15] and [DNSSEC17] and that the servers give the same responses.
+Running this test case without running [DNSSEC15] and [DNSSEC17] can
+give an incomplete report of the CDS and CDNSKEY status of 
+*Child Zone*.
 
 ## Inputs
 
@@ -39,80 +29,55 @@ report of CDS and CDNSKEY status of *Child Zone*.
 
 ## Summary
 
-* If no CDS or CDNSKEY is found, the test case will terminate early
+* If no CDS record is found, the test case will terminate early
   with no message tag outputted.
-* In the table below, "CDS (CDNSKEY)" means "CDS" or "CDNSKEY" or both,
-  as applicable.
-* If a CDS or CDNSKEY record is of "delete" type, then it can by
-  definition not match or point at any DNSKEY record.
+* If a CDS record is of "delete" type, then it can by definition not
+  match or point at any DNSKEY record.
 
 Message Tag outputted                | [Default level] | Description of when message tag is outputted
 :------------------------------------|:--------|:-----------------------------------------
-DS16_CDNSKEY_INVALID_RRSIG           | ERROR   | CDNSKEY RRset signed with an invalid RRSIG.
-DS16_CDNSKEY_MATCHES_NO_DNSKEY       | WARNING | CDNSKEY record does not match any DNSKEY in DNSKEY RRset.
-DS16_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY| ERROR   | CDNSKEY RRset is signed but not by a key in DNSKEY RRset.
-DS16_CDS_CDNSKEY_UNSIGNED            | ERROR   | CDS (CDNSKEY) RRset is not signed.
-DS16_CDS_CDNSKEY_WITHOUT_DNSKEY      | ERROR   | CDS (CDNSKEY) RRset exists, but no DNSKEY RRset.
+DS16_CDS_UNSIGNED                    | ERROR   | CDS RRset is not signed.
+DS16_CDS_WITHOUT_DNSKEY              | ERROR   | CDS RRset exists, but no DNSKEY RRset.
 DS16_CDS_INVALID_RRSIG               | ERROR   | CDS RRset is signed with an invalid RRSIG.
 DS16_CDS_MATCHES_NO_DNSKEY           | WARNING | CDS record does not match any DNSKEY in DNSKEY RRset.
 DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY    | ERROR   | CDS RRset is signed but not by a key in DNSKEY RRset.
-DS16_DELETE_CDNSKEY                  | INFO    | CDNSKEY RRset have a "delete" CDNSKEY record as a single record.
 DS16_DELETE_CDS                      | INFO    | CDS RRset have a "delete" CDS record as a single record.
-DS16_DNSKEY_NOT_SIGNED_BY_CDNSKEY    | WARNING | DNSKEY RRset is not signed by the key or keys that the CDNSKEY records point to.
 DS16_DNSKEY_NOT_SIGNED_BY_CDS        | WARNING | DNSKEY RRset is not signed by the key or keys that the CDS records point to.
-DS16_MIXED_DELETE_CDS_CDNSKEY        | ERROR   | "Delete" CDS (CDNSKEY) record is mixed with normal CDS (CDNSKEY) record.
+DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed with normal CDS record.
 
 ## Ordered description of steps to be taken to execute the test case
 
 1.  Create a CDS query with EDNS enabled and the DO bit set for the
     apex of the *Child Zone*.
 
-2.  Create a CDNSKEY query with EDNS enabled and the DO bit set for
+2.  Create a DNSKEY query with EDNS enabled and the DO bit set for
     the apex of the *Child Zone*.
 
-3.  Create a DNSKEY query with EDNS enabled and the DO bit set for
-    the apex of the *Child Zone*.
-
-4.  Retrieve all name server IP addresses for the *Child Zone* using
+3.  Retrieve all name server IP addresses for the *Child Zone* using
     [Method4] and [Method5] ("NS IP").
 
-5.  Create the following empty sets:
+4.  Create the following empty sets:
     1.  Name server IP address and associated CDS RRset and its RRSIG
-        records ("CDS RRsets"). A name server IP may hold an empty
-        RRset or no RRSIG records.
-    2.  Name server IP address and associated CDNSKEY RRset and its
-        RRSIG redords ("CDNSKEY RRsets"). A name server IP may hold an
-        empty RRset or no RRSIG records.
-    3.  Name server IP address and associated DNSKEY RRset and its 
-        RRsig records ("DNSKEY RRsets"). A name server IP may hold an empty
-        RRset or no RRSIG records.
-    4.  Name server IP address ("No DNSKEY RRset").
-    5.  Name server IP address ("Mixed Delete CDS").
-    6.  Name server IP address ("Delete CDS").
-    7.  Name server IP address and associated CDS key tag 
+        records ("CDS RRsets"). RRSIG records may be absent.
+    2.  Name server IP address and associated DNSKEY RRset and its 
+        RRsig records ("DNSKEY RRsets"). RRSIG records may be absent.
+    3.  Name server IP address ("No DNSKEY RRset").
+    4.  Name server IP address ("Mixed Delete CDS").
+    5.  Name server IP address ("Delete CDS").
+    6.  Name server IP address and associated CDS key tag 
         ("No Match CDS With DNSKEY").
-    8.  Name server IP address and associated CDS key tag
+    7.  Name server IP address and associated CDS key tag
         ("DNSKEY Not Signed By CDS").
-    9.  Name server IP address ("CDS Not Signed").
-    10. Name server IP address and key tag
+    8.  Name server IP address ("CDS Not Signed").
+    9.  Name server IP address and key tag
         ("CDS Signed By Unknown DNSKEY").
-    11. Name server IP address and key tag ("CDS Invalid RRSIG").
-    12. Name server IP address ("Mixed Delete CDNSKEY").
-    13. Name server IP address ("Delete CDNSKEY").
-    14. Name server IP address and associated CDNSKEY key tag 
-        ("No Match CDNSKEY With DNSKEY").
-    15. Name server IP address and key tag
-        ("DNSKEY Not Signed By CDNSKEY").
-    16. Name server IP address ("CDNSKEY Not Signed").
-    17. Name server IP address and key tag
-        ("CDNSKEY Signed By Unknown DNSKEY").
-    18. Name server IP address and key tag ("CDNSKEY Invalid RRSIG").
+    10. Name server IP address and key tag ("CDS Invalid RRSIG").
 
-6.  Repeat the following steps for each name server IP address in 
+5.  Repeat the following steps for each name server IP address in 
     *NS IP*:
 
     1. Send the CDS query over UDP to the name server IP address.
-       1. If no DNS response is returned, then go to next name server 
+       1. If no DNS response is returned, then go to next name server
           IP.
        2. Else, if AA bit is not set in the DNS response, then go to
           next name server IP.
@@ -122,18 +87,9 @@ DS16_MIXED_DELETE_CDS_CDNSKEY        | ERROR   | "Delete" CDS (CDNSKEY) record i
           in the answer section, then add the name server IP and the
           CDS RRset to the *CDS RRsets* set. Also include any associated
           RRSIG records.
-    2. Send the CDNSKEY query over UDP to the name server IP address.
-       1. If no DNS response is returned, then go to next name server
-          IP.
-       2. Else, if AA bit is not set in the DNS response, then go to
-          next name server IP.
-       3. Else, if the RCODE in the DNS response is not *NOERROR*, then
-          go to next name server IP.
-       4. Else, if the DNS response contains at least one CDNSKEY
-          record in the answer section, then add the name server IP and
-          the CDNSKEY RRset from the answer section to the 
-          *CDNSKEY RRsets* set. Also include any associated RRSIG records.
-    3. Send the DNSKEY query over UDP to the name server IP address.
+       5. Else, if the answer section has no CDS records, go to next
+          name server IP.
+    2. Send the DNSKEY query over UDP to the name server IP address.
        1. If no DNS response is returned, then go to next name server
           IP.
        2. Else, if AA bit is not set in the DNS response, then go to
@@ -142,16 +98,16 @@ DS16_MIXED_DELETE_CDS_CDNSKEY        | ERROR   | "Delete" CDS (CDNSKEY) record i
           go to next name server IP.
        4. Else, if the DNS response contains at least one DNSKEY
           record in the answer section, then add the name server IP and
-          the CDNSKEY RRset from the answer section to the 
+          the DNSKEY RRset from the answer section to the 
           *DNSKEY RRsets* set. Also include any associated RRSIG records.
-    4. Go to next name server IP.
+    3. Go to next name server IP.
 
-7.  If neither of the *CDS RRsets* and *CDNSKEY RRsets* sets,
-    respectively, has any RRset then terminate this test case.
+6.  If the *CDS RRsets* set is empty then terminate this test case.
 
-8.  For each name server IP in the *CDS RRsets* set do:
+7.  For each name server IP in the *CDS RRsets* set do:
 
-    1. Get the CDS and its RRSIG records, if any.
+    1. If the CDS RRset is non-empty, get the RRset and its RRSIG
+       records, else go to next name server IP address.
     2. If any CDS record is a "delete" CDS, then do:
        1. If there is more than a single CDS record then add the name
           server IP to the *Mixed Delete CDS* set.
@@ -167,7 +123,7 @@ DS16_MIXED_DELETE_CDS_CDNSKEY        | ERROR   | "Delete" CDS (CDNSKEY) record i
        1. Compare the key tag from the CDS record with the calculated
           key tags for the DNSKEY records.
        2. If the CDS record does not match any DNSKEY record then add
-          the name server IP address and key tag to 
+          the name server IP address and key tag to the
           *No Match CDS With DNSKEY* set.
        3. Else, if there is no RRSIG for the DNSKEY RRset created by
           the DNSKEY record that the CDS record points at then add the
@@ -184,105 +140,49 @@ DS16_MIXED_DELETE_CDS_CDNSKEY        | ERROR   | "Delete" CDS (CDNSKEY) record i
           key tag to the *CDS Invalid RRSIG* set.
     8. Go to next name server IP address.
 
-9.  For each name server IP in the *CDNSKEY RRsets* set do:
-
-    1. Get the CDNSKEY and its RRSIG records, if any.
-    2. If any CDNSKEY record is a "delete" CDNSKEY, then do:
-       1. If there is more than a single CDNSKEY record then add the
-          name server IP to the *Mixed Delete CDNSKEY* set.
-       2. Else, add the name server IP address to the *Delete CDNSKEY*
-          set.
-       2. Go to next name server IP.
-    3. Get the DNSKEY and its RRSIG records, if any, from the
-       *DNSKEY RRsets* for the same name server IP.
-    4. If there are no DNSKEY records, then do:
-       1. Add name server IP address to the *No DNSKEY RRset* set
-          (duplicates not possible).
-       2. Go to next name server IP.
-    5. Repeat the following steps for each CDNSKEY record:
-       1. Compare the CDNSKEY record with the DNSKEY records.
-       2. If the CDNSKEY record does not match any DNSKEY record then
-          add the name server IP address and key tag to 
-          *No Match CDNSKEY With DNSKEY* set.
-       3. Else, if there is no RRSIG for the DNSKEY RRset created by
-          the DNSKEY record matching the CDNSKEY record then add the
-          name server IP address and key tag of CDNSKEY record to the
-          *DNSKEY Not Signed By CDNSKEY* set.
-    6. If there are no RRSIG records for the CDNSKEY RRset, then add
-       the name server IP address to the *CDNSKEY Not Signed* set.
-    7. Else, for each RRSIG (CDNSKEY) do:
-       1. If the key tag of the RRSIG does not match any DNSKEY then
-          add the name server IP address and key tag to the
-          *CDNSKEY Signed By Unknown DNSKEY* set.
-       2. Else, if the RRSIG cannot be validated by the DNSKEY it
-          refers to by key tag, then add the name server IP and RRSIG
-          key tag to the *CDNSKEY Invalid RRSIG* set.
-    8. Go to next name server IP address.
-
-10. If the *No DNSKEY RRset* set is non-empty, then output
-    *[DS16_CDS_CDNSKEY_WITHOUT_DNSKEY]* with all name server IP addresses
+8.  If the *No DNSKEY RRset* set is non-empty, then output
+    *[DS16_CDS_WITHOUT_DNSKEY]* with all name server IP addresses
     in the set.
 
-11. If the *Mixed Delete CDS* set or the *Mixed Delete CDNSKEY* set is
-    non-empty, then output *[DS16_MIXED_DELETE_CDS_CDNSKEY]* with all
-    name server IP addresses in the two sets.
+9.  If the *Mixed Delete CDS* set is
+    non-empty, then output *[DS16_MIXED_DELETE_CDS]* with all
+    name server IP addresses in the set.
 
-12. If the *Delete CDS* set is non-empty, then output
+10. If the *Delete CDS* set is non-empty, then output
     *[DS16_DELETE_CDS]* with all name server IP addresses.
 
-13. If the *Delete CDNSKEY* set is non-empty then output
-    *[DS16_DELETE_CDNSKEY]* with all name server IP addresses.
-
-14. If the *No Match CDS With DNSKEY* set is non-empty then for each
+11. If the *No Match CDS With DNSKEY* set is non-empty then for each
     key tag in the set output *[DS16_CDS_MATCHES_NO_DNSKEY]* with the
     CDS key tag and the name server IP addresses in the set per key
     tag.
 
-15. If the *No Match CDNSKEY With DNSKEY* set is non-empty then for
-    each key tag in the set output *[DS16_CDNSKEY_MATCHES_NO_DNSKEY]*
-    with the CDNSKEY key tag and the name server IP addresses in the
-    set per key tag.
-
-16. If the *DNSKEY Not Signed By CDS* set is non-empty then for
+12. If the *DNSKEY Not Signed By CDS* set is non-empty then for
     each key tag in the set output *[DS16_DNSKEY_NOT_SIGNED_BY_CDS]*
     with the RRSIG key tag and the name server IP addresses in the set
     per key tag.
 
-17. If the *DNSKEY Not Signed By CDNSKEY* set is non-empty then for
-    each key tag in the set output
-    *[DS16_DNSKEY_NOT_SIGNED_BY_CDNSKEY]* with the RRSIG key tag and
-    the name server IP addresses in the set per key tag.
+13. If the *CDS Not Signed* set is non-empty then output 
+    *[DS16_CDS_UNSIGNED]* with all name server IP addresses in the set.
 
-18. If the *CDS Not Signed* set or the *CDNSKEY Not Signed* set is
-    non-empty then output *[DS16_CDS_CDNSKEY_UNSIGNED]* with all
-    name server IP addresses in the two sets.
-
-19. If the *CDS Signed By Unknown DNSKEY* set is non-empty then output
+14. If the *CDS Signed By Unknown DNSKEY* set is non-empty then output
     *[DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY]* with the name server IP
     addresses in the set.
 
-20. If the *CDNSKEY Signed By Unknown DNSKEY* set is non-empty then
-    output *[DS16_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY]* with the name server
-    IP addresses in the set.
-
-21. If the *CDS Invalid RRSIG* set is non-empty then for each key tag
+15. If the *CDS Invalid RRSIG* set is non-empty then for each key tag
     in the set output *[DS16_CDS_INVALID_RRSIG]* with the RRSIG key
     tag and the name server IP addresses in the set per key tag.
-
-22. If the *CDNSKEY Invalid RRSIG* set is non-empty then for each key
-    tag in the set output *[DS16_CDNSKEY_INVALID_RRSIG]* with the RRSIG
-    key tag and the name server IP addresses in the set per key tag.
 
 ## Outcome(s)
 
 The outcome of this Test Case is "fail" if there is at least one message
-with the [severity level] *ERROR* or *CRITICAL*.
+with the severity level *[ERROR]* or *[CRITICAL]*.
 
 The outcome of this Test Case is "warning" if there is at least one message
-with the [severity level] *WARNING*, but no message with severity level
+with the [severity level] *[WARNING]*, but no message with severity level
 *ERROR* or *CRITICAL*.
 
-In other cases the outcome of this Test Case is "pass".
+In other cases, no message or only messages with severity level 
+*[INFO]* or *[NOTICE]*, the outcome of this Test Case is "pass".
 
 ## Special procedural requirements
 
@@ -296,28 +196,25 @@ None.
 
 
 [Basic04]:                               ../Basic-TP/basic04.md
+[CRITICAL]:                              ../SeverityLevelDefinitions.md#critical
 [DNSSEC15]:                              dnssec15.md
-[DS16_CDNSKEY_INVALID_RRSIG]:            #summary
-[DS16_CDNSKEY_MATCHES_NO_DNSKEY]:        #summary
-[DS16_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY]: #summary
-[DS16_CDS_CDNSKEY_UNSIGNED]:             #summary
-[DS16_CDS_CDNSKEY_WITHOUT_DNSKEY]:       #summary
+[DNSSEC17]:                              dnssec17.md
 [DS16_CDS_INVALID_RRSIG]:                #summary
 [DS16_CDS_MATCHES_NO_DNSKEY]:            #summary
 [DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY]:     #summary
-[DS16_DELETE_CDNSKEY]:                   #summary
+[DS16_CDS_UNSIGNED]:                     #summary
+[DS16_CDS_WITHOUT_DNSKEY]:               #summary
 [DS16_DELETE_CDS]:                       #summary
-[DS16_DNSKEY_NOT_SIGNED_BY_CDNSKEY]:     #summary
 [DS16_DNSKEY_NOT_SIGNED_BY_CDS]:         #summary
-[DS16_MIXED_DELETE_CDS_CDNSKEY]:         #summary
+[DS16_MIXED_DELETE_CDS]:                 #summary
 [Default level]:                         ../SeverityLevelDefinitions.md
-[ERROR]:                                 #summary
+[ERROR]:                                 ../SeverityLevelDefinitions.md#error
+[INFO]:                                  ../SeverityLevelDefinitions.md#info
 [Method4]:                               ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]:                               ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NOTICE]:                                ../SeverityLevelDefinitions.md#notice
 [RFC 7344, section 4]:                   https://tools.ietf.org/html/rfc7344#section-4
 [RFC 7344]:                              https://tools.ietf.org/html/rfc7344
 [RFC 8078]:                              https://tools.ietf.org/html/rfc8078
-
-
-
+[WARNING]:                               ../SeverityLevelDefinitions.md#warning
 

--- a/docs/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -5,7 +5,7 @@
 
 ## Objective
 
-CDS and CDNSKEY record types are defined in [RFC 7344] and [RFC 8878].
+CDS and CDNSKEY record types are defined in [RFC 7344] and [RFC 8078].
 Both record types are optional in a zone. The objective of this test
 case is to verify that they are they are valid. This Test case is
 only relevant if the zone has either CDS or CDNSKEY record or both.
@@ -33,7 +33,7 @@ that the servers give the same responses.
 * "Child Zone" - The domain name to be tested.
 
 ## Summary
-* If no CDS or CDNSKEY is found, the test case is nor run.
+* If no CDS or CDNSKEY is found, the test case is not run.
 * [ERROR] message if there is no DNSKEY RRset.
 * [WARNING] message if a CDS record does not match any
   DNSKEY in DNSKEY RRset (except for "delete" CDS).
@@ -331,7 +331,7 @@ None.
 [NOTICE]:                                #outcomes
 [RFC 7344, section 4]:                   https://tools.ietf.org/html/rfc7344#section-4
 [RFC 7344]:                              https://tools.ietf.org/html/rfc7344
-[RFC 8878]:                              https://tools.ietf.org/html/rfc8078
+[RFC 8078]:                              https://tools.ietf.org/html/rfc8078
 [Severity Level]:                        ../SeverityLevelDefinitions.md
 [WARNING]:                               #outcomes
 

--- a/docs/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -38,31 +38,29 @@ report of CDS and CDNSKEY status of *Child Zone*.
 * "Child Zone" - The domain name to be tested.
 
 ## Summary
+
 * If no CDS or CDNSKEY is found, the test case will terminate early
-  with no message.
-* [ERROR] message if there is no DNSKEY RRset.
-* [WARNING] message if a CDS record does not match any
-  DNSKEY in DNSKEY RRset (except for "delete" CDS).
-* [WARNING] message if a CDNSKEY record does not match any
-  DNSKEY in DNSKEY RRset (except for "delete" CDNSKEY).
-* [WARNING] message if the DNSKEY RRset is not signed by the key or
-  keys that the CDS and CDNSKEY records point to.
-* [ERROR] message if CDS RRset is not signed.
-* [ERROR] message if CDNSKEY RRset is not signed.
-* [ERROR] message if CDS RRset is signed with an invalid RRSIG.
-* [ERROR] message if CDNSKEY RRset signed with an invalid RRSIG.
-* [ERROR] message if CDS RRset is signed but not by a key in DNSKEY
-  RRset.
-* [ERROR] message if CDNSKEY RRset is signed but not by a key in DNSKEY
-  RRset.
-* [INFO] message if CDS RRset have a "delete" CDS record as a single
-  record.
-* [INFO] message if CDNSKEY RRset have a "delete" CDNSKEY record as a
-  single record.
-* [ERROR] message if "delete" CDS record is mixed with normal CDS
-  record.
-* [ERROR] message if "delete" CDNSKEY record is mixed with normal
-  CDNSKEY record.
+  with no message tag outputted.
+* In the table below, "CDS (CDNSKEY)" means "CDS" or "CDNSKEY" or both,
+  as applicable.
+* If a CDS or CDNSKEY record is of "delete" type, then it can by
+  definition not match or point at any DNSKEY record.
+
+Message Tag outputted                | [Default level] | Description of when message tag is outputted
+:------------------------------------|:--------|:-----------------------------------------
+DS16_CDNSKEY_INVALID_RRSIG           | ERROR   | CDNSKEY RRset signed with an invalid RRSIG.
+DS16_CDNSKEY_MATCHES_NO_DNSKEY       | WARNING | CDNSKEY record does not match any DNSKEY in DNSKEY RRset.
+DS16_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY| ERROR   | CDNSKEY RRset is signed but not by a key in DNSKEY RRset.
+DS16_CDS_CDNSKEY_UNSIGNED            | ERROR   | CDS (CDNSKEY) RRset is not signed.
+DS16_CDS_CDNSKEY_WITHOUT_DNSKEY      | ERROR   | CDS (CDNSKEY) RRset exists, but no DNSKEY RRset.
+DS16_CDS_INVALID_RRSIG               | ERROR   | CDS RRset is signed with an invalid RRSIG.
+DS16_CDS_MATCHES_NO_DNSKEY           | WARNING | CDS record does not match any DNSKEY in DNSKEY RRset.
+DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY    | ERROR   | CDS RRset is signed but not by a key in DNSKEY RRset.
+DS16_DELETE_CDNSKEY                  | INFO    | CDNSKEY RRset have a "delete" CDNSKEY record as a single record.
+DS16_DELETE_CDS                      | INFO    | CDS RRset have a "delete" CDS record as a single record.
+DS16_DNSKEY_NOT_SIGNED_BY_CDNSKEY    | WARNING | DNSKEY RRset is not signed by the key or keys that the CDNSKEY records point to.
+DS16_DNSKEY_NOT_SIGNED_BY_CDS        | WARNING | DNSKEY RRset is not signed by the key or keys that the CDS records point to.
+DS16_MIXED_DELETE_CDS_CDNSKEY        | ERROR   | "Delete" CDS (CDNSKEY) record is mixed with normal CDS (CDNSKEY) record.
 
 ## Ordered description of steps to be taken to execute the test case
 
@@ -94,20 +92,20 @@ report of CDS and CDNSKEY status of *Child Zone*.
     7.  Name server IP address and associated CDS key tag 
         ("No Match CDS With DNSKEY").
     8.  Name server IP address and associated CDS key tag
-        ("CDS Not Signed DNSKEY").
+        ("DNSKEY Not Signed By CDS").
     9.  Name server IP address ("CDS Not Signed").
     10. Name server IP address and key tag
-        ("CDS Signed Unknown DNSKEY").
+        ("CDS Signed By Unknown DNSKEY").
     11. Name server IP address and key tag ("CDS Invalid RRSIG").
     12. Name server IP address ("Mixed Delete CDNSKEY").
     13. Name server IP address ("Delete CDNSKEY").
     14. Name server IP address and associated CDNSKEY key tag 
         ("No Match CDNSKEY With DNSKEY").
     15. Name server IP address and key tag
-        ("CDNSKEY Not Signed DNSKEY").
+        ("DNSKEY Not Signed By CDNSKEY").
     16. Name server IP address ("CDNSKEY Not Signed").
     17. Name server IP address and key tag
-        ("CDNSKEY Signed Unknown DNSKEY").
+        ("CDNSKEY Signed By Unknown DNSKEY").
     18. Name server IP address and key tag ("CDNSKEY Invalid RRSIG").
 
 6.  Repeat the following steps for each name server IP address in 
@@ -174,13 +172,13 @@ report of CDS and CDNSKEY status of *Child Zone*.
        3. Else, if there is no RRSIG for the DNSKEY RRset created by
           the DNSKEY record that the CDS record points at then add the
           name server IP address and key tag of CDS record to the
-          *CDS Not Signed DNSKEY* set.
+          *DNSKEY Not Signed By CDS* set.
     6. If there are no RRSIG records for the CDS RRset, then add the
        name server IP address to the *CDS Not Signed* set.
     7. Else, for each RRSIG (CDS) do:
        1. If the key tag of the RRSIG does not match any DNSKEY then
           add the name server IP address and key tag to the
-          *CDS Signed Unknown DNSKEY* set.
+          *CDS Signed By Unknown DNSKEY* set.
        2. Else, if the RRSIG cannot be validated by the DNSKEY it
           refers to by key tag, then add the name server IP and RRSIG
           key tag to the *CDS Invalid RRSIG* set.
@@ -209,13 +207,13 @@ report of CDS and CDNSKEY status of *Child Zone*.
        3. Else, if there is no RRSIG for the DNSKEY RRset created by
           the DNSKEY record matching the CDNSKEY record then add the
           name server IP address and key tag of CDNSKEY record to the
-          *CDNSKEY Not Signed DNSKEY* set.
+          *DNSKEY Not Signed By CDNSKEY* set.
     6. If there are no RRSIG records for the CDNSKEY RRset, then add
        the name server IP address to the *CDNSKEY Not Signed* set.
     7. Else, for each RRSIG (CDNSKEY) do:
        1. If the key tag of the RRSIG does not match any DNSKEY then
           add the name server IP address and key tag to the
-          *CDNSKEY Signed Unknown DNSKEY* set.
+          *CDNSKEY Signed By Unknown DNSKEY* set.
        2. Else, if the RRSIG cannot be validated by the DNSKEY it
           refers to by key tag, then add the name server IP and RRSIG
           key tag to the *CDNSKEY Invalid RRSIG* set.
@@ -245,26 +243,26 @@ report of CDS and CDNSKEY status of *Child Zone*.
     with the CDNSKEY key tag and the name server IP addresses in the
     set per key tag.
 
-16. If the *CDS Not Signed DNSKEY* set is non-empty then for
-    each key tag in the set output *[DS16_CDS_NOT_SIGNED_DNSKEY]*
+16. If the *DNSKEY Not Signed By CDS* set is non-empty then for
+    each key tag in the set output *[DS16_DNSKEY_NOT_SIGNED_BY_CDS]*
     with the RRSIG key tag and the name server IP addresses in the set
     per key tag.
 
-17. If the *CDNSKEY Not Signed DNSKEY* set is non-empty then for
+17. If the *DNSKEY Not Signed By CDNSKEY* set is non-empty then for
     each key tag in the set output
-    *[DS16_NOT_SIGNED_DNSKEY]* with the RRSIG key tag and
+    *[DS16_DNSKEY_NOT_SIGNED_BY_CDNSKEY]* with the RRSIG key tag and
     the name server IP addresses in the set per key tag.
 
 18. If the *CDS Not Signed* set or the *CDNSKEY Not Signed* set is
     non-empty then output *[DS16_CDS_CDNSKEY_UNSIGNED]* with all
     name server IP addresses in the two sets.
 
-19. If the *CDS Signed Unknown DNSKEY* set is non-empty then output
-    *[DS16_CDS_SIGNED_UNKNOWN_DNSKEY]* with the name server IP
+19. If the *CDS Signed By Unknown DNSKEY* set is non-empty then output
+    *[DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY]* with the name server IP
     addresses in the set.
 
-20. If the *CDNSKEY Signed Unknown DNSKEY* set is non-empty then
-    output *[DS16_CDNSKEY_SIGNED_UNKNOWN_DNSKEY]* with the name server
+20. If the *CDNSKEY Signed By Unknown DNSKEY* set is non-empty then
+    output *[DS16_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY]* with the name server
     IP addresses in the set.
 
 21. If the *CDS Invalid RRSIG* set is non-empty then for each key tag
@@ -286,24 +284,6 @@ with the [severity level] *WARNING*, but no message with severity level
 
 In other cases the outcome of this Test Case is "pass".
 
-Message                              | Default [severity level]
-:------------------------------------|:-----------------------------------
-DS16_CDNSKEY_INVALID_RRSIG           | ERROR
-DS16_CDNSKEY_MATCHES_NO_DNSKEY       | WARNING
-DS16_NOT_SIGNED_DNSKEY               | WARNING
-DS16_CDNSKEY_SIGNED_UNKNOWN_DNSKEY   | ERROR
-DS16_CDS_CDNSKEY_UNSIGNED            | ERROR
-DS16_CDS_CDNSKEY_WITHOUT_DNSKEY      | ERROR
-DS16_CDS_INVALID_RRSIG               | ERROR
-DS16_CDS_MATCHES_NO_DNSKEY           | WARNING
-DS16_CDS_NOT_SIGNED_DNSKEY           | WARNING
-DS16_CDS_SIGNED_UNKNOWN_DNSKEY       | ERROR
-DS16_DELETE_CDNSKEY                  | INFO
-DS16_DELETE_CDS                      | INFO
-DS16_MIXED_DELETE_CDS_CDNSKEY        | ERROR
-
-
-
 ## Special procedural requirements
 
 If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
@@ -317,29 +297,26 @@ None.
 
 [Basic04]:                               ../Basic-TP/basic04.md
 [DNSSEC15]:                              dnssec15.md
-[DS16_CDNSKEY_INVALID_RRSIG]:            #outcomes
-[DS16_CDNSKEY_MATCHES_NO_DNSKEY]:        #outcomes
-[DS16_CDNSKEY_SIGNED_UNKNOWN_DNSKEY]:    #outcomes
-[DS16_CDS_CDNSKEY_UNSIGNED]:             #outcomes
-[DS16_CDS_CDNSKEY_WITHOUT_DNSKEY]:       #outcomes
-[DS16_CDS_INVALID_RRSIG]:                #outcomes
-[DS16_CDS_MATCHES_NO_DNSKEY]:            #outcomes
-[DS16_CDS_NOT_SIGNED_DNSKEY]:            #outcomes
-[DS16_CDS_SIGNED_UNKNOWN_DNSKEY]:        #outcomes
-[DS16_DELETE_CDNSKEY]:                   #outcomes
-[DS16_DELETE_CDS]:                       #outcomes
-[DS16_MIXED_DELETE_CDS_CDNSKEY]:         #outcomes
-[DS16_NOT_SIGNED_DNSKEY]:                #outcomes
-[ERROR]:                                 #outcomes
+[DS16_CDNSKEY_INVALID_RRSIG]:            #summary
+[DS16_CDNSKEY_MATCHES_NO_DNSKEY]:        #summary
+[DS16_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY]: #summary
+[DS16_CDS_CDNSKEY_UNSIGNED]:             #summary
+[DS16_CDS_CDNSKEY_WITHOUT_DNSKEY]:       #summary
+[DS16_CDS_INVALID_RRSIG]:                #summary
+[DS16_CDS_MATCHES_NO_DNSKEY]:            #summary
+[DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY]:     #summary
+[DS16_DELETE_CDNSKEY]:                   #summary
+[DS16_DELETE_CDS]:                       #summary
+[DS16_DNSKEY_NOT_SIGNED_BY_CDNSKEY]:     #summary
+[DS16_DNSKEY_NOT_SIGNED_BY_CDS]:         #summary
+[DS16_MIXED_DELETE_CDS_CDNSKEY]:         #summary
+[Default level]:                         ../SeverityLevelDefinitions.md
+[ERROR]:                                 #summary
 [Get-Del-NS-IPs]:                        https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/MethodsNT.md#method-get-delegation-ns-ip-addresses
 [Get-Zone-NS-IPs]:                       https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/MethodsNT.md#method-get-zone-ns-ip-addresses
-[INFO]:                                  #outcomes
-[NOTICE]:                                #outcomes
 [RFC 7344, section 4]:                   https://tools.ietf.org/html/rfc7344#section-4
 [RFC 7344]:                              https://tools.ietf.org/html/rfc7344
 [RFC 8078]:                              https://tools.ietf.org/html/rfc8078
-[Severity Level]:                        ../SeverityLevelDefinitions.md
-[WARNING]:                               #outcomes
 
 
 

--- a/docs/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -8,7 +8,7 @@
 CDS and CDNSKEY record types are defined in [RFC 7344] and [RFC 8078].
 Both record types are optional in a zone. The objective of this test
 case is to verify that the CDS RRset is valid. This test case is
-only relevant if the zone has at least on CDS record. For tests of the
+only relevant if the zone has at least one CDS record. For tests of the
 CDNSKEY, see test case [DNSSEC17].
 
 ## Scope
@@ -47,16 +47,7 @@ DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed wi
 
 ## Ordered description of steps to be taken to execute the test case
 
-1.  Create a CDS query with EDNS enabled and the DO bit set for the
-    apex of the *Child Zone*.
-
-2.  Create a DNSKEY query with EDNS enabled and the DO bit set for
-    the apex of the *Child Zone*.
-
-3.  Retrieve all name server IP addresses for the *Child Zone* using
-    [Method4] and [Method5] ("NS IP").
-
-4.  Create the following empty sets:
+1.  Create the following empty sets:
     1.  Name server IP address and associated CDS RRset and its RRSIG
         records ("CDS RRsets"). RRSIG records may be absent.
     2.  Name server IP address and associated DNSKEY RRset and its 
@@ -73,6 +64,15 @@ DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed wi
         ("CDS Signed By Unknown DNSKEY").
     10. Name server IP address and key tag ("CDS Invalid RRSIG").
 
+2.  Create a CDS query with EDNS enabled and the DO bit set for the
+    apex of the *Child Zone*.
+
+3.  Create a DNSKEY query with EDNS enabled and the DO bit set for
+    the apex of the *Child Zone*.
+
+4.  Retrieve all name server IP addresses for the *Child Zone* using
+    [Method4] and [Method5] ("NS IP").
+
 5.  Repeat the following steps for each name server IP address in 
     *NS IP*:
 
@@ -83,12 +83,11 @@ DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed wi
           next name server IP.
        3. Else, if the RCODE in the DNS response is not *NOERROR*, then
           go to next name server IP.
-       4. Else, if the DNS response contains at least one CDS record
-          in the answer section, then add the name server IP and the
-          CDS RRset to the *CDS RRsets* set. Also include any associated
-          RRSIG records.
-       5. Else, if the answer section has no CDS records, go to next
+       4. Else, if the answer section has no CDS records, go to next
           name server IP.
+       5. Add the name server IP and the CDS RRset from the answer
+          section to the *CDS RRsets* set. Also include any associated
+          RRSIG records in the answer section.
     2. Send the DNSKEY query over UDP to the name server IP address.
        1. If no DNS response is returned, then go to next name server
           IP.
@@ -99,7 +98,8 @@ DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed wi
        4. Else, if the DNS response contains at least one DNSKEY
           record in the answer section, then add the name server IP and
           the DNSKEY RRset from the answer section to the 
-          *DNSKEY RRsets* set. Also include any associated RRSIG records.
+          *DNSKEY RRsets* set. Also include any associated RRSIG 
+          records in the answer section.
     3. Go to next name server IP.
 
 6.  If the *CDS RRsets* set is empty then terminate this test case.
@@ -123,7 +123,7 @@ DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed wi
        1. Compare the key tag from the CDS record with the calculated
           key tags for the DNSKEY records.
        2. If the CDS record does not match any DNSKEY record then add
-          the name server IP address and key tag to the
+          the name server IP address and CDS record key tag to the
           *No Match CDS With DNSKEY* set.
        3. Else, if there is no RRSIG for the DNSKEY RRset created by
           the DNSKEY record that the CDS record points at then add the
@@ -151,26 +151,30 @@ DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed wi
 10. If the *Delete CDS* set is non-empty, then output
     *[DS16_DELETE_CDS]* with all name server IP addresses.
 
-11. If the *No Match CDS With DNSKEY* set is non-empty then for each
-    key tag in the set output *[DS16_CDS_MATCHES_NO_DNSKEY]* with the
-    CDS key tag and the name server IP addresses in the set per key
-    tag.
+11. If the *No Match CDS With DNSKEY* set is non-empty then do:
+    * For each CDS key tag in the set do:
+        * Output *[DS16_CDS_MATCHES_NO_DNSKEY]* with the CDS key tag
+          and the name server IP addresses in the set for that key
+          tag.
 
-12. If the *DNSKEY Not Signed By CDS* set is non-empty then for
-    each key tag in the set output *[DS16_DNSKEY_NOT_SIGNED_BY_CDS]*
-    with the RRSIG key tag and the name server IP addresses in the set
-    per key tag.
+12. If the *DNSKEY Not Signed By CDS* set is non-empty then do:
+    * For each CDS key tag in the set do:
+        * Output *[DS16_DNSKEY_NOT_SIGNED_BY_CDS]* with the CDS key
+          tag and the name server IP addresses in the set for that
+          key tag.
 
-13. If the *CDS Not Signed* set is non-empty then output 
+13. If the *CDS Invalid RRSIG* set is non-empty then do:
+    * For each RRSIG key tag in the set do:
+        * Output *[DS16_CDS_INVALID_RRSIG]* with the RRSIG key tag and
+          the name server IP addresses in the set for that key tag.
+
+14. If the *CDS Not Signed* set is non-empty then output 
     *[DS16_CDS_UNSIGNED]* with all name server IP addresses in the set.
 
-14. If the *CDS Signed By Unknown DNSKEY* set is non-empty then output
+15. If the *CDS Signed By Unknown DNSKEY* set is non-empty then output
     *[DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY]* with the name server IP
     addresses in the set.
 
-15. If the *CDS Invalid RRSIG* set is non-empty then for each key tag
-    in the set output *[DS16_CDS_INVALID_RRSIG]* with the RRSIG key
-    tag and the name server IP addresses in the set per key tag.
 
 ## Outcome(s)
 

--- a/docs/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -74,7 +74,7 @@ DS16_MIXED_DELETE_CDS_CDNSKEY        | ERROR   | "Delete" CDS (CDNSKEY) record i
     the apex of the *Child Zone*.
 
 4.  Retrieve all name server IP addresses for the *Child Zone* using
-    [Get-Del-NS-IPs] and [Get-Zone-NS-IPs] ("NS IP").
+    [Method4] and [Method5] ("NS IP").
 
 5.  Create the following empty sets:
     1.  Name server IP address and associated CDS RRset and its RRSIG
@@ -312,8 +312,8 @@ None.
 [DS16_MIXED_DELETE_CDS_CDNSKEY]:         #summary
 [Default level]:                         ../SeverityLevelDefinitions.md
 [ERROR]:                                 #summary
-[Get-Del-NS-IPs]:                        https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/MethodsNT.md#method-get-delegation-ns-ip-addresses
-[Get-Zone-NS-IPs]:                       https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/MethodsNT.md#method-get-zone-ns-ip-addresses
+[Method4]:                               ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                               ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 [RFC 7344, section 4]:                   https://tools.ietf.org/html/rfc7344#section-4
 [RFC 7344]:                              https://tools.ietf.org/html/rfc7344
 [RFC 8078]:                              https://tools.ietf.org/html/rfc8078

--- a/docs/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -7,10 +7,10 @@
 
 CDS and CDNSKEY record types are defined in [RFC 7344] and [RFC 8078].
 Both record types are optional in a zone. The objective of this test
-case is to verify that they are they are valid. This Test case is
+case is to verify that they are are valid. This Test case is
 only relevant if the zone has either CDS or CDNSKEY record or both.
 
-If an CDS record is included in the zone, the corresponding CDNSKEY
+If a CDS record is included in the zone, the corresponding CDNSKEY
 record should also be included ([RFC 7344][RFC 7344, section 4],
 section 4).
 
@@ -22,18 +22,24 @@ in content ([RFC 7344][RFC 7344, section 4], section 4). It means that
 both must be derived from the same DNSKEY or both being "delete" CDS
 and CDNSKEY.
 
-If a name server has issues covered by [Basic04] (basic name server
-issues) no messages will be outputted from this test case.
+## Scope
 
-It is assumed that the Child Zone has been tested by [DNSSEC15] and
-that the servers give the same responses.
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will just ignore non-responsive name servers or name servers not
+giving a correct DNS response for an authoritative name server.
+
+It is assumed that *Child Zone* has been tested by [DNSSEC15] and
+that the servers give the same responses. Running this test case
+without running [DNSSEC15], before or after, can give an incomplete
+report of CDS and CDNSKEY status of *Child Zone*.
 
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
 
 ## Summary
-* If no CDS or CDNSKEY is found, the test case is not run.
+* If no CDS or CDNSKEY is found, the test case will terminate early
+  with no message.
 * [ERROR] message if there is no DNSKEY RRset.
 * [WARNING] message if a CDS record does not match any
   DNSKEY in DNSKEY RRset (except for "delete" CDS).
@@ -74,13 +80,13 @@ that the servers give the same responses.
 
 5.  Create the following empty sets:
     1.  Name server IP address and associated CDS RRset and its RRSIG
-        records ("CDS RRsets"). A name server IP can hold an empty 
+        records ("CDS RRsets"). A name server IP may hold an empty
         RRset or no RRSIG records.
     2.  Name server IP address and associated CDNSKEY RRset and its
-        RRSIG redords ("CDNSKEY RRsets"). A name server IP can hold an
+        RRSIG redords ("CDNSKEY RRsets"). A name server IP may hold an
         empty RRset or no RRSIG records.
     3.  Name server IP address and associated DNSKEY RRset and its 
-        RRsig records ("DNSKEY RRsets"). A name server IP can hold an empty
+        RRsig records ("DNSKEY RRsets"). A name server IP may hold an empty
         RRset or no RRSIG records.
     4.  Name server IP address ("No DNSKEY RRset").
     5.  Name server IP address ("Mixed Delete CDS").
@@ -116,7 +122,7 @@ that the servers give the same responses.
           go to next name server IP.
        4. Else, if the DNS response contains at least one CDS record
           in the answer section, then add the name server IP and the
-          CDS RRset to the *CDS RRsets* set. Also include any assciated
+          CDS RRset to the *CDS RRsets* set. Also include any associated
           RRSIG records.
     2. Send the CDNSKEY query over UDP to the name server IP address.
        1. If no DNS response is returned, then go to next name server
@@ -128,7 +134,7 @@ that the servers give the same responses.
        4. Else, if the DNS response contains at least one CDNSKEY
           record in the answer section, then add the name server IP and
           the CDNSKEY RRset from the answer section to the 
-          *CDNSKEY RRsets* set. Also include any assciated RRSIG records.
+          *CDNSKEY RRsets* set. Also include any associated RRSIG records.
     3. Send the DNSKEY query over UDP to the name server IP address.
        1. If no DNS response is returned, then go to next name server
           IP.
@@ -139,7 +145,7 @@ that the servers give the same responses.
        4. Else, if the DNS response contains at least one DNSKEY
           record in the answer section, then add the name server IP and
           the CDNSKEY RRset from the answer section to the 
-          *DNSKEY RRsets* set. Also include any assciated RRSIG records.
+          *DNSKEY RRsets* set. Also include any associated RRSIG records.
     4. Go to next name server IP.
 
 7.  If neither of the *CDS RRsets* and *CDNSKEY RRsets* sets,
@@ -147,20 +153,20 @@ that the servers give the same responses.
 
 8.  For each name server IP in the *CDS RRsets* set do:
 
-    1. Extract the CDS and its RRSIG records, if any.
+    1. Get the CDS and its RRSIG records, if any.
     2. If any CDS record is a "delete" CDS, then do:
        1. If there is more than a single CDS record then add the name
           server IP to the *Mixed Delete CDS* set.
        2. Else, add the name server IP address to the *Delete CDS*
           set.
-       2. Go to next name server IP.
-    3. Extract the DNSKEY and its RRSIG records, if any, from the 
+       3. Go to next name server IP.
+    3. Get the DNSKEY and its RRSIG records, if any, from the
        *DNSKEY RRsets* for the same name server IP.
     4. If there are no DNSKEY records, then do:
        1. Add name server IP address to the *No DNSKEY RRset* set.
        2. Go to next name server IP.
     5. Repeat the following steps for each CDS record:
-       1. Compare the key tag from the CDS record with the caculated
+       1. Compare the key tag from the CDS record with the calculated
           key tags for the DNSKEY records.
        2. If the CDS record does not match any DNSKEY record then add
           the name server IP address and key tag to 
@@ -182,14 +188,14 @@ that the servers give the same responses.
 
 9.  For each name server IP in the *CDNSKEY RRsets* set do:
 
-    1. Extract the CDNSKEY and its RRSIG records, if any.
+    1. Get the CDNSKEY and its RRSIG records, if any.
     2. If any CDNSKEY record is a "delete" CDNSKEY, then do:
        1. If there is more than a single CDNSKEY record then add the
           name server IP to the *Mixed Delete CDNSKEY* set.
        2. Else, add the name server IP address to the *Delete CDNSKEY*
           set.
        2. Go to next name server IP.
-    3. Extract the DNSKEY and its RRSIG records, if any, from the 
+    3. Get the DNSKEY and its RRSIG records, if any, from the
        *DNSKEY RRsets* for the same name server IP.
     4. If there are no DNSKEY records, then do:
        1. Add name server IP address to the *No DNSKEY RRset* set

--- a/docs/specifications/tests/DNSSEC-TP/dnssec17.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec17.md
@@ -41,7 +41,7 @@ DS17_CDNSKEY_MATCHES_NO_DNSKEY       | WARNING | CDNSKEY record does not match a
 DS17_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY| ERROR   | CDNSKEY RRset is signed but not by a key in DNSKEY RRset.
 DS17_CDNSKEY_UNSIGNED                | ERROR   | CDNSKEY RRset is not signed.
 DS17_CDNSKEY_WITHOUT_DNSKEY          | ERROR   | CDNSKEY RRset exists, but there is no DNSKEY RRset.
-DS17_DELETE_CDNSKEY                  | INFO    | CDNSKEY RRset have a "delete" CDNSKEY record as a single record.
+DS17_DELETE_CDNSKEY                  | INFO    | CDNSKEY RRset has a "delete" CDNSKEY record as a single record.
 DS17_DNSKEY_NOT_SIGNED_BY_CDNSKEY    | WARNING | DNSKEY RRset is not signed by the key or keys that the CDNSKEY records point to.
 DS17_MIXED_DELETE_CDNSKEY            | ERROR   | "Delete" CDNSKEY record is mixed with normal CDNSKEY record.
 
@@ -178,7 +178,7 @@ The outcome of this Test Case is "fail" if there is at least one message
 with the severity level *[ERROR]* or *[CRITICAL]*.
 
 The outcome of this Test Case is "warning" if there is at least one message
-with the [severity level] *[WARNING]*, but no message with severity level
+with the severity level *[WARNING]*, but no message with severity level
 *ERROR* or *CRITICAL*.
 
 In other cases, no message or only messages with severity level 

--- a/docs/specifications/tests/DNSSEC-TP/dnssec17.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec17.md
@@ -1,4 +1,4 @@
-# DNSSEC16: Validate CDNSKEY
+# DNSSEC17: Validate CDNSKEY
 
 ## Test case identifier
 **DNSSEC17**
@@ -49,9 +49,9 @@ DS17_MIXED_DELETE_CDNSKEY            | ERROR   | "Delete" CDNSKEY record is mixe
 
 1.  Create the following empty sets:
     1.  Name server IP address and associated CDNSKEY RRset and its
-        RRSIG redords ("CDNSKEY RRsets"). RRSIG records may be absent.
+        RRSIG redords ("CDNSKEY RRsets"). The set of RRSIG records may be empty
     2.  Name server IP address and associated DNSKEY RRset and its 
-        RRsig records ("DNSKEY RRsets"). RRSIG records may be absent.
+        RRSIG records ("DNSKEY RRsets"). The set of RRSIG records may be empty.
     3.  Name server IP address ("No DNSKEY RRset").
     4.  Name server IP address ("Mixed Delete CDNSKEY").
     5.  Name server IP address ("Delete CDNSKEY").
@@ -107,15 +107,16 @@ DS17_MIXED_DELETE_CDNSKEY            | ERROR   | "Delete" CDNSKEY record is mixe
 7.  For each name server IP in the *CDNSKEY RRsets* set do:
 
     1. If the CDNSKEY RRset is non-empty, get the RRset and its RRSIG
-       records, else go to next name server IP address.
+       records, else go to next name server IP address. The set of the RRSIG
+       records may be empty.
     2. If any CDNSKEY record is a "delete" CDNSKEY, then do:
        1. If there is more than a single CDNSKEY record then add the
           name server IP to the *Mixed Delete CDNSKEY* set.
        2. Else, add the name server IP address to the *Delete CDNSKEY*
           set.
        3. Go to next name server IP.
-    3. Get the DNSKEY and its RRSIG records, if any, from the
-       *DNSKEY RRsets* for the same name server IP.
+    3. Get the DNSKEY and its RRSIG records from the *DNSKEY RRsets* for the same
+       name server IP. The set of RRSIG records may be empty.
     4. If there are no DNSKEY records, then do:
        1. Add name server IP address to the *No DNSKEY RRset* set
           (duplicates not possible).

--- a/docs/specifications/tests/DNSSEC-TP/dnssec17.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec17.md
@@ -1,0 +1,220 @@
+# DNSSEC16: Validate CDNSKEY
+
+## Test case identifier
+**DNSSEC17**
+
+## Objective
+
+CDS and CDNSKEY record types are defined in [RFC 7344] and [RFC 8078].
+Both record types are optional in a zone. The objective of this test
+case is to verify that the CDNSKEY RRset is valid. This test case is
+only relevant if the zone has at least on CDNSKEY record. For tests of the
+CDS, see test case [DNSSEC16].
+
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will just ignore non-responsive name servers or name servers not
+giving a correct DNS response for an authoritative name server.
+
+It is assumed that *Child Zone* has been tested or will be tested by 
+[DNSSEC15] and [DNSSEC16] and that the servers give the same responses.
+Running this test case without running [DNSSEC15] and [DNSSEC16] can
+give an incomplete report of the CDS and CDNSKEY status of 
+*Child Zone*.
+
+## Inputs
+
+* "Child Zone" - The domain name to be tested.
+
+## Summary
+
+* If no CDNSKEY record is found, the test case will terminate early
+  with no message tag outputted.
+* If a CDNSKEY record is of "delete" type, then it can by
+  definition not match or point at any DNSKEY record.
+
+Message Tag outputted                | [Default level] | Description of when message tag is outputted
+:------------------------------------|:--------|:-----------------------------------------
+DS17_CDNSKEY_INVALID_RRSIG           | ERROR   | CDNSKEY RRset signed with an invalid RRSIG.
+DS17_CDNSKEY_MATCHES_NO_DNSKEY       | WARNING | CDNSKEY record does not match any DNSKEY in DNSKEY RRset.
+DS17_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY| ERROR   | CDNSKEY RRset is signed but not by a key in DNSKEY RRset.
+DS17_CDNSKEY_UNSIGNED                | ERROR   | CDNSKEY RRset is not signed.
+DS17_CDNSKEY_WITHOUT_DNSKEY          | ERROR   | CDNSKEY RRset exists, but there is no DNSKEY RRset.
+DS17_DELETE_CDNSKEY                  | INFO    | CDNSKEY RRset have a "delete" CDNSKEY record as a single record.
+DS17_DNSKEY_NOT_SIGNED_BY_CDNSKEY    | WARNING | DNSKEY RRset is not signed by the key or keys that the CDNSKEY records point to.
+DS17_MIXED_DELETE_CDNSKEY            | ERROR   | "Delete" CDNSKEY record is mixed with normal CDNSKEY record.
+
+## Ordered description of steps to be taken to execute the test case
+
+1.  Create a CDNSKEY query with EDNS enabled and the DO bit set for
+    the apex of the *Child Zone*.
+
+2.  Create a DNSKEY query with EDNS enabled and the DO bit set for
+    the apex of the *Child Zone*.
+
+3.  Retrieve all name server IP addresses for the *Child Zone* using
+    [Method4] and [Method5] ("NS IP").
+
+4.  Create the following empty sets:
+    1.  Name server IP address and associated CDNSKEY RRset and its
+        RRSIG redords ("CDNSKEY RRsets"). RRSIG records may be absent.
+    2.  Name server IP address and associated DNSKEY RRset and its 
+        RRsig records ("DNSKEY RRsets"). RRSIG records may be absent.
+    3.  Name server IP address ("No DNSKEY RRset").
+    4.  Name server IP address ("Mixed Delete CDNSKEY").
+    5.  Name server IP address ("Delete CDNSKEY").
+    6.  Name server IP address and associated CDNSKEY key tag 
+        ("No Match CDNSKEY With DNSKEY").
+    7.  Name server IP address and key tag
+        ("DNSKEY Not Signed By CDNSKEY").
+    8.  Name server IP address ("CDNSKEY Not Signed").
+    9.  Name server IP address and key tag
+        ("CDNSKEY Signed By Unknown DNSKEY").
+    10. Name server IP address and key tag ("CDNSKEY Invalid RRSIG").
+
+5.  Repeat the following steps for each name server IP address in 
+    *NS IP*:
+
+    1. Send the CDNSKEY query over UDP to the name server IP address.
+       1. If no DNS response is returned, then go to next name server
+          IP.
+       2. Else, if AA bit is not set in the DNS response, then go to
+          next name server IP.
+       3. Else, if the RCODE in the DNS response is not *NOERROR*, then
+          go to next name server IP.
+       4. Else, if the DNS response contains at least one CDNSKEY
+          record in the answer section, then add the name server IP and
+          the CDNSKEY RRset from the answer section to the 
+          *CDNSKEY RRsets* set. Also include any associated RRSIG records.
+       5. Else, go to next name server IP.
+    2. Send the DNSKEY query over UDP to the name server IP address.
+       1. If no DNS response is returned, then go to next name server
+          IP.
+       2. Else, if AA bit is not set in the DNS response, then go to
+          next name server IP.
+       3. Else, if the RCODE in the DNS response is not *NOERROR*, then
+          go to next name server IP.
+       4. Else, if the DNS response contains at least one DNSKEY
+          record in the answer section, then add the name server IP and
+          the DNSKEY RRset from the answer section to the 
+          *DNSKEY RRsets* set. Also include any associated RRSIG records.
+    3. Go to next name server IP.
+
+6.  If the *CDNSKEY RRsets* set is empty then terminate this test case.
+
+7.  For each name server IP in the *CDNSKEY RRsets* set do:
+
+    1. If the CDNSKEY RRset is non-empty, get the RRset and its RRSIG
+       records, else go to next name server IP address.
+    2. If any CDNSKEY record is a "delete" CDNSKEY, then do:
+       1. If there is more than a single CDNSKEY record then add the
+          name server IP to the *Mixed Delete CDNSKEY* set.
+       2. Else, add the name server IP address to the *Delete CDNSKEY*
+          set.
+       3. Go to next name server IP.
+    3. Get the DNSKEY and its RRSIG records, if any, from the
+       *DNSKEY RRsets* for the same name server IP.
+    4. If there are no DNSKEY records, then do:
+       1. Add name server IP address to the *No DNSKEY RRset* set
+          (duplicates not possible).
+       2. Go to next name server IP.
+    5. Repeat the following steps for each CDNSKEY record:
+       1. Compare the CDNSKEY record with the DNSKEY records.
+       2. If the CDNSKEY record does not match any DNSKEY record then
+          add the name server IP address and key tag to 
+          *No Match CDNSKEY With DNSKEY* set.
+       3. Else, if there is no RRSIG for the DNSKEY RRset created by
+          the DNSKEY record matching the CDNSKEY record then add the
+          name server IP address and key tag of CDNSKEY record to the
+          *DNSKEY Not Signed By CDNSKEY* set.
+    6. If there are no RRSIG records for the CDNSKEY RRset, then add
+       the name server IP address to the *CDNSKEY Not Signed* set.
+    7. Else, for each RRSIG (CDNSKEY) do:
+       1. If the key tag of the RRSIG does not match any DNSKEY then
+          add the name server IP address and key tag to the
+          *CDNSKEY Signed By Unknown DNSKEY* set.
+       2. Else, if the RRSIG cannot be validated by the DNSKEY it
+          refers to by key tag, then add the name server IP and RRSIG
+          key tag to the *CDNSKEY Invalid RRSIG* set.
+    8. Go to next name server IP address.
+
+8.  If the *No DNSKEY RRset* set is non-empty, then output
+    *[DS17_CDNSKEY_WITHOUT_DNSKEY]* with all name server IP addresses
+    in the set.
+
+9. If the the *Mixed Delete CDNSKEY* set is
+    non-empty, then output *[DS17_MIXED_DELETE_CDNSKEY]* with all
+    name server IP addresses in the set.
+
+10. If the *Delete CDNSKEY* set is non-empty then output
+    *[DS17_DELETE_CDNSKEY]* with all name server IP addresses.
+
+11. If the *No Match CDNSKEY With DNSKEY* set is non-empty then for
+    each key tag in the set output *[DS17_CDNSKEY_MATCHES_NO_DNSKEY]*
+    with the CDNSKEY key tag and the name server IP addresses in the
+    set per key tag.
+
+12. If the *DNSKEY Not Signed By CDNSKEY* set is non-empty then for
+    each key tag in the set output
+    *[DS17_DNSKEY_NOT_SIGNED_BY_CDNSKEY]* with the RRSIG key tag and
+    the name server IP addresses in the set per key tag.
+
+13. If the *CDNSKEY Not Signed* set is
+    non-empty then output *[DS17_CDNSKEY_UNSIGNED]* with all
+    name server IP addresses in the set.
+
+14. If the *CDNSKEY Signed By Unknown DNSKEY* set is non-empty then
+    output *[DS17_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY]* with the name server
+    IP addresses in the set.
+
+15. If the *CDNSKEY Invalid RRSIG* set is non-empty then for each key
+    tag in the set output *[DS17_CDNSKEY_INVALID_RRSIG]* with the RRSIG
+    key tag and the name server IP addresses in the set per key tag.
+
+## Outcome(s)
+
+The outcome of this Test Case is "fail" if there is at least one message
+with the severity level *[ERROR]* or *[CRITICAL]*.
+
+The outcome of this Test Case is "warning" if there is at least one message
+with the [severity level] *[WARNING]*, but no message with severity level
+*ERROR* or *CRITICAL*.
+
+In other cases, no message or only messages with severity level 
+*[INFO]* or *[NOTICE]*, the outcome of this Test Case is "pass".
+
+## Special procedural requirements
+
+If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
+result of any test using this transport protocol. Log a message reporting
+the ignored protocol.
+
+## Intercase dependencies
+
+None.
+
+
+[Basic04]:                               ../Basic-TP/basic04.md
+[CRITICAL]:                              ../SeverityLevelDefinitions.md#critical
+[DNSSEC15]:                              dnssec15.md
+[DNSSEC16]:                              dnssec16.md
+[DS17_CDNSKEY_INVALID_RRSIG]:            #summary
+[DS17_CDNSKEY_MATCHES_NO_DNSKEY]:        #summary
+[DS17_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY]: #summary
+[DS17_CDNSKEY_UNSIGNED]:                 #summary
+[DS17_CDNSKEY_WITHOUT_DNSKEY]:           #summary
+[DS17_DELETE_CDNSKEY]:                   #summary
+[DS17_DNSKEY_NOT_SIGNED_BY_CDNSKEY]:     #summary
+[DS17_MIXED_DELETE_CDNSKEY]:             #summary
+[Default level]:                         ../SeverityLevelDefinitions.md
+[ERROR]:                                 ../SeverityLevelDefinitions.md#error
+[INFO]:                                  ../SeverityLevelDefinitions.md#info
+[Method4]:                               ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                               ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NOTICE]:                                ../SeverityLevelDefinitions.md#notice
+[RFC 7344, section 4]:                   https://tools.ietf.org/html/rfc7344#section-4
+[RFC 7344]:                              https://tools.ietf.org/html/rfc7344
+[RFC 8078]:                              https://tools.ietf.org/html/rfc8078
+[WARNING]:                               ../SeverityLevelDefinitions.md#warning
+


### PR DESCRIPTION
Now updated to create two test cases, DNSSEC16 for validating CDS and DNSSEC17 for validating CDNSKEY. Previously there was one test case for both.

Also see #938 (PR to create DNSSEC15), #941 (PR to create DNSSEC18 and [New-Test-Cases-for-CDS-CDNSKEY] (a temporary document).


[New-Test-Cases-for-CDS-CDNSKEY]: https://github.com/matsduf/zonemaster/blob/notes-for-new-DNSSEC-test-cases-for-CDS-CDNSKEY/docs/specifications/tests/DNSSEC-TP/New-Test-Cases-for-CDS-CDNSKEY.md