### PR TITLE
Updates DNSSEC specifications to lower level of no response

### DIFF
--- a/docs/specifications/tests/DNSSEC-TP/dnssec02.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec02.md
@@ -25,6 +25,11 @@ is meant to be a KSK and pointed out by a DS record. It is noted if
 the DNSKEY record that the DS points at does not have that flag set
 ([RFC 4034][RFC 4034#2.1.1], section 2.1.1).
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -113,7 +118,7 @@ DNSKEY_NOT_ZONE_SIGN          | ERROR
 DS_MATCHES                    | INFO
 NO_MATCHING_DNSKEY            | ERROR
 NO_MATCHING_RRSIG             | ERROR
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 NO_RESPONSE_DNSKEY            | ERROR
 NO_RRSIG_DNSKEY               | ERROR
 UNEXPECTED_RESPONSE_DS        | WARNING
@@ -135,6 +140,7 @@ None.
 
 
 
+[Basic04]:                 ../Basic-TP/basic04.md
 [BROKEN_DS]:               #outcomes
 [BROKEN_RRSIG]:            #outcomes
 [DNSKEY_KSK_NOT_SEP]:      #outcomes

--- a/docs/specifications/tests/DNSSEC-TP/dnssec05.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec05.md
@@ -46,6 +46,11 @@ Algorithm number | Algorithm (or description)
 255              | (Reserved)
 
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * The domain name to be tested ("Child Zone").
@@ -96,7 +101,7 @@ In other cases the outcome of this Test Case is "pass".
 
 Message                       | Default severity level
 :-----------------------------|:-----------------------------------
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 NO_RESPONSE_DNSKEY            | WARNING
 ALGORITHM_DEPRECATED          | ERROR
 ALGORITHM_RESERVED            | ERROR
@@ -123,6 +128,7 @@ The test case is only performed if some DNSKEY record is found in the
 
 None.
 
+[Basic04]:               ../Basic-TP/basic04.md
 [RFC 8624]: https://www.rfc-editor.org/rfc/rfc8624.html#section-3.1
 [IANA registry]: https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xml
 

--- a/docs/specifications/tests/DNSSEC-TP/dnssec10.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec10.md
@@ -24,6 +24,11 @@ The description of the NSEC3 RR is in
 use in the DNS response is described in
 [RFC 5155][RFC 5155#section-7.2], section 7.2.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -120,7 +125,7 @@ INCONSISTENT_NSEC_NSEC3       | ERROR
 INVALID_RCODE                 | WARNING
 MIXED_NSEC_NSEC3              | ERROR
 NO_NSEC_NSEC3                 | ERROR
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 NSEC3_COVERS_NOT              | ERROR
 NSEC3_NOT_SIGNED              | ERROR
 NSEC3_SIG_VERIFY_ERROR        | ERROR
@@ -146,6 +151,7 @@ The test case is only performed if some DNSKEY record is found in the
 
 None.
 
+[Basic04]:                 ../Basic-TP/basic04.md
 [BROKEN_DNSSEC]:           #outcomes
 [DNSSEC README]:           ./README.md
 [HAS_NSEC3]:               #outcomes

--- a/docs/specifications/tests/DNSSEC-TP/dnssec13.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec13.md
@@ -22,6 +22,11 @@ is a RRSIG of that algorithm for the three selected RRsets.
 Furtermore, it is verified that the RRSIG of those RRsets have
 been created by a DNSKEY from the zone's DNSKEY RRset.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -135,7 +140,7 @@ Message                       | Default severity level
 :-----------------------------|:-----------------------------------
 ALGO_NOT_SIGNED_RRSET         | WARNING
 ALL_ALGO_SIGNED               | INFO
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 NO_RESPONSE_RRSET             | ERROR
 RRSET_NOT_SIGNED              | ERROR
 RRSIG_BROKEN                  | ERROR
@@ -162,6 +167,7 @@ None.
 
 [ALGO_NOT_SIGNED_RRSET]:      #outcomes
 [ALL_ALGO_SIGNED]:            #outcomes
+[Basic04]:                    ../Basic-TP/basic04.md
 [DNSSEC README]:              ./README.md
 [NO_RESPONSE]:                #outcomes
 [NO_RESPONSE_RRSET]:          #outcomes

--- a/docs/specifications/tests/DNSSEC-TP/dnssec14.md
+++ b/docs/specifications/tests/DNSSEC-TP/dnssec14.md
@@ -31,6 +31,11 @@ section 5.6.2.
 This test case verifies that RSA DNSKEYs follows the stated key lengths
 from the RFCs and also the NIST recommended shortest key length.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested. 
@@ -85,7 +90,7 @@ In other cases the outcome of this Test Case is "pass".
 
 Message                       | Default severity level
 :-----------------------------|:-----------------------------------
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 NO_RESPONSE_DNSKEY            | WARNING
 DNSKEY_SMALLER_THAN_REC       | WARNING
 DNSKEY_TOO_SMALL_FOR_ALGO     | ERROR
@@ -109,22 +114,21 @@ The test case is only performed if some DNSKEY record is found in the
 
 None.
 
-[IANA registry]:                             https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xml
-[NIST SP 800-57 Part 1 Rev. 4]:              https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-4/final
-[RFC 3110]:                                  https://tools.ietf.org/html/rfc3110
-[RFC 5155]:                                  https://tools.ietf.org/html/rfc5155
-[RFC 5702]:                                  https://tools.ietf.org/html/rfc5702#section-2
-[RFC 8624]:                                  https://www.rfc-editor.org/rfc/rfc8624.html#section-3.1
+[Basic04]:                                               ../Basic-TP/basic04.md
+[DNSKEY_SMALLER_THAN_REC]:                               #outcomes
+[DNSKEY_TOO_LARGE_FOR_ALGO]:                             #outcomes
+[DNSKEY_TOO_SMALL_FOR_ALGO]:                             #outcomes
+[DNSSEC README]:                                         ./README.md
+[IANA registry]:                                         https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xml
+[KEY_SIZE_OK]:                                           #outcomes
+[Method4]:                                               ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                                               ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NIST SP 800-57 Part 1 Rev. 4]:                          https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-4/final
+[NO_RESPONSE]:                                           #outcomes
+[NO_RESPONSE_DNSKEY]:                                    #outcomes
+[RFC 3110]:                                              https://tools.ietf.org/html/rfc3110
+[RFC 5155]:                                              https://tools.ietf.org/html/rfc5155
+[RFC 5702]:                                              https://tools.ietf.org/html/rfc5702#section-2
+[RFC 8624]:                                              https://www.rfc-editor.org/rfc/rfc8624.html#section-3.1
 [Recommendation for key Management, part 1, revision 4]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r4.pdf
-
-[Method4]:                   ../Methods.md#method-4-obtain-glue-address-records-from-parent
-[Method5]:                   ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-
-[DNSSEC README]:             ./README.md
-[NO_RESPONSE]:               #outcomes
-[NO_RESPONSE_DNSKEY]:        #outcomes
-[DNSKEY_SMALLER_THAN_REC]:   #outcomes
-[DNSKEY_TOO_SMALL_FOR_ALGO]: #outcomes
-[DNSKEY_TOO_LARGE_FOR_ALGO]: #outcomes
-[KEY_SIZE_OK]:               #outcomes
 


### PR DESCRIPTION
BASIC04 has been implemented to report on problem with responses from nameservers. The DNSSEC specifications and their implementation, repeats reporting the same thing with no benefit. With this PR the Consistency test case will refer that to BASIC04.

A PR to lower the level in the profile will be created in Zonemaster-Engine (https://github.com/zonemaster/zonemaster-engine/pull/923).

* Adds reference to BASIC04, which tests all name servers for non-response.
* Lower default level to DEBUG for messages that report on non-response.
* ~~DNSSEC14 has not been updated. See discussion in zonemaster/zonemaster-engine#920~~
* DNSSEC14 is included.

Relates to #950 and #951