### PR TITLE
Updates CONSISTENCY specifications to lower level of no response

### DIFF
--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -122,28 +122,18 @@ When comparing SOA serial it must be done using the arithmetic defined in
 
 None
 
+
 [Basic04]:                    ../Basic-TP/basic04.md
-[RFC 1034]: https://tools.ietf.org/html/rfc1035
-
-[RFC 1035]: https://tools.ietf.org/html/rfc1035
-
-[RFC 1982]: https://tools.ietf.org/html/rfc1982 
-
-[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
-
-[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-
-[NO_RESPONSE]: #outcomes
-
-[NO_RESPONSE_SOA_QUERY]: #outcomes
-
-[ONE_SOA_SERIAL]: #outcomes
-
-[MULTIPLE_SOA_SERIALS]: #outcomes
-
-[MULTIPLE_SOA_SERIALS_OK]: #outcomes
-
-[SOA_SERIAL]: #outcomes
-
-[SOA_SERIAL_VARIATION]: #outcomes
+[MULTIPLE_SOA_SERIALS]:       #outcomes
+[MULTIPLE_SOA_SERIALS_OK]:    #outcomes
+[Method4]:                    ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                    ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_RESPONSE]:                #outcomes
+[NO_RESPONSE_SOA_QUERY]:      #outcomes
+[ONE_SOA_SERIAL]:             #outcomes
+[RFC 1034]:                   https://tools.ietf.org/html/rfc1035
+[RFC 1035]:                   https://tools.ietf.org/html/rfc1035
+[RFC 1982]:                   https://tools.ietf.org/html/rfc1982
+[SOA_SERIAL]:                 #outcomes
+[SOA_SERIAL_VARIATION]:       #outcomes
 

--- a/docs/specifications/tests/Consistency-TP/consistency01.md
+++ b/docs/specifications/tests/Consistency-TP/consistency01.md
@@ -24,6 +24,11 @@ explains the serial number arithmetic, and section 4.3.5 of
 [RFC 1034] explains the importance of
 serial number consistency.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested 
@@ -90,7 +95,7 @@ In other cases the outcome of this Test Case is "pass".
 
 Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 NO_RESPONSE_SOA_QUERY         | DEBUG
 ONE_SOA_SERIAL                | INFO
 MULTIPLE_SOA_SERIALS          | WARNING
@@ -117,6 +122,7 @@ When comparing SOA serial it must be done using the arithmetic defined in
 
 None
 
+[Basic04]:                    ../Basic-TP/basic04.md
 [RFC 1034]: https://tools.ietf.org/html/rfc1035
 
 [RFC 1035]: https://tools.ietf.org/html/rfc1035

--- a/docs/specifications/tests/Consistency-TP/consistency02.md
+++ b/docs/specifications/tests/Consistency-TP/consistency02.md
@@ -70,18 +70,13 @@ None
 
 
 [Basic04]:                    ../Basic-TP/basic04.md
-[RFC 1034]: https://tools.ietf.org/html/rfc1034
-
-[RFC 1035]: https://tools.ietf.org/html/rfc1035
-
-[RFC 1982]: https://tools.ietf.org/html/rfc1982 
-
-[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
-
-[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-
-[NO_RESPONSE]: #outcomes
-[NO_RESPONSE_SOA_QUERY]: #outcomes
-[ONE_SOA_RNAME]: #outcomes
-[MULTIPLE_SOA_RNAMES]: #outcomes
+[MULTIPLE_SOA_RNAMES]:        #outcomes
+[Method4]:                    ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                    ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_RESPONSE]:                #outcomes
+[NO_RESPONSE_SOA_QUERY]:      #outcomes
+[ONE_SOA_RNAME]:              #outcomes
+[RFC 1034]:                   https://tools.ietf.org/html/rfc1034
+[RFC 1035]:                   https://tools.ietf.org/html/rfc1035
+[RFC 1982]:                   https://tools.ietf.org/html/rfc1982
 

--- a/docs/specifications/tests/Consistency-TP/consistency02.md
+++ b/docs/specifications/tests/Consistency-TP/consistency02.md
@@ -15,6 +15,11 @@ failures being reported to different persons.
 The objective of this test is to verify that the administrative contact is
 consistent between different authoritative name servers.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * The domain name to be tested ("Child Zone")
@@ -47,7 +52,7 @@ In other cases the outcome of this Test Case is "pass".
 
 Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 NO_RESPONSE_SOA_QUERY         | DEBUG
 ONE_SOA_RNAME                 | INFO
 MULTIPLE_SOA_RNAMES           | NOTICE
@@ -64,6 +69,7 @@ on the ignored result.
 None
 
 
+[Basic04]:                    ../Basic-TP/basic04.md
 [RFC 1034]: https://tools.ietf.org/html/rfc1034
 
 [RFC 1035]: https://tools.ietf.org/html/rfc1035

--- a/docs/specifications/tests/Consistency-TP/consistency03.md
+++ b/docs/specifications/tests/Consistency-TP/consistency03.md
@@ -17,6 +17,11 @@ SOA fields:
 * [CONSISTENCY02] (RNAME)
 * [CONSISTENCY06] (MNAME)
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * The domain name to be tested ("Child Zone").
@@ -60,7 +65,7 @@ In other cases the outcome of this Test Case is "pass".
 
 Message                          | Default severity level (if message is emitted)
 :--------------------------------|:-----------------------------------
-NO_RESPONSE                      | WARNING
+NO_RESPONSE                      | DEBUG
 NO_RESPONSE_SOA_QUERY            | DEBUG
 ONE_SOA_TIME_PARAMETER_SET       | INFO
 MULTIPLE_SOA_TIME_PARAMETER_SET  | NOTICE
@@ -76,6 +81,7 @@ on the ignored result.
 
 None.
 
+[Basic04]:                    ../Basic-TP/basic04.md
 [Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
 
 [Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child

--- a/docs/specifications/tests/Consistency-TP/consistency03.md
+++ b/docs/specifications/tests/Consistency-TP/consistency03.md
@@ -81,23 +81,15 @@ on the ignored result.
 
 None.
 
-[Basic04]:                    ../Basic-TP/basic04.md
-[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
 
-[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-
-[NO_RESPONSE]: #outcomes
-
-[NO_RESPONSE_SOA_QUERY]: #outcomes
-
-[ONE_SOA_TIME_PARAMETER_SET]: #outcomes
-
-[MULTIPLE_SOA_TIME_PARAMETER_SET]: #outcomes
-
-[CONSISTENCY01]: consistency01.md
-
-[CONSISTENCY02]: consistency02.md
-
-[CONSISTENCY06]: consistency06.md
-
+[Basic04]:                           ../Basic-TP/basic04.md
+[CONSISTENCY01]:                     consistency01.md
+[CONSISTENCY02]:                     consistency02.md
+[CONSISTENCY06]:                     consistency06.md
+[MULTIPLE_SOA_TIME_PARAMETER_SET]:   #outcomes
+[Method4]:                           ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                           ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_RESPONSE]:                       #outcomes
+[NO_RESPONSE_SOA_QUERY]:             #outcomes
+[ONE_SOA_TIME_PARAMETER_SET]:        #outcomes
 

--- a/docs/specifications/tests/Consistency-TP/consistency04.md
+++ b/docs/specifications/tests/Consistency-TP/consistency04.md
@@ -77,19 +77,14 @@ on the ignored result.
 
 None
 
+
 [Basic04]:                    ../Basic-TP/basic04.md
-[RFC 1034]: https://tools.ietf.org/html/rfc1034
+[MULTIPLE_NS_SET]:            #outcomes
+[Method4]:                    ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                    ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_RESPONSE]:                #outcomes
+[NO_RESPONSE_NS_QUERY]:       #outcomes
+[ONE_NS_SET]:                 #outcomes
+[RFC 1034]:                   https://tools.ietf.org/html/rfc1034
+[RFC 1035]:                   https://tools.ietf.org/html/rfc1035
 
-[RFC 1035]: https://tools.ietf.org/html/rfc1035
-
-[Method4]:  ../Methods.md#method-4-obtain-glue-address-records-from-parent
-
-[Method5]:  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-
-[NO_RESPONSE]: #outcomes
-
-[NO_RESPONSE_NS_QUERY]: #outcomes
-
-[ONE_NS_SET]: #outcomes
-
-[MULTIPLE_NS_SET]: #outcomes

--- a/docs/specifications/tests/Consistency-TP/consistency04.md
+++ b/docs/specifications/tests/Consistency-TP/consistency04.md
@@ -19,6 +19,11 @@ same number of NS records, and for each NS record in one of the
 sets there is exactly one NS record with identical owner name, 
 class, TTL and RDATA in the other NS set.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * The domain name to be tested ("Child Zone").
@@ -55,8 +60,8 @@ In other cases the outcome of this Test Case is "pass".
 
 Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------
-NO_RESPONSE                   | WARNING
-NO_RESPONSE_NS_QUERY          | WARNING
+NO_RESPONSE                   | DEBUG
+NO_RESPONSE_NS_QUERY          | DEBUG
 ONE_NS_SET                    | INFO
 MULTIPLE_NS_SET               | NOTICE
 
@@ -72,6 +77,7 @@ on the ignored result.
 
 None
 
+[Basic04]:                    ../Basic-TP/basic04.md
 [RFC 1034]: https://tools.ietf.org/html/rfc1034
 
 [RFC 1035]: https://tools.ietf.org/html/rfc1035

--- a/docs/specifications/tests/Consistency-TP/consistency05.md
+++ b/docs/specifications/tests/Consistency-TP/consistency05.md
@@ -13,6 +13,11 @@ match the authoritative A and AAAA records for that host. This is an IANA
 The objective of this test is to verify that the [glue records][terminology] 
 in the delegation are consistent with authoritative data.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -127,8 +132,8 @@ The outcome of this Test case is "pass" in all other cases.
 
 Message                           | Default severity level (when message is outputted)
 :---------------------------------|:-----------------------------------
-CHILD_NS_FAILED                   | NOTICE
-NO_RESPONSE                       | WARNING
+CHILD_NS_FAILED                   | DEBUG
+NO_RESPONSE                       | DEBUG
 CHILD_ZONE_LAME                   | ERROR
 IN_BAILIWICK_ADDR_MISMATCH        | ERROR
 OUT_OF_BAILIWICK_ADDR_MISMATCH    | ERROR
@@ -178,6 +183,7 @@ respected.
 
 
 [BASIC01]:                  ../Basic-TP/basic01.md
+[Basic04]:                  ../Basic-TP/basic04.md
 [DELEGATION05]:             ../Delegation-TP/delegation05.md
 [Methods]:                  ../Methods.md
 [Method2]:                  ../Methods.md#method-2-obtain-glue-name-records-from-parent

--- a/docs/specifications/tests/Consistency-TP/consistency05.md
+++ b/docs/specifications/tests/Consistency-TP/consistency05.md
@@ -182,25 +182,24 @@ any changes to the DNS tree introduced by an [undelegated test] must be
 respected.
 
 
-[BASIC01]:                  ../Basic-TP/basic01.md
-[Basic04]:                  ../Basic-TP/basic04.md
-[DELEGATION05]:             ../Delegation-TP/delegation05.md
-[Methods]:                  ../Methods.md
-[Method2]:                  ../Methods.md#method-2-obtain-glue-name-records-from-parent
-[Method3]:                  ../Methods.md#method-3-obtain-name-servers-from-child
-[Method4]:                  ../Methods.md#method-4-obtain-glue-address-records-from-parent
-[Method5]:                  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-[name server requirement]:  https://www.iana.org/help/nameserver-requirements
-[RFC 7719]:                 https://tools.ietf.org/html/rfc7719
-[terminology]:              #terminology
-[undelegated test]:         ../../test-types/undelegated-test.md
-
-[CHILD_NS_FAILED]:                #outcomes
-[NO_RESPONSE]:                    #outcomes
-[CHILD_ZONE_LAME]:                #outcomes
-[IN_BAILIWICK_ADDR_MISMATCH]:     #outcomes
-[OUT_OF_BAILIWICK_ADDR_MISMATCH]: #outcomes
-[EXTRA_ADDRESS_CHILD]:            #outcomes
-[UNDEL_OOB_ADDR_MISMATCH]:        #outcomes
 [ADDRESSES_MATCH]:                #outcomes
+[BASIC01]:                        ../Basic-TP/basic01.md
+[Basic04]:                        ../Basic-TP/basic04.md
+[CHILD_NS_FAILED]:                #outcomes
+[CHILD_ZONE_LAME]:                #outcomes
+[DELEGATION05]:                   ../Delegation-TP/delegation05.md
+[EXTRA_ADDRESS_CHILD]:            #outcomes
+[IN_BAILIWICK_ADDR_MISMATCH]:     #outcomes
+[Method2]:                        ../Methods.md#method-2-obtain-glue-name-records-from-parent
+[Method3]:                        ../Methods.md#method-3-obtain-name-servers-from-child
+[Method4]:                        ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                        ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[Methods]:                        ../Methods.md
+[NO_RESPONSE]:                    #outcomes
+[OUT_OF_BAILIWICK_ADDR_MISMATCH]: #outcomes
+[RFC 7719]:                       https://tools.ietf.org/html/rfc7719
+[UNDEL_OOB_ADDR_MISMATCH]:        #outcomes
+[name server requirement]:        https://www.iana.org/help/nameserver-requirements
+[terminology]:                    #terminology
+[undelegated test]:               ../../test-types/undelegated-test.md
 

--- a/docs/specifications/tests/Consistency-TP/consistency06.md
+++ b/docs/specifications/tests/Consistency-TP/consistency06.md
@@ -80,19 +80,12 @@ None
 
 
 [Basic04]:                  ../Basic-TP/basic04.md
-[RFC 1034]: https://tools.ietf.org/html/rfc1035
-
-[RFC 1035]: https://tools.ietf.org/html/rfc1035
-
-[Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
-
-[Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-
-[NO_RESPONSE]: #outcomes
-
-[NO_RESPONSE_SOA_QUERY]: #outcomes
-
-[ONE_SOA_MNAME]: #outcomes
-
-[MULTIPLE_SOA_MNAMES]: #outcomes
+[MULTIPLE_SOA_MNAMES]:      #outcomes
+[Method4]:                  ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                  ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NO_RESPONSE]:              #outcomes
+[NO_RESPONSE_SOA_QUERY]:    #outcomes
+[ONE_SOA_MNAME]:            #outcomes
+[RFC 1034]:                 https://tools.ietf.org/html/rfc1035
+[RFC 1035]:                 https://tools.ietf.org/html/rfc1035
 

--- a/docs/specifications/tests/Consistency-TP/consistency06.md
+++ b/docs/specifications/tests/Consistency-TP/consistency06.md
@@ -13,6 +13,11 @@ All authoritative name servers must serve the same SOA record (section
 for this zone". Inconsistency in MNAME of the domain might result in 
 operational failures for applications that uses MNAME.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -57,7 +62,7 @@ In other cases the outcome of this Test Case is "pass".
 
 Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 NO_RESPONSE_SOA_QUERY         | DEBUG
 ONE_SOA_MNAME                 | INFO
 MULTIPLE_SOA_MNAMES           | NOTICE
@@ -74,6 +79,7 @@ on the ignored result.
 None
 
 
+[Basic04]:                  ../Basic-TP/basic04.md
 [RFC 1034]: https://tools.ietf.org/html/rfc1035
 
 [RFC 1035]: https://tools.ietf.org/html/rfc1035


### PR DESCRIPTION
BASIC04 has been implemented to report on problem with responses from nameservers. The Consistency specifications and their implementation, repeats reporting the same thing with no benefit. With this PR the Consistency test case will refer that to BASIC04.

A PR to lower the level in the profile is created in Zonemaster-Engine (https://github.com/zonemaster/zonemaster-engine/pull/923).

* Adds reference to BASIC04, which tests all name servers for non-response.
* Lower default level to DEBUG for messages that report on non-response.