### PR TITLE
Test specification template

### DIFF
--- a/docs/internal-documentation/templates/specifications/tests/MessageTagSpecification.md
+++ b/docs/internal-documentation/templates/specifications/tests/MessageTagSpecification.md
@@ -14,7 +14,7 @@ The tag can be broken into three parts, in order:
 
 ## Test case specific prefix
 
-The message tag prefix is an abreviation of the test case identifier created by
+The message tag prefix is an abbreviation of the test case identifier created by
 a 1-2 letter abbreviation of the test level name and the two-digit suffix of the
 test case ID. For specification of the test case ID see
 [Test Case Identifier Specification].

--- a/docs/internal-documentation/templates/specifications/tests/MessageTagSpecification.md
+++ b/docs/internal-documentation/templates/specifications/tests/MessageTagSpecification.md
@@ -1,0 +1,46 @@
+# Message Tag Specification
+
+Message tags outputted by the test cases, and defined in the test case
+specifications, must conform to the following specifications.
+
+The message tag must match the regex `/^[A-Z][A-Z0-9_][A-Z]$/`. Lower case
+letters are not allowed.
+
+The tag can be broken into three parts, in order:
+
+* Test case specific prefix
+* Delimiter "_"
+* Tag string
+
+## Test case specific prefix
+
+The message tag prefix is an abreviation of the test case identifier created by
+a 1-2 letter abbreviation of the test level name and the two-digit suffix of the
+test case ID. For specification of the test case ID see
+[Test Case Identifier Specification].
+
+The test level abbreviation is always as follows:
+
+Test level name  | Example Test case ID   | Abreviation | Prefix  | Example message tag
+:----------------|:-----------------------|:------------|:--------|:-------------------
+Address          | Adress01               | A           | A01     | A01_NO_RESPONSE
+Basic            | Basic04                | B           | B04     | B04_NO_DATA
+Connectivity     | Connectivity03         | CN          | CN03    | CN03_HAS_DATA
+Consistency      | Consistency01          | CS          | CS01    | CS01_SAME_VALUE
+DNSSEC           | DNSSEC15               | DS          | DS15    | DS15_NO_KEY
+Delegation       | Delegation05           | DG          | DG05    | DG05_NO_GLUE
+Nameserver       | Nameserver08           | N           | N08     | N08_TOO_FEW_NS
+Syntax           | Syntax06               | S           | S06     | S06_WRONG_FORMAT
+Zone             | Zone07                 | Z           | Z07     | Z07_SOA_RESTRY
+
+## Delimiter
+
+The delimiter between the prefix and the tag string is "_". See the examples in
+the table above.
+
+## Tag string
+
+The tag string should be a short string that gives information about the message.
+
+
+[Test Case Identifier Specification]:   TestCaseIdentifierSpecification.md

--- a/docs/internal-documentation/templates/specifications/tests/MessageTagSpecification.md
+++ b/docs/internal-documentation/templates/specifications/tests/MessageTagSpecification.md
@@ -21,7 +21,7 @@ test case ID. For specification of the test case ID see
 
 The test level abbreviation is always as follows:
 
-Test level name  | Example Test case ID   | Abreviation | Prefix  | Example message tag
+Test level name  | Example Test case ID   | Abbreviation| Prefix  | Example message tag
 :----------------|:-----------------------|:------------|:--------|:-------------------
 Address          | Adress01               | A           | A01     | A01_NO_RESPONSE
 Basic            | Basic04                | B           | B04     | B04_NO_DATA

--- a/docs/internal-documentation/templates/specifications/tests/Template01.md
+++ b/docs/internal-documentation/templates/specifications/tests/Template01.md
@@ -3,7 +3,7 @@
 
 # Template01: This is a test specification template
 
-> > Replace "Template01" with test case ID. Replace the text with at short
+> > Replace "Template01" with test case ID. Replace the text with a short
 > > description
 
 ## Test case identifier
@@ -65,7 +65,7 @@ giving a correct DNS response for an authoritative name server.
 
 ## Summary
 
-> > First we can have bullets, if applicable, that states noteable things about
+> > First we can have bullets, if applicable, that states notable things about
 > > the execution or the messages. E.g.
 * If no CDS record is found, the test case will terminate early
   with no message tag outputted.
@@ -74,8 +74,14 @@ giving a correct DNS response for an authoritative name server.
 
 > > Here is a table of all message tags referred to in the steps. The tag in the
 > > first column, the default severity level in the second, and a statement on
-> > when the message is outputted in the third. Always use the same table set-up,
-> > but with the correct tags. E.g.:
+> > when the message is outputted in the fourth.
+> >
+> > If data from the test, e.g. list of name server IP addresses, is to be
+> > outputted with the message, then the datatypes are listed in the third
+> > column, "arguments". The third column is left empty when no arguments are
+> > used for the message.
+> >
+> > Always use the same table set-up, but with the correct tags. E.g.:
 
 Message Tag outputted         | Level   | Arguments  | Description of when message tag is outputted
 :-----------------------------|:--------|:-----------|:--------------------------------------------
@@ -103,15 +109,15 @@ message. The argument names are defined in the [argument list].
 > > should be as explicit as possible to avoid that different implementations or
 > > executions do different interpretations or assumptions.
 > >
-> > The steps should written in such a way that it reasonbly possible to use
-> > them to execute the test case manually using tools such as [`dig`]. It can
-> > be assumed that the reader of the text has good understanding of DNS.
+> > The steps should be written in such a way that it is reasonably possible to
+> > use them to execute the test case manually using tools such as [`dig`]. It
+> > can be assumed that the reader of the text has good understanding of DNS.
 > >
 > > The steps should state what messages (message tags) to be outputted when.
 > > Only messages with default severity level DEBUG or higher can be included.
 > >
 > > All messages with level INFO or higher must be included. I.e. the
-> > implementation should not include messages with default level INFO or higer
+> > implementation should not include messages with default level INFO or higher
 > > unless included in the specification.
 > >
 > > Messages DEBUG or lower can be added in the implementation as needed.
@@ -182,8 +188,7 @@ The test case is only performed if some DNSKEY record is found in the
 
 None.
 
-> > ...cases or specification on the outcome that this test case depend on,
-> > e.g.:
+> > ...or specification on the outcome that this test case depend on, e.g.:
 
 Example of formal dependency to be added.
 
@@ -223,17 +228,17 @@ respected.
 
 
 > > ----
-> > The text below is invisible when rendered by Github.
+> > The links listed below are not invisible when rendered by Github.
 > >
 > > All link names are listed below to the left with the link target to the
-> > right. They are only visiable when viewing the source of this document.
+> > right. They are only visible when viewing the source of this document.
 > >
 > > All message tags are linked to section **Summary**
 
-[T01_ALGO_NOT_SUPPORTED_BY_ZM]: #summary
-[T01_HAS_NSEC]:                 #summary
-[T01_HAS_NSEC3]:                #summary
-[T01_INCONSISTENT_DNSSEC]:      #summary
+[T01_ALGO_NOT_SUPPORTED_BY_ZM]:         #summary
+[T01_HAS_NSEC]:                         #summary
+[T01_HAS_NSEC3]:                        #summary
+[T01_INCONSISTENT_DNSSEC]:              #summary
 
 > > All links in the template are absolute, but in the specification they should
 > > be relative if the link target is in the zonemaster/zonemaster repository.

--- a/docs/internal-documentation/templates/specifications/tests/Template01.md
+++ b/docs/internal-documentation/templates/specifications/tests/Template01.md
@@ -1,0 +1,253 @@
+> > Limit all lines to 80 characters with the possible exception of tables
+> > such as the one in the summary section.
+
+# Template01: This is a test specification template
+
+> > Replace "Template01" with test case ID. Replace the text with at short
+> > description
+
+## Test case identifier
+**Template01**
+
+> > Replace with correct test case ID as specified in the
+> > [Test Case Identifier Specification].
+
+## Table of contents
+
+> > If the specification contains extra sections, of if some section is not
+> > included, update the list. In the normal case, keep the following sections.
+
+* [Objective](#Objective)
+* [Scope](#Scope)
+* [Inputs](#Inputs)
+* [Summary](#Summary)
+* [Test procedure](#Test-procedure)
+* [Outcome(s)](#Outcomes)
+* [Special procedural requirements](#Special-procedural-requirements)
+* [Intercase dependencies](#Intercase-dependencies)
+* [Terminology](#terminology)
+
+## Objective
+
+> > Write a description of what this test case tests, i.e. the details that are
+> > considered to be right and wrong. Include references to RFCs and other
+> > documents.
+> >
+> > Do not include full links here (in the source). Put them at the end of the
+> > specification document instead, as in this template.
+> >
+> > Do have deep links, but keep the display text short if possible. E.g.:
+
+...described in [RFC 4035][RFC 4035#section-3.1.3], section 3.1.3, ...
+
+## Scope
+
+> > If this test case assumes, but not depends on, another test case then specify
+> > it. Dependency would mean that the test case is affected by the other test
+> > case, or even cannot be run if the other has not been run. Assuming that
+> > another test case been run is just to make it possible to ignore certain
+> > errors. E.g.:
+
+It is assumed that *Child Zone* has been tested and reported by [Basic04]. This
+test case will just ignore non-responsive name servers or name servers not
+giving a correct DNS response for an authoritative name server.
+
+
+## Inputs
+
+> > Input data to the test case. Always include the Child zone, but it can also
+> > be other data units.
+> >
+> > The input data name is put in quote marks '""', then a hyphen '-' as a
+> > separator, and finally a description.
+
+* "Child Zone" - The domain name to be tested.
+
+## Summary
+
+> > First we can have bullets, if applicable, that states noteable things about
+> > the execution or the messages. E.g.
+* If no CDS record is found, the test case will terminate early
+  with no message tag outputted.
+* If a CDS record is of "delete" type, then it can by definition not
+  match or point at any DNSKEY record.
+
+> > Here is a table of all message tags referred to in the steps. The tag in the
+> > first column, the default severity level in the second, and a statement on
+> > when the message is outputted in the third. Always use the same table set-up,
+> > but with the correct tags. E.g.:
+
+Message Tag outputted         | [Default level] | Description of when message tag is outputted
+:-----------------------------|:----------------|:-----------------------------------------
+T01_BROKEN_DNSSEC             | ERROR           | Replies do not follow the standard.
+T01_ALGO_NOT_SUPPORTED_BY_ZM  | NOTICE          | The algorithm used is not supported by the Zonemaster implementation.
+T01_HAS_NSEC                  | INFO            | The *Child Zone* uses NSEC.
+T01_HAS_NSEC3                 | INFO            | The *Child Zone* uses NSEC3.
+T01_INCONSISTENT_DNSSEC       | ERROR           | The configuration of the zone is inconsistent with respect to DNSSEC.
+
+> > The message tags should be formed following the [Message Tag Specification].
+> >
+> > The default level is selected from the
+> > [Severity Level Definitions][Default level].
+
+## Test procedure
+
+> > This section contains the detailed steps to execute the test case. The steps
+> > should be as explicit as possible to avoid that different implementations or
+> > execusions do different interpretations or assumptions.
+> >
+> > The steps should written in such a way that it reasonbly possible to use
+> > them to execute the test case manually using tools such as [`dig`]. It can
+> > be assumed that the reader of the text has good understanding of DNS.
+> >
+> > The steps should state what messages (message tags) to be outputted when.
+> > Only messages with default severity level DEBUG or higher can be included.
+> >
+> > All messages with level INFO or higher must be included. I.e. the
+> > implementation should not include messages with default level INFO or higer
+> > unless included in the specification.
+> >
+> > Messages DEBUG or lower can be added in the implementation as needed.
+> >
+> > Also include statement on what other information to be accompanied
+> > with the message (included as parameter to the message tag). Example of such
+> > information is IP adresses to name servers.
+> >
+> > When refering to the data defined in **Inputs** then use the name in
+> > *italic*, e.g.:
+
+2. Create a DNSKEY query with DO flag set for *Child Zone*.
+
+> > If data sets are created, then defined them in quote marks. E.g.:
+
+4. Create three empty sets, "NSEC-Zone", "NSEC3-Zone", and
+   "No-DNSSEC-Zone".
+
+> > When used (referred to) in the steps, make the name italic. E.g.:
+
+6. Add the name server IP to the *NSEC-Zone* set (*NSEC3-Zone*
+         set).
+
+> > When a message is outputted in the steps, it is done by outputting
+> > the message tag, "T01_HAS_NSEC3" in the example below. Make the tag as a link
+> > name in italic. What the link name points at is to be defined at the bottom
+> > of the document. E.g.:
+
+8. If the NSEC (NSEC3) records do not "cover" the
+   *Non-Existent Query Name*, then output *[T01_HAS_NSEC3]*
+
+## Outcome(s)
+> > First we have standard text that should normally be the same in all
+> > test case specifications.
+
+The outcome of this Test Case is "fail" if there is at least one message
+with the severity level *[ERROR]* or *[CRITICAL]*.
+
+The outcome of this Test Case is "warning" if there is at least one message
+with the severity level *[WARNING]*, but no message with severity level
+*ERROR* or *CRITICAL*.
+
+In other cases, no message or only messages with severity level
+*[INFO]* or *[NOTICE]*, the outcome of this Test Case is "pass".
+
+> > Then there could be statements about data being outputted from the test case
+> > for use as input data for other test cases.
+
+## Special procedural requirements
+
+> > First we have standard text that should normally be the same in all
+> > test case specifications.
+
+If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
+result of any test using this transport protocol. Log a message reporting
+on the ignored result.
+
+> > Then there could be some other limitations or specialties of how or when
+> > this test case is run. E.g.:
+
+The test case is only performed if some DNSKEY record is found in the
+*Child Zone*.
+
+## Intercase dependencies
+
+> > Either the following text if there is no formal dependencies on other test
+> > cases...
+
+None.
+
+> > ...cases or specification on the outcome that this test case depend on,
+> > e.g.:
+
+Example of formal dependency to be added.
+
+> > Also see the text under **Objective** about test cases that are assumed to be
+> > run, but that this test case does not depend on. I.e. not dependencies in a
+> > formal sense.
+
+
+## Terminology
+
+> > If there is no terminology to be explained, then this section should contain
+> > the following text:
+
+No special terminology for this test case.
+
+> > Following are examples of terminology that are candidates to be included
+> > in the section.
+
+The terms "in-bailiwick" and "out-of-bailiwick" are used as defined
+in [RFC 8499][RFC 8499#page-25], section 7, page 25.
+
+The term "glue records" is defined in [RFC 8499][RFC 8499#page-24], section 7,
+page 24.
+
+When the term "using Method" is used, names and IP addresses are fetched
+using the defined [Methods].
+
+The term "send" (to an IP address) is used when a DNS query is sent to
+a specific name server.
+
+The term "DNS Lookup" is used when a recursive lookup is used, though
+any changes to the DNS tree introduced by an [undelegated test] must be
+respected.
+
+
+
+
+
+> > ----
+> > The text below is invisible when rendered by Github.
+> >
+> > All link names are listed below to the left with the link target to the
+> > right. They are only visiable when viewing the source of this document.
+> >
+> > All message tags are linked to section **Summary**
+
+[T01_ALGO_NOT_SUPPORTED_BY_ZM]: #summary
+[T01_HAS_NSEC]:                 #summary
+[T01_HAS_NSEC3]:                #summary
+[T01_INCONSISTENT_DNSSEC]:      #summary
+
+> > All links in the template are absolute, but in the specification they should
+> > be relative if the link target is in the zonemaster/zonemaster repository.
+
+
+[Basic04]:                              https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/Basic-TP/basic04.md
+[CRITICAL]:                             https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#critical
+[Default level]:                        https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
+[ERROR]:                                https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#error
+[INFO]:                                 https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#info
+[Message Tag Specification]:            MessageTagSpecification.md
+[Methods]:                              ../Methods.md
+[NOTICE]:                               https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#notice
+[RFC 4035#section-3.1.3]:               https://tools.ietf.org/html/rfc4035#section-3.1.3
+[RFC 8499#page-24]:                     https://datatracker.ietf.org/doc/html/rfc8499#page-24
+[RFC 8499#page-25]:                     https://datatracker.ietf.org/doc/html/rfc8499#page-25
+[Test Case Identifier Specification]:   TestCaseIdentifierSpecification.md
+[Undelegated test]:                     ../../test-types/undelegated-test.md
+[WARNING]:                              https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#warning
+[`dig`]:                                https://en.wikipedia.org/wiki/Dig_(command)
+
+> > Keep all links sorted, and make a straight column of the link targets.
+
+

--- a/docs/internal-documentation/templates/specifications/tests/Template01.md
+++ b/docs/internal-documentation/templates/specifications/tests/Template01.md
@@ -77,18 +77,24 @@ giving a correct DNS response for an authoritative name server.
 > > when the message is outputted in the third. Always use the same table set-up,
 > > but with the correct tags. E.g.:
 
-Message Tag outputted         | [Default level] | Description of when message tag is outputted
-:-----------------------------|:----------------|:-----------------------------------------
-T01_BROKEN_DNSSEC             | ERROR           | Replies do not follow the standard.
-T01_ALGO_NOT_SUPPORTED_BY_ZM  | NOTICE          | The algorithm used is not supported by the Zonemaster implementation.
-T01_HAS_NSEC                  | INFO            | The *Child Zone* uses NSEC.
-T01_HAS_NSEC3                 | INFO            | The *Child Zone* uses NSEC3.
-T01_INCONSISTENT_DNSSEC       | ERROR           | The configuration of the zone is inconsistent with respect to DNSSEC.
+Message Tag outputted         | Level   | Params | Description of when message tag is outputted
+:-----------------------------|:--------|:-------|:--------------------------------------------
+T01_BROKEN_DNSSEC             | ERROR   |   X    | Replies do not follow the standard.
+T01_ALGO_NOT_SUPPORTED_BY_ZM  | NOTICE  |   X    | The algorithm used is not supported by the Zonemaster implementation.
+T01_HAS_NSEC                  | INFO    |        | The *Child Zone* uses NSEC.
+T01_HAS_NSEC3                 | INFO    |        | The *Child Zone* uses NSEC3.
+T01_INCONSISTENT_DNSSEC       | ERROR   |   X    | The configuration of the zone is inconsistent with respect to DNSSEC.
+
+"Level" in the table is the default severity level of the message. The severity
+level can be changed in the [Zonemaster-Engine profile]. Also see the
+[Severity Level Definitions] document.
+
+An "X" in the parms column indicate that the message is accompanied with data
+parameters, such as name server IP addresses.
 
 > > The message tags should be formed following the [Message Tag Specification].
 > >
-> > The default level is selected from the
-> > [Severity Level Definitions][Default level].
+> > The default severity level is selected from the [Severity Level Definitions].
 
 ## Test procedure
 
@@ -231,10 +237,8 @@ respected.
 > > All links in the template are absolute, but in the specification they should
 > > be relative if the link target is in the zonemaster/zonemaster repository.
 
-
 [Basic04]:                              https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/Basic-TP/basic04.md
 [CRITICAL]:                             https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#critical
-[Default level]:                        https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
 [ERROR]:                                https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#error
 [INFO]:                                 https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#info
 [Message Tag Specification]:            MessageTagSpecification.md
@@ -243,9 +247,11 @@ respected.
 [RFC 4035#section-3.1.3]:               https://tools.ietf.org/html/rfc4035#section-3.1.3
 [RFC 8499#page-24]:                     https://datatracker.ietf.org/doc/html/rfc8499#page-24
 [RFC 8499#page-25]:                     https://datatracker.ietf.org/doc/html/rfc8499#page-25
+[Severity Level Definitions]:           https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
 [Test Case Identifier Specification]:   TestCaseIdentifierSpecification.md
 [Undelegated test]:                     ../../test-types/undelegated-test.md
 [WARNING]:                              https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#warning
+[Zonemaster-Engine profile]:            https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
 [`dig`]:                                https://en.wikipedia.org/wiki/Dig_(command)
 
 > > Keep all links sorted, and make a straight column of the link targets.

--- a/docs/internal-documentation/templates/specifications/tests/Template01.md
+++ b/docs/internal-documentation/templates/specifications/tests/Template01.md
@@ -14,7 +14,7 @@
 
 ## Table of contents
 
-> > If the specification contains extra sections, of if some section is not
+> > If the specification contains extra sections, or if some section is not
 > > included, update the list. In the normal case, keep the following sections.
 
 * [Objective](#Objective)
@@ -45,7 +45,7 @@
 > > If this test case assumes, but not depends on, another test case then specify
 > > it. Dependency would mean that the test case is affected by the other test
 > > case, or even cannot be run if the other has not been run. Assuming that
-> > another test case been run is just to make it possible to ignore certain
+> > another test case has been run is just to make it possible to ignore certain
 > > errors. E.g.:
 
 It is assumed that *Child Zone* has been tested and reported by [Basic04]. This
@@ -94,7 +94,7 @@ T01_INCONSISTENT_DNSSEC       | ERROR           | The configuration of the zone 
 
 > > This section contains the detailed steps to execute the test case. The steps
 > > should be as explicit as possible to avoid that different implementations or
-> > execusions do different interpretations or assumptions.
+> > executions do different interpretations or assumptions.
 > >
 > > The steps should written in such a way that it reasonbly possible to use
 > > them to execute the test case manually using tools such as [`dig`]. It can

--- a/docs/internal-documentation/templates/specifications/tests/Template01.md
+++ b/docs/internal-documentation/templates/specifications/tests/Template01.md
@@ -77,20 +77,21 @@ giving a correct DNS response for an authoritative name server.
 > > when the message is outputted in the third. Always use the same table set-up,
 > > but with the correct tags. E.g.:
 
-Message Tag outputted         | Level   | Params | Description of when message tag is outputted
-:-----------------------------|:--------|:-------|:--------------------------------------------
-T01_BROKEN_DNSSEC             | ERROR   |   X    | Replies do not follow the standard.
-T01_ALGO_NOT_SUPPORTED_BY_ZM  | NOTICE  |   X    | The algorithm used is not supported by the Zonemaster implementation.
-T01_HAS_NSEC                  | INFO    |        | The *Child Zone* uses NSEC.
-T01_HAS_NSEC3                 | INFO    |        | The *Child Zone* uses NSEC3.
-T01_INCONSISTENT_DNSSEC       | ERROR   |   X    | The configuration of the zone is inconsistent with respect to DNSSEC.
+Message Tag outputted         | Level   | Arguments  | Description of when message tag is outputted
+:-----------------------------|:--------|:-----------|:--------------------------------------------
+T01_BROKEN_DNSSEC             | ERROR   | ns_ip_list | Replies do not follow the standard.
+T01_ALGO_NOT_SUPPORTED_BY_ZM  | NOTICE  | algo_descr, algo_num | The algorithm used is not supported by the Zonemaster implementation.
+T01_HAS_NSEC                  | INFO    |            | The *Child Zone* uses NSEC.
+T01_HAS_NSEC3                 | INFO    |            | The *Child Zone* uses NSEC3.
+T01_INCONSISTENT_DNSSEC       | ERROR   | keytag     | The configuration of the zone is inconsistent with respect to DNSSEC.
 
-"Level" in the table is the default severity level of the message. The severity
-level can be changed in the [Zonemaster-Engine profile]. Also see the
+The value in the Level column is the default severity level of the message. The
+severity level can be changed in the [Zonemaster-Engine profile]. Also see the
 [Severity Level Definitions] document.
 
-An "X" in the parms column indicate that the message is accompanied with data
-parameters, such as name server IP addresses.
+The argument names in the Arguments column lists the arguments used in the
+message. The argument names are defined in the [argument list].
+
 
 > > The message tags should be formed following the [Message Tag Specification].
 > >
@@ -237,6 +238,7 @@ respected.
 > > All links in the template are absolute, but in the specification they should
 > > be relative if the link target is in the zonemaster/zonemaster repository.
 
+[Argument list]:                        https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
 [Basic04]:                              https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/Basic-TP/basic04.md
 [CRITICAL]:                             https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#critical
 [ERROR]:                                https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#error
@@ -253,6 +255,7 @@ respected.
 [WARNING]:                              https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md#warning
 [Zonemaster-Engine profile]:            https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
 [`dig`]:                                https://en.wikipedia.org/wiki/Dig_(command)
+
 
 > > Keep all links sorted, and make a straight column of the link targets.
 

--- a/docs/internal-documentation/templates/specifications/tests/Template01.md
+++ b/docs/internal-documentation/templates/specifications/tests/Template01.md
@@ -81,15 +81,16 @@ giving a correct DNS response for an authoritative name server.
 > > column, "arguments". The third column is left empty when no arguments are
 > > used for the message.
 > >
-> > Always use the same table set-up, but with the correct tags. E.g.:
+> > Always use the same table set-up, but with the correct tags. Keep the table
+> > sorted by message tag. Here is an example:
 
-Message Tag outputted         | Level   | Arguments  | Description of when message tag is outputted
-:-----------------------------|:--------|:-----------|:--------------------------------------------
-T01_BROKEN_DNSSEC             | ERROR   | ns_ip_list | Replies do not follow the standard.
+Message Tag outputted         | Level   | Arguments            | Description of when message tag is outputted
+:-----------------------------|:--------|:---------------------|:--------------------------------------------
 T01_ALGO_NOT_SUPPORTED_BY_ZM  | NOTICE  | algo_descr, algo_num | The algorithm used is not supported by the Zonemaster implementation.
-T01_HAS_NSEC                  | INFO    |            | The *Child Zone* uses NSEC.
-T01_HAS_NSEC3                 | INFO    |            | The *Child Zone* uses NSEC3.
-T01_INCONSISTENT_DNSSEC       | ERROR   | keytag     | The configuration of the zone is inconsistent with respect to DNSSEC.
+T01_BROKEN_DNSSEC             | ERROR   | ns_ip_list           | Replies do not follow the standard.
+T01_HAS_NSEC                  | INFO    |                      | The *Child Zone* uses NSEC.
+T01_HAS_NSEC3                 | INFO    |                      | The *Child Zone* uses NSEC3.
+T01_INCONSISTENT_DNSSEC       | ERROR   | keytag               | The configuration of the zone is inconsistent with respect to DNSSEC.
 
 The value in the Level column is the default severity level of the message. The
 severity level can be changed in the [Zonemaster-Engine profile]. Also see the

--- a/docs/internal-documentation/templates/specifications/tests/Template01.md
+++ b/docs/internal-documentation/templates/specifications/tests/Template01.md
@@ -65,7 +65,7 @@ giving a correct DNS response for an authoritative name server.
 
 ## Summary
 
-> > First we can have bullets, if applicable, that states notable things about
+> > First we can have bullets, if applicable, that state notable things about
 > > the execution or the messages. E.g.
 * If no CDS record is found, the test case will terminate early
   with no message tag outputted.
@@ -228,7 +228,7 @@ respected.
 
 
 > > ----
-> > The links listed below are not invisible when rendered by Github.
+> > The links listed below are not visible when rendered by Github.
 > >
 > > All link names are listed below to the left with the link target to the
 > > right. They are only visible when viewing the source of this document.

--- a/docs/internal-documentation/templates/specifications/tests/Template01.md
+++ b/docs/internal-documentation/templates/specifications/tests/Template01.md
@@ -56,7 +56,7 @@ giving a correct DNS response for an authoritative name server.
 ## Inputs
 
 > > Input data to the test case. Always include the Child zone, but it can also
-> > be other data units.
+> > be other data units, such as current time, if that is relevant.
 > >
 > > The input data name is put in quote marks '""', then a hyphen '-' as a
 > > separator, and finally a description.
@@ -108,7 +108,7 @@ message. The argument names are defined in the [argument list].
 
 > > This section contains the detailed steps to execute the test case. The steps
 > > should be as explicit as possible to avoid that different implementations or
-> > executions do different interpretations or assumptions.
+> > executions make different interpretations or assumptions.
 > >
 > > The steps should be written in such a way that it is reasonably possible to
 > > use them to execute the test case manually using tools such as [`dig`]. It
@@ -121,7 +121,8 @@ message. The argument names are defined in the [argument list].
 > > implementation should not include messages with default level INFO or higher
 > > unless included in the specification.
 > >
-> > Messages DEBUG or lower can be added in the implementation as needed.
+> > Messages DEBUG or lower can be added in the implementation as needed without
+> > being included in the specification.
 > >
 > > Also include statement on what other information to be accompanied
 > > with the message (included as parameter to the message tag). Example of such
@@ -172,9 +173,9 @@ In other cases, no message or only messages with severity level
 > > First we have standard text that should normally be the same in all
 > > test case specifications.
 
-If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
-result of any test using this transport protocol. Log a message reporting
-on the ignored result.
+If either IPv4 or IPv6 transport is disabled, skip sending queries over that
+transport protocol. A message will be outputted reporting that the transport
+protocol has been skipped.
 
 > > Then there could be some other limitations or specialties of how or when
 > > this test case is run. E.g.:

--- a/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -13,12 +13,12 @@ test level's name. The following test levels are defined and available:
 * Syntax
 * Zone
 
-The test case identifier has the format: \<Test Level name> + \<Index>
+The test case identifier has the format: `{Test Level name} + {Index}`
 
 The test level name is listed above, and the identifier takes the same upper
 case/lower case format as listed above.
 
-The \<Index> is a two-digit suffix 01-99, and should be selected so that the test
+The `{Index}` is a two-digit suffix 01-99, and should be selected so that the test
 case identifier is unique. Normally the first free index is selected.
 
 Example of test case identifiers:

--- a/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -6,7 +6,7 @@ test level's name. The following test levels are defined and available:
 * Address
 * Basic
 * Connectivity
-* Consitency
+* Consistency
 * DNSSEC
 * Delegation
 * Nameserver
@@ -25,7 +25,7 @@ Example of test case identifiers:
 
 * Address03
 * Basic04
-* DNSSEC1515
+* DNSSEC15
 * Zone06
 
 One execptional test case identifier is `Basic00`, in which the index suffix is

--- a/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -1,0 +1,32 @@
+# Test Case Identifier Specification
+
+All test cases belong to one specific test level, and it gets its name from that
+test level's name. The following test levels are defined and available:
+
+* Address
+* Basic
+* Connectivity
+* Consitency
+* DNSSEC
+* Delegation
+* Nameserver
+* Syntax
+* Zone
+
+The test case identifier has the format: <Test Level name> + <Index>
+
+The test level name is listed above, and the identifier takes the same uppe
+case/lower case format as listed above.
+
+The <Index> is a two-digit suffix 01-99, and should be selected so that the test
+case identifier is unique. Normally the first free index is selected.
+
+Example of test case identifiers:
+
+* Address03
+* Basic04
+* DNSSEC1515
+* Zone06
+
+One execptional test case identifier is `Basic00`, in which the index suffix is
+out of range of the stated range above.

--- a/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -13,12 +13,12 @@ test level's name. The following test levels are defined and available:
 * Syntax
 * Zone
 
-The test case identifier has the format: <Test Level name> + <Index>
+The test case identifier has the format: \<Test Level name> + \<Index>
 
-The test level name is listed above, and the identifier takes the same uppe
+The test level name is listed above, and the identifier takes the same upper
 case/lower case format as listed above.
 
-The <Index> is a two-digit suffix 01-99, and should be selected so that the test
+The \<Index> is a two-digit suffix 01-99, and should be selected so that the test
 case identifier is unique. Normally the first free index is selected.
 
 Example of test case identifiers:


### PR DESCRIPTION
## Purpose

The test case specifications have evolved over the years, and different specifications have different layouts. Originally, the test message tags were not included, then they were added and then moved. The layout has changed gradually, and not always consistently since the only template available has been a recently updated or created specification.

## Changes

This PR adds two specifications and one template. The specifications are of "Message Tag" and "Test Case Identifier", respectively. The template is for a test case specification, and is dependent on the twp specifications.

The template should not be considered to be *The Final Template*, and should be updated when needed.

## How to test this PR

This documentation only, and no testing is relevant.
