### PR TITLE
Updates Zone10 specifications to lower level of no response

### DIFF
--- a/docs/specifications/tests/Zone-TP/zone10.md
+++ b/docs/specifications/tests/Zone-TP/zone10.md
@@ -62,7 +62,7 @@ MULTIPLE_SOA                  | ERROR
 NO_RESPONSE                   | DEBUG
 NO_SOA_IN_RESPONSE            | DEBUG
 ONE_SOA                       | INFO
-WRONG_SOA                     | ERROR
+WRONG_SOA                     | DEBUG
 
 
 ## Special procedural requirements

--- a/docs/specifications/tests/Zone-TP/zone10.md
+++ b/docs/specifications/tests/Zone-TP/zone10.md
@@ -13,6 +13,12 @@ This test case will verify that the zone of the domain to be tested return
 exactly one SOA record.
 
 
+## Scope
+
+It is assumed that *Child Zone* has been tested by [Basic04]. This test
+case will set DEBUG level on messages for non-responsive name servers.
+
+
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
@@ -53,8 +59,8 @@ In other cases the outcome of this Test Case is "pass".
 Message                       | Default severity level
 :-----------------------------|:-----------------------------------
 MULTIPLE_SOA                  | ERROR
-NO_RESPONSE                   | WARNING
-NO_SOA_IN_RESPONSE            | WARNING
+NO_RESPONSE                   | DEBUG
+NO_SOA_IN_RESPONSE            | DEBUG
 ONE_SOA                       | INFO
 WRONG_SOA                     | ERROR
 
@@ -80,6 +86,7 @@ The term "send" (to an IP address) is used when a DNS query is sent to
 a specific name server.
 
 
+[Basic04]:                   ../Basic-TP/basic04.md
 [MULTIPLE_SOA]:              #outcomes
 [Method4]:                   ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]:                   ../Methods.md#method-5-obtain-the-name-server-address-records-from-child

--- a/docs/specifications/tests/Zone-TP/zone10.md
+++ b/docs/specifications/tests/Zone-TP/zone10.md
@@ -1,4 +1,4 @@
-# ZONE10: No multipe SOA records
+# ZONE10: No multiple SOA records
 
 
 ## Test case identifier


### PR DESCRIPTION
BASIC04 has been implemented to report on problem with responses from nameservers. The Zone10 specification and its implementation, repeats reporting the same thing with no benefit. With this PR the Zone10 test case will refer that to BASIC04.

A PR to lower the level in the profile is created in Zonemaster-Engine (https://github.com/zonemaster/zonemaster-engine/pull/923).

* Adds reference to BASIC04, which tests all name servers for non-response.
* Lower default level to DEBUG for messages that report on non-response.

This PR relates to #950, #951, #952, #953, #954