### PR TITLE
Updates copyright statements (zm/zm)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,10 @@
 ### Code license
 
-Copyright (c) 2013-2020, Internetstiftelsen (<https://internetstiftelsen.se/en/>)
-Copyright (c) 2013-2020, AFNIC (<https://www.afnic.fr/en/>)
+Copyright (c) The Swedish Internet Foundation (<https://internetstiftelsen.se/en/>)
+Copyright (c) AFNIC (<https://www.afnic.fr/en/>)
 All rights reserved.
+
+Copyright belongs to external contributor where applicable.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
@@ -28,8 +30,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### Documentation license
 
-Copyright (c) 2013-2020, Internetstiftelsen (<https://internetstiftelsen.se/en/>)
-Copyright (c) 2013-2020, AFNIC (<https://www.afnic.fr/en/>)
+Copyright (c) The Swedish Internet Foundation (<https://internetstiftelsen.se/en/>)
+Copyright (c) AFNIC (<https://www.afnic.fr/en/>)
+All rights reserved.
+
+Copyright belongs to external contributor where applicable.
 
 Creative Commons Attribution 4.0 International License applies. See
 <https://creativecommons.org/licenses/by/4.0/> for the license conditions.

--- a/USING.md
+++ b/USING.md
@@ -10,19 +10,13 @@ There are three ways one can use the Zonemaster software:
    * From the Command Line Interface (CLI): In this case, the user has to
      install two components of the Zonemaster software, i.e. the
      "zonemaster-engine" and the "zonemaster-cli". Reference for installing
-     these two components can be found from the [readme document](README.md).
+     these two components can be found from the [readme document][README-installation].
    * There are cases, wherein an organisation or a user, that wants to have the
      results of their DNS validation stored and can be viewed later. In that
      case, in addition to the "zonemaster-engine" and "zonemaster-cli", the user has
      to install the "zonemaster-backend" and the "zonemaster-gui". Reference for
-     installing in all these components can be found in the [readme document](README.md).
+     installing in all these components can be found in the [readme document][README-installation].
 
--------
 
-Copyright (c) 2013, 2014, 2015, IIS (The Internet Infrastructure Foundation)
-Copyright (c) 2013, 2014, 2015, AFNIC
-Creative Commons Attribution 4.0 International License
-
-You should have received a copy of the license along with this
-work.  If not, see <https://creativecommons.org/licenses/by/4.0/>.
+[README-installation]: https://github.com/zonemaster/zonemaster/blob/master/README.md#installation
 


### PR DESCRIPTION
## Purpose

In the copyright statement a range of years is given. That requires updates, but year is not needed.

Nothing is said about copyright for contributors.

## Changes

Removes year from copyright and "translates" the name of Internetstiftelsen. Adds statement about contributor's copyright.

Removes copyright statement from file not needing it.

## How to test this PR

No need to test.