### PR TITLE
Updates NAMESERVER specifications to lower level of no response

### DIFF
--- a/docs/specifications/tests/Nameserver-TP/nameserver01.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver01.md
@@ -15,6 +15,11 @@ elaborated by [D.J. Bernstein].
 Section 2.5 of [RFC 2870] have very specific requirement on disabling 
 recursion functionality on root name servers.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * The domain name to be tested ("Child Zone").
@@ -54,7 +59,7 @@ In other cases the outcome of this Test Case is "pass".
 
 Message                       | Default severity level (if message is emitted)
 :-----------------------------|:-----------------------------------
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 IS_A_RECURSOR                 | ERROR
 NO_RECURSOR                   | INFO
 
@@ -81,6 +86,7 @@ Valid domain names according to the "IDNA 2008 specification" is found in
  
 
 
+[Basic04]:               ../Basic-TP/basic04.md
 [D.J. Bernstein]: http://cr.yp.to/djbdns/separation.html
 [IDNA 2008 specification]: #terminology
 [IS_A_RECURSOR]: #outcomes

--- a/docs/specifications/tests/Nameserver-TP/nameserver02.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver02.md
@@ -31,6 +31,11 @@ To eliminating the risk of falsely classifying the server as not supporting
 ENDS due e.g. firewall issues, the UDP buffer size is set to 512 bytes 
 (octets).
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -90,7 +95,7 @@ The outcome of this Test case is "pass" in all other cases.
 
 Message                           | Default severity level (when message is outputted)
 :---------------------------------|:-----------------------------------
-NO_RESPONSE                       | WARNING
+NO_RESPONSE                       | DEBUG
 NO_EDNS_SUPPORT                   | WARNING
 BREAKS_ON_EDNS                    | ERROR
 EDNS_RESPONSE_WITHOUT_EDNS        | ERROR
@@ -108,6 +113,7 @@ the ignored result.
 None
 
 
+[Basic04]:                       ../Basic-TP/basic04.md
 [BREAKS_ON_EDNS]:                #outcomes
 [EDNS_RESPONSE_WITHOUT_EDNS]:    #outcomes
 [EDNS_VERSION_ERROR]:            #outcomes

--- a/docs/specifications/tests/Nameserver-TP/nameserver05.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver05.md
@@ -11,6 +11,12 @@ misbehaviours trying to answer queries for AAAA records, as described in
 authoritative for the domain shows any of these behaviours.
 
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -66,7 +72,7 @@ AAAA_QUERY_DROPPED            | ERROR
 AAAA_UNEXPECTED_RCODE         | ERROR
 AAAA_WELL_PROCESSED           | INFO
 A_UNEXPECTED_RCODE            | WARNING
-NO_RESPONSE                   | WARNING
+NO_RESPONSE                   | DEBUG
 
 
 ## Special procedural requirements
@@ -86,6 +92,7 @@ None.
 [AAAA_UNEXPECTED_RCODE]: #outcomes
 [AAAA_WELL_PROCESSED]:   #outcomes
 [A_UNEXPECTED_RCODE]:    #outcomes
+[Basic04]:               ../Basic-TP/basic04.md
 [Method4]:               ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]:               ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 [NO_RESPONSE]:           #outcomes

--- a/docs/specifications/tests/Nameserver-TP/nameserver10.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver10.md
@@ -22,6 +22,11 @@ the combination of the normal RCODE field in the DNS package header
 EXTENDED-RCODE field ([RFC 6891][RFC 6891#6.1.3], section 6.1.3). Also see
 [IANA RCODE Registry].
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -63,7 +68,7 @@ The outcome of this Test case is "pass" in all other cases.
 
 Message                           | Default severity level (when message is outputted)
 :---------------------------------|:-----------------------------------
-NO_RESPONSE                       | WARNING
+NO_RESPONSE                       | DEBUG
 NO_EDNS_SUPPORT                   | WARNING
 UNSUPPORTED_EDNS_VER              | WARNING
 NS_ERROR                          | WARNING
@@ -79,6 +84,7 @@ the ignored result.
 None
 
 
+[Basic04]:              ../Basic-TP/basic04.md
 [IANA RCODE Registry]:  https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 [Method4]:              ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]:              ../Methods.md#method-5-obtain-the-name-server-address-records-from-child

--- a/docs/specifications/tests/Nameserver-TP/nameserver11.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver11.md
@@ -16,6 +16,11 @@ processed as though the OPTION-CODE was not even there.
 In this test case, we will query  with an unknown EDNS OPTION-CODE and expect
 that the OPTION-CODE is not present in the response for the query.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 "Child Zone" - The domain name to be tested.
@@ -59,10 +64,10 @@ The outcome of this Test case is "pass" in all other cases.
 
 Message                           | Default severity level (when message is outputed)
 :---------------------------------|:--------------------------------------------------
-NO_RESPONSE                       | WARNING
+NO_RESPONSE                       | DEBUG
 NO_EDNS_SUPPORT                   | WARNING
-NS_ERROR			  | WARNING     
-UNKNOWN_OPTION_CODE		  | WARNING     
+NS_ERROR                          | WARNING
+UNKNOWN_OPTION_CODE               | WARNING
 
 ## Special procedural requirements
 
@@ -76,6 +81,7 @@ None.
 
 
 
+[Basic04]:               ../Basic-TP/basic04.md
 [IANA-DNSSYSTEM-PARAMETERS]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-11
 [Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child

--- a/docs/specifications/tests/Nameserver-TP/nameserver12.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver12.md
@@ -18,6 +18,11 @@ In this test case, the query will have an unknown EDNS flag set, i.e.
 one of the Z flag bits set to "1", and it is expected that all "Z" 
 bits to be clear in the response (set to "0").
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 "Child Zone" - The domain name to be tested.
@@ -60,7 +65,7 @@ The outcome of this Test case is "pass" in all other cases.
 
 Message                           | Default severity level
 :---------------------------------|:----------------------------
-NO_RESPONSE                       | WARNING
+NO_RESPONSE                       | DEBUG
 NO_EDNS_SUPPORT                   | WARNING
 NS_ERROR                          | WARNING     
 Z_FLAGS_NOTCLEAR                  | WARNING
@@ -76,6 +81,7 @@ the ignored result.
 None.
 
 
+[Basic04]:                      ../Basic-TP/basic04.md
 [EDNS Header Flags]:            https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-13
 [IANA]:                         https://www.iana.org/
 [Method4]:                      ../Methods.md#method-4-obtain-glue-address-records-from-parent

--- a/docs/specifications/tests/Nameserver-TP/nameserver13.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver13.md
@@ -20,6 +20,11 @@ To trigger a truncated response, the OPT pseudo record 'DO' bit is set and the
 buffer size is limited to 512 bytes. If the zone is not signed with DNSSEC, the
 response will probably not be truncated anyway.
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
 ## Inputs
 
 "Child Zone" - The domain name to be tested.
@@ -62,10 +67,10 @@ The outcome of this Test case is "pass" in all other cases.
 
 Message                           | Default severity level (when message is outputed)
 :---------------------------------|:--------------------------------------------------
-NO_RESPONSE                       | WARNING
+NO_RESPONSE                       | DEBUG
 NO_EDNS_SUPPORT                   | WARNING
-NS_ERROR			  | WARNING     
-MISSING_OPT_IN_TRUNCATED   	  | WARNING
+NS_ERROR                          | WARNING
+MISSING_OPT_IN_TRUNCATED          | WARNING
 
 ## Special procedural requirements
 
@@ -79,6 +84,7 @@ None.
 
 
 
+[Basic04]:               ../Basic-TP/basic04.md
 [MISSING_OPT_IN_TRUNCATED]: #outcomes
 [Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child

--- a/docs/specifications/tests/Nameserver-TP/nameserver14.md
+++ b/docs/specifications/tests/Nameserver-TP/nameserver14.md
@@ -4,16 +4,21 @@
 
 **NAMESERVER14** 
 
-### Objective
+## Objective
 
 This test case actually combines the test options in test cases [NAMESERVER10]
 and [NAMESERVER11].
 
-### Inputs
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
+## Inputs
 
 "Child Zone" - The domain name to be tested.
 
-### Ordered description of steps to be taken to execute the test case
+## Ordered description of steps to be taken to execute the test case
 
 1. Create an SOA query for the *Child Zone* with an OPT record with 
    EDNS version set to "1" and  with EDNS OPTION-CODE set to an
@@ -45,7 +50,7 @@ and [NAMESERVER11].
 		4. The option is not present in the response
 	8. Else output *[NS_ERROR]*.
  
-### Outcome(s)
+## Outcome(s)
 
 The outcome of this Test Case is "fail" if there is at least one message
 with the severity level *ERROR* or *CRITICAL*.
@@ -58,13 +63,13 @@ The outcome of this Test case is "pass" in all other cases.
 
 Message                           | Default severity level (Output message)
 :---------------------------------|:--------------------------------------------------
-NO_RESPONSE                       | WARNING
+NO_RESPONSE                       | DEBUG
 NO_EDNS_SUPPORT                   | WARNING
-NS_ERROR			  | WARNING     
+NS_ERROR                          | WARNING
 UNKNOWN_OPTION_CODE               | WARNING
-UNSUPPORTED_EDNS_VER      	  | WARNING
+UNSUPPORTED_EDNS_VER              | WARNING
 
-### Special procedural requirements
+## Special procedural requirements
 
 If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
 result of any test using this transport protocol and log a message reporting
@@ -74,8 +79,8 @@ the ignored result.
 
 None.
 
-[IANA-DNSSYSTEM-PARAMETERS]:
-https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-11
+[Basic04]:               ../Basic-TP/basic04.md
+[IANA-DNSSYSTEM-PARAMETERS]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-11
 [Method4]: ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]: ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 [NAMESERVER10]: nameserver10.md


### PR DESCRIPTION
BASIC04 has been implemented to report on problem with responses from nameservers. The Nameserver specifications and their implementation, repeats reporting the same thing with no benefit. With this PR the Consistency test case will refer that to BASIC04.

A PR to lower the level in the profile is created in Zonemaster-Engine (https://github.com/zonemaster/zonemaster-engine/pull/923).

* Adds reference to BASIC04, which tests all name servers for non-response.
* Lower default level to DEBUG for messages that report on non-response.

This PR relates to #950, #951, #952