### PR TITLE
Adds specification of default query and response handling

### DIFF
--- a/docs/specifications/tests/DNSQueryAndResponsSpecification.md
+++ b/docs/specifications/tests/DNSQueryAndResponsSpecification.md
@@ -1,0 +1,154 @@
+# DNS Query and Respons Specification
+
+**Table of contents**
+* [Overview](#Overview)
+* [Application of this specification](#application-of-this-specification)
+* [Default setting in *DNS Query*](#default-setting-in-dns-query)
+* [Default setting in *EDNS Query*](#default-setting-in-edns-query)
+* [Default setting in *DNSSEC Query*](#default-setting-in-dnssec-query)
+* [Default handling of a *DNS Response*](#default-handling-of-a-dns-response)
+* [Default handling of an *EDNS Response*](#default-handling-of-an-edns-response)
+* [Default handling of a *DNSSEC response*](#default-handling-of-a-dnssec-response)
+
+
+## Overview
+
+Almost all [test cases] emit DNS queries and react on the responses. This
+document defines the default "setting" of a DNS query and the default handling
+of "setting" in the DNS response. The meaning of "setting" here will be clear
+from the specification below.
+
+
+## Application of this specification
+
+This specification applies to all [test case specifications][Test Cases] that has
+an explicit reference to this document.
+
+
+## Default setting in *DNS Query*
+
+A *DNS Query* has the following default setting. A test case specification can
+refer to a *DNS Query* with one or several changes to the setting items.
+Specifically, the test case specification must always specify query name and
+query type.
+
+|Setting Item |Default value |Comment                      |
+|:------------|:----------|:-------------------------------|
+|Protocol     | UDP       |                                |
+|OpCode       | "query"   | Always "query" in a query      |
+|QR flag      | unset     | Always unset in a query        |
+|AA flag      | unset     |                                |
+|TC flag      | unset     |                                |
+|RD flag      | unset     |                                |
+|RA flag      | unset     |                                |
+|AD flag      | unset     |                                |
+|CD flag      | unset     |                                |
+|RCODE        | "NoError" | Always "NoError" in a query    |
+|Query name   | -         | Defined in test case           |
+|Query type   | -         | Defined in test case           |
+|ENDS         | no        | No OPT record is included      |
+
+
+## Default setting in *EDNS Query*
+
+An *EDNS Query* inherit the default setting from a *DNS Query* except for the
+setting items specified below.
+
+A test case specification can refer to an *EDNS Query* with one or several
+changes to the setting items. Specifically, the test case specification must
+always specify query name and query type.
+
+|Setting Item          |Default value |Comment                   |
+|:---------------------|:-------|:-------------------------------|
+|ENDS                  | yes    | OPT record is included         |
+|EDNS UDP Message size | 512    |                                |
+|ENDS Extended RCODE   | no     |                                |
+|ENDS Version          | 0      |                                |
+|ENDS DO flag          | unset  |                                |
+|EDNS Z lag            | unset  |                                |
+|EDNS0 Option          | none   |                                |
+
+
+## Default setting in *DNSSEC Query*
+
+An *DNSSEC Query* inherit the default setting from an *EDNS Query* except for the
+setting items specified below.
+
+A test case specification can refer to an *DNSSEC Query* with one or several
+changes to the setting items. Specifically, the test case specification must
+always specify query name and query type.
+
+|Setting               |Default value |Comment                   |
+|:---------------------|:-------|:-------------------------------|
+|ENDS DO flag          | set    |                                |
+
+
+## Default handling of a *DNS Response*
+
+A *DNS Response* is a response to a *DNS Query*. Unless specified in the test
+case specification, the items in the response is handled as listed.
+
+|Response Item |Default handling    | Comment                         |
+|:-------------|:-------------------|:--------------------------------|
+|OpCode        | Must be "response" | Always "response" in a response |
+|QR flag       | Must be set        | Always set in a response        |
+|AA flag       | -                  | Defined in test case            |
+|TC flag       | Re-query over TCP   |                                 |
+|RD flag       | ignore             |                                 |
+|RA flag       | ignore             |                                 |
+|AD flag       | ignore             |                                 |
+|CD flag       | ignore             |                                 |
+|RCODE         | -                  | Defined in test case            |
+|Query name    | ignore             |                                 |
+|Query type    | ignore             |                                 |
+|ENDS          | ignore             |                                 |
+
+
+* Check against query name and query type is, by default, done against the values
+  in the query, not in the response.
+  
+* When fetching records from the answer section, these are the default criteria:
+  * Only records matching the query name and the query type are fetched. RRSIG
+    records, when available, meeting the next criterium are also fetched.
+  * RRSIG records with the same query name and covering the query type are
+    fetched.
+  * CNAME records are ignored unless the query type is CNAME.
+
+* When CNAME chains are followed (by specification) and fetch from the answer
+  section, these are the default criteria:
+  * The first CNAME in the chain must match the query name.
+  * The last record in the chain must either be a CNAME or a record matching the
+    query type.
+
+* Authority and additional sections are by default ignored.
+
+
+## Default handling of an *EDNS Response*
+
+A *EDNS response* is a response to an *EDNS Query*. An *EDNS Response* inherits
+the default handling from a *DNS Response* except for the response items
+specified below. Unless specified in the test case specification, the items in
+the response is handled as the default handling.
+
+|Response Item |Default handling | Comment                            |
+|:-------------|:----------------|:-----------------------------------|
+|ENDS          | -               | Defined in test case specification |
+
+
+## Default handling of a *DNSSEC response*
+
+A *DNSSEC response* is a response to an *DNSSEC Query*. A *DNSSEC Response*
+inherits the default handling from a *EDNS Response* except for the response
+items specified below. Unless specified in the test case specification, the items
+in the response is handled as the default handling.
+
+|Response Item |Default handling | Comment                            |
+|:-------------|:----------------|:-----------------------------------|
+| EDNS DO flag | ignore          |                                    |
+
+
+
+[Test Cases]:                  README.md#list-of-defined-test-cases
+
+
+

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -13,7 +13,7 @@
 
 ## Overview
 
-Almost all [test cases] emit DNS queries and react on the responses. This
+Almost all [test cases] emit DNS queries and react to the responses. This
 document defines the default "setting" of a DNS query and the default handling
 of "setting" in the DNS response. The meaning of "setting" here will be clear
 from the specification below.
@@ -28,22 +28,22 @@ an explicit reference to this document.
 ## Default setting in *DNS Query*
 
 A *DNS Query* has the following default setting. A test case specification can
-refer to a *DNS Query* with one or several changes to the *Setting Items*
-overriding the default values. If a *Setting Item* is specified as "fixed" then
-the default value cannot be overidden.
+refer to a *DNS Query* with one or several changes to the *Parameters*
+overriding the default values. If a *Parameter* is specified as "fixed" (with a
+"X" in that column) then the default value cannot be overidden.
 
-|Setting Item |Default value |Fixed |Comment                       |
+|Parameter    |Default value |Fixed |Comment                       |
 |:------------|:-------------|:-----|:-----------------------------|
 |Protocol     | UDP          |      |                              |
-|OpCode       | "query"      | yes  |                              |
-|QR flag      | unset        | yes  | Always unset in a query      |
-|AA flag      | unset        | yes  |                              |
-|TC flag      | unset        | yes  |                              |
+|OpCode       | "query"      | X    |                              |
+|QR flag      | unset        | X    | Always unset in a query      |
+|AA flag      | unset        | X    |                              |
+|TC flag      | unset        | X    |                              |
 |RD flag      | unset        |      |                              |
-|RA flag      | unset        | yes  |                              |
+|RA flag      | unset        | X    |                              |
 |AD flag      | unset        |      |                              |
 |CD flag      | unset        |      |                              |
-|RCODE        | "NoError"    | yes  |                              |
+|RCODE        | "NoError"    | X    |                              |
 |Query name   | -            |      | Must be defined in test case |
 |Query type   | -            |      | Must be defined in test case |
 |Query class  | "IN"         |      |                              |
@@ -53,15 +53,15 @@ the default value cannot be overidden.
 ## Default setting in *EDNS Query*
 
 An *EDNS Query* inherit the default setting from a *DNS Query* except for the
-setting items specified below. If a *Setting Item* is specified as "fixed" then
-the default value cannot be overidden.
+parameters specified below. If a *Parameter* is specified as "fixed" (with a
+"X" in that column) then the default value cannot be overidden.
 
 A test case specification can refer to an *EDNS Query* with one or several
-changes to the setting items.
+changes to the *Parameters*.
 
-|Setting Item          |Default value        |Fixed |Comment |
+|Parameter             |Default value        |Fixed |Comment |
 |:---------------------|:--------------------|:-----|:-------|
-|EDNS                  | OPT record included | yes  |        |
+|EDNS                  | OPT record included | X    |        |
 |EDNS UDP Message size | 512                 |      |        |
 |EDNS Extended RCODE   | no                  |      |        |
 |EDNS Version          | 0                   |      |        |
@@ -72,30 +72,30 @@ changes to the setting items.
 
 ## Default setting in *DNSSEC Query*
 
-An *DNSSEC Query* inherit the default setting from an *EDNS Query* except for the
-setting items specified below. If a *Setting Item* is specified as "fixed" then
-the default value cannot be overidden.
+A *DNSSEC Query* inherits the default setting from an *EDNS Query* except for the
+parameter specified below. If a *Parameter* is specified as "fixed" (with a
+"X" in that column) then the default value cannot be overidden.
 
-A test case specification can refer to an *DNSSEC Query* with one or several
-changes to the setting items.
+A test case specification can refer to a *DNSSEC Query* with one or several
+changes to the Parameters.
 
-|Setting               |Default value |Fixed |Comment |
+|Parameter             |Default value |Fixed |Comment |
 |:---------------------|:-------------|:-----|:-------|
-|EDNS DO flag          | set          | yes  |        |
+|EDNS DO flag          | set          | X    |        |
 
 
 ## Default handling of a *DNS Response*
 
 A *DNS Response* is a response to a *DNS Query*. Unless specified in the test
-case specification, the items in the response is handled as listed. If a
-*Response Item* is specified as "fixed" then the requirement, as specified under
-"Default handling", must be successful for the response to be considered to be a
-valid DNS response.
+case specification, the items in the response are handled as listed. If a
+*Response Item* is specified as "fixed" (with a "X" in that column) then the
+requirement, as specified under "Default handling", must be successful for the
+response to be considered to be a valid DNS response.
 
 |Response Item |Default handling                          | Fixed | Comment              |
 |:-------------|:-----------------------------------------|:------|:---------------------|
-|OpCode        | Require value to be "response"           | yes   |                      |
-|QR flag       | Require flag to be set                   | yes   |                      |
+|OpCode        | Require value to be "response"           | X     |                      |
+|QR flag       | Require flag to be set                   | X     |                      |
 |AA flag       | -                                        |       | Defined in test case |
 |TC flag       | Re-query over TCP if set                 |       |                      |
 |RD flag       | ignore                                   |       |                      |
@@ -105,7 +105,7 @@ valid DNS response.
 |RCODE         | -                                        |       | Defined in test case |
 |Query name    | ignore                                   |       |                      |
 |Query type    | ignore                                   |       |                      |
-|Query class   | Require value to be same as in the query | yes   | Normally "IN"        |
+|Query class   | Require value to be same as in the query |       | Normally "IN"        |
 |EDNS          | ignore                                   |       |                      |
 
 * Check against query name and query type is, by default, done against the values
@@ -118,8 +118,8 @@ valid DNS response.
     fetched.
   * CNAME records are ignored unless the query type is CNAME.
 
-* When CNAME chains are followed (by specification) and fetch from the answer
-  section, these are the default criteria:
+* When the test case specification states that CNAME chains are to followed in
+  the the answer section, these are the default criteria:
   * The first CNAME in the chain must match the query name.
   * The last record in the chain must either be a CNAME or a record matching the
     query type.
@@ -132,21 +132,19 @@ valid DNS response.
 An *EDNS response* is a response to an *EDNS Query*. An *EDNS Response* inherits
 the default handling from a *DNS Response* except for the response items
 specified below. Unless specified in the test case specification, the items in
-the response is handled using the default handling.
+the response are handled using the default handling.
 
-|Response Item |Default handling                   | Comment                                                            |
-|:-------------|:----------------------------------|:-------------------------------------------------------------------|
-|EDNS          | Issue a message if OPT is missing | Set to DEBUG level unless specified in the test case specification |
+|Response Item |Default handling             | Comment                                                        |
+|:-------------|:----------------------------|:----------------------- ---------------------------------------|
+|EDNS          | Take note if OPT is missing | Further actions to be specified in the test case specification |
 
-The test case implementation should discover a missing OPT record and take some
-action.
 
 ## Default handling of a *DNSSEC response*
 
-A *DNSSEC response* is a response to an *DNSSEC Query*. A *DNSSEC Response*
+A *DNSSEC response* is a response to a *DNSSEC Query*. A *DNSSEC Response*
 inherits the default handling from a *EDNS Response* except for the response
 items specified below. Unless specified in the test case specification, the items
-in the response is handled using the default handling.
+in the response are handled using the default handling.
 
 |Response Item |Default handling                       | Comment                                                            |
 |:-------------|:------------------------------------- |:-------------------------------------------------------------------|

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -1,4 +1,4 @@
-# DNS Query and Respons Specification
+# DNS Query and Response Defaults
 
 **Table of contents**
 * [Overview](#Overview)
@@ -32,21 +32,22 @@ refer to a *DNS Query* with one or several changes to the setting items.
 Specifically, the test case specification must always specify query name and
 query type.
 
-|Setting Item |Default value |Comment                      |
-|:------------|:----------|:-------------------------------|
-|Protocol     | UDP       |                                |
-|OpCode       | "query"   | Always "query" in a query      |
-|QR flag      | unset     | Always unset in a query        |
-|AA flag      | unset     |                                |
-|TC flag      | unset     |                                |
-|RD flag      | unset     |                                |
-|RA flag      | unset     |                                |
-|AD flag      | unset     |                                |
-|CD flag      | unset     |                                |
-|RCODE        | "NoError" | Always "NoError" in a query    |
-|Query name   | -         | Defined in test case           |
-|Query type   | -         | Defined in test case           |
-|ENDS         | no        | No OPT record is included      |
+|Setting Item |Default value |Comment                         |
+|:------------|:-------------|:-------------------------------|
+|Protocol     | UDP          |                                |
+|OpCode       | "query"      | Always "query" in a query      |
+|QR flag      | unset        | Always unset in a query        |
+|AA flag      | unset        |                                |
+|TC flag      | unset        |                                |
+|RD flag      | unset        |                                |
+|RA flag      | unset        |                                |
+|AD flag      | unset        |                                |
+|CD flag      | unset        |                                |
+|RCODE        | "NoError"    | Always "NoError" in a query    |
+|Query name   | -            | Must be defined in test case   |
+|Query type   | -            | Must be defined in test case   |
+|Query class  | "IN"         | Always "IN" in the query       |
+|ENDS         | no           | No OPT record is included      |
 
 
 ## Default setting in *EDNS Query*
@@ -55,8 +56,7 @@ An *EDNS Query* inherit the default setting from a *DNS Query* except for the
 setting items specified below.
 
 A test case specification can refer to an *EDNS Query* with one or several
-changes to the setting items. Specifically, the test case specification must
-always specify query name and query type.
+changes to the setting items.
 
 |Setting Item          |Default value |Comment                   |
 |:---------------------|:-------|:-------------------------------|
@@ -75,8 +75,7 @@ An *DNSSEC Query* inherit the default setting from an *EDNS Query* except for th
 setting items specified below.
 
 A test case specification can refer to an *DNSSEC Query* with one or several
-changes to the setting items. Specifically, the test case specification must
-always specify query name and query type.
+changes to the setting items.
 
 |Setting               |Default value |Comment                   |
 |:---------------------|:-------|:-------------------------------|
@@ -93,7 +92,7 @@ case specification, the items in the response is handled as listed.
 |OpCode        | Must be "response" | Always "response" in a response |
 |QR flag       | Must be set        | Always set in a response        |
 |AA flag       | -                  | Defined in test case            |
-|TC flag       | Re-query over TCP   |                                 |
+|TC flag       | Re-query over TCP  |                                 |
 |RD flag       | ignore             |                                 |
 |RA flag       | ignore             |                                 |
 |AD flag       | ignore             |                                 |
@@ -101,6 +100,7 @@ case specification, the items in the response is handled as listed.
 |RCODE         | -                  | Defined in test case            |
 |Query name    | ignore             |                                 |
 |Query type    | ignore             |                                 |
+|Query class   | ignore             | Must be "IN" in the response    |
 |ENDS          | ignore             |                                 |
 
 
@@ -108,8 +108,8 @@ case specification, the items in the response is handled as listed.
   in the query, not in the response.
   
 * When fetching records from the answer section, these are the default criteria:
-  * Only records matching the query name and the query type are fetched. RRSIG
-    records, when available, meeting the next criterium are also fetched.
+  * Only records matching the query name and the query type are fetched. Any
+    RRSIG records meeting the next criterium are also fetched.
   * RRSIG records with the same query name and covering the query type are
     fetched.
   * CNAME records are ignored unless the query type is CNAME.
@@ -125,10 +125,10 @@ case specification, the items in the response is handled as listed.
 
 ## Default handling of an *EDNS Response*
 
-A *EDNS response* is a response to an *EDNS Query*. An *EDNS Response* inherits
+An *EDNS response* is a response to an *EDNS Query*. An *EDNS Response* inherits
 the default handling from a *DNS Response* except for the response items
 specified below. Unless specified in the test case specification, the items in
-the response is handled as the default handling.
+the response is handled using the default handling.
 
 |Response Item |Default handling | Comment                            |
 |:-------------|:----------------|:-----------------------------------|
@@ -140,7 +140,7 @@ the response is handled as the default handling.
 A *DNSSEC response* is a response to an *DNSSEC Query*. A *DNSSEC Response*
 inherits the default handling from a *EDNS Response* except for the response
 items specified below. Unless specified in the test case specification, the items
-in the response is handled as the default handling.
+in the response is handled using the default handling.
 
 |Response Item |Default handling | Comment                            |
 |:-------------|:----------------|:-----------------------------------|

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -28,80 +28,84 @@ an explicit reference to this document.
 ## Default setting in *DNS Query*
 
 A *DNS Query* has the following default setting. A test case specification can
-refer to a *DNS Query* with one or several changes to the setting items.
-Specifically, the test case specification must always specify query name and
-query type.
+refer to a *DNS Query* with one or several changes to the *Setting Items*
+overriding the default values. If a *Setting Item* is specified as "fixed" then
+the default value cannot be overidden.
 
-|Setting Item |Default value |Comment                         |
-|:------------|:-------------|:-------------------------------|
-|Protocol     | UDP          |                                |
-|OpCode       | "query"      | Always "query" in a query      |
-|QR flag      | unset        | Always unset in a query        |
-|AA flag      | unset        |                                |
-|TC flag      | unset        |                                |
-|RD flag      | unset        |                                |
-|RA flag      | unset        |                                |
-|AD flag      | unset        |                                |
-|CD flag      | unset        |                                |
-|RCODE        | "NoError"    | Always "NoError" in a query    |
-|Query name   | -            | Must be defined in test case   |
-|Query type   | -            | Must be defined in test case   |
-|Query class  | "IN"         | Always "IN" in the query       |
-|ENDS         | no           | No OPT record is included      |
+|Setting Item |Default value |Fixed |Comment                       |
+|:------------|:-------------|:-----|:-----------------------------|
+|Protocol     | UDP          |      |                              |
+|OpCode       | "query"      | yes  |                              |
+|QR flag      | unset        | yes  | Always unset in a query      |
+|AA flag      | unset        | yes  |                              |
+|TC flag      | unset        | yes  |                              |
+|RD flag      | unset        |      |                              |
+|RA flag      | unset        | yes  |                              |
+|AD flag      | unset        |      |                              |
+|CD flag      | unset        |      |                              |
+|RCODE        | "NoError"    | yes  |                              |
+|Query name   | -            |      | Must be defined in test case |
+|Query type   | -            |      | Must be defined in test case |
+|Query class  | "IN"         | yes  |                              |
+|EDNS         | no           |      | No OPT record is included    |
 
 
 ## Default setting in *EDNS Query*
 
 An *EDNS Query* inherit the default setting from a *DNS Query* except for the
-setting items specified below.
+setting items specified below. If a *Setting Item* is specified as "fixed" then
+the default value cannot be overidden.
 
 A test case specification can refer to an *EDNS Query* with one or several
 changes to the setting items.
 
-|Setting Item          |Default value |Comment                   |
-|:---------------------|:-------|:-------------------------------|
-|ENDS                  | yes    | OPT record is included         |
-|EDNS UDP Message size | 512    |                                |
-|ENDS Extended RCODE   | no     |                                |
-|ENDS Version          | 0      |                                |
-|ENDS DO flag          | unset  |                                |
-|EDNS Z lag            | unset  |                                |
-|EDNS0 Option          | none   |                                |
+|Setting Item          |Default value        |Fixed |Comment |
+|:---------------------|:--------------------|:-----|:-------|
+|EDNS                  | OPT record included | yes  |        |
+|EDNS UDP Message size | 512                 |      |        |
+|EDNS Extended RCODE   | no                  |      |        |
+|EDNS Version          | 0                   |      |        |
+|EDNS DO flag          | unset               |      |        |
+|EDNS Z lag            | unset               |      |        |
+|EDNS0 Option          | none                |      |        |
 
 
 ## Default setting in *DNSSEC Query*
 
 An *DNSSEC Query* inherit the default setting from an *EDNS Query* except for the
-setting items specified below.
+setting items specified below. If a *Setting Item* is specified as "fixed" then
+the default value cannot be overidden.
 
 A test case specification can refer to an *DNSSEC Query* with one or several
 changes to the setting items.
 
-|Setting               |Default value |Comment                   |
-|:---------------------|:-------|:-------------------------------|
-|ENDS DO flag          | set    |                                |
+|Setting               |Default value |Fixed |Comment |
+|:---------------------|:-------------|:-----|:-------|
+|EDNS DO flag          | set          | yes  |        |
 
 
 ## Default handling of a *DNS Response*
 
 A *DNS Response* is a response to a *DNS Query*. Unless specified in the test
-case specification, the items in the response is handled as listed.
+case specification, the items in the response is handled as listed. If a
+*Response Item* is specified as "fixed" then the requirement in default action
+must be successful for the response to be considered to be a valid DNS response.
 
-|Response Item |Default handling    | Comment                         |
-|:-------------|:-------------------|:--------------------------------|
-|OpCode        | Must be "response" | Always "response" in a response |
-|QR flag       | Must be set        | Always set in a response        |
-|AA flag       | -                  | Defined in test case            |
-|TC flag       | Re-query over TCP  |                                 |
-|RD flag       | ignore             |                                 |
-|RA flag       | ignore             |                                 |
-|AD flag       | ignore             |                                 |
-|CD flag       | ignore             |                                 |
-|RCODE         | -                  | Defined in test case            |
-|Query name    | ignore             |                                 |
-|Query type    | ignore             |                                 |
-|Query class   | ignore             | Must be "IN" in the response    |
-|ENDS          | ignore             |                                 |
+|Response Item |Default handling               | Fixed | Comment              |
+|:-------------|:------------------------------|:------|:---------------------|
+|OpCode        | Require value to be "response"| yes   |                      |
+|QR flag       | Require flag to be set        | yes   |                      |
+|AA flag       | -                             |       | Defined in test case |
+|TC flag       | Re-query over TCP if set      |       |                      |
+|RD flag       | ignore                        |       |                      |
+|RA flag       | ignore                        |       |                      |
+|AD flag       | ignore                        |       |                      |
+|CD flag       | ignore                        |       |                      |
+|RCODE         | -                             |       | Defined in test case |
+|Query name    | ignore                        |       |                      |
+|Query type    | ignore                        |       |                      |
+|Query class   | Require value to be "IN"      | yes   |                      |
+|EDNS          | ignore                        |       |                      |
 
 
 * Check against query name and query type is, by default, done against the values
@@ -130,10 +134,12 @@ the default handling from a *DNS Response* except for the response items
 specified below. Unless specified in the test case specification, the items in
 the response is handled using the default handling.
 
-|Response Item |Default handling | Comment                            |
-|:-------------|:----------------|:-----------------------------------|
-|ENDS          | -               | Defined in test case specification |
+|Response Item |Default handling                 | Comment                                                              |
+|:-------------|:--------------------------------|:---------------------------------------------------------------------|
+|EDNS          | Raise warning if OPT is missing | Create DEBUG message unless specified in the test case specification |
 
+The test case implementation should discover a missing OPT record and take some
+action.
 
 ## Default handling of a *DNSSEC response*
 
@@ -142,10 +148,12 @@ inherits the default handling from a *EDNS Response* except for the response
 items specified below. Unless specified in the test case specification, the items
 in the response is handled using the default handling.
 
-|Response Item |Default handling | Comment                            |
-|:-------------|:----------------|:-----------------------------------|
-| EDNS DO flag | ignore          |                                    |
+|Response Item |Default handling                     | Comment                                                              |
+|:-------------|:----------------------------------- |:---------------------------------------------------------------------|
+| EDNS DO flag | Raise warning if DO flag is missing | Create DEBUG message unless specified in the test case specification |
 
+The test case implementation should discover a missing DO flag and take some
+action.
 
 
 [Test Cases]:                  README.md#list-of-defined-test-cases

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -109,7 +109,7 @@ to be considered to be a DNS response.
 |EDNS          | ignore                                   |       |                      |
 
 * Check against query name and query type is, by default, done against the values
-  in the query section in the query, not in the response.
+  in the question section in the query, not in the response.
   
 * When fetching records from the answer section, these are the default criteria:
   * Only records matching the query name and the query type are fetched. Any
@@ -118,9 +118,11 @@ to be considered to be a DNS response.
     fetched.
   * CNAME records are ignored unless the query type is CNAME.
 
-* When the test case specification states that CNAME chains are to be followed in
-  the the answer section, these are the default criteria for the chain to be
-  fetched:
+* When the test case specification states that a CNAME chain is to be followed,
+  the default handling is to look for a valid CNAME chain in the answer section
+  and fetch all records in that chain. The records in the chain are arranged in
+  the logical order. These are the default criteria for a CNAME chain to be
+  valid:
   * The first CNAME in the chain must match the query name.
   * The last record in the chain must either be a CNAME or a record matching the
     query type.
@@ -139,7 +141,7 @@ specified below. Unless specified in the test case specification, the items in
 the response are handled using the default handling.
 
 |Response Item |Default handling             | Comment                                                        |
-|:-------------|:----------------------------|:----------------------- ---------------------------------------|
+|:-------------|:----------------------------|:---------------------------------------------------------------|
 |EDNS          | Take note if OPT is missing | Further actions to be specified in the test case specification |
 
 
@@ -150,7 +152,7 @@ inherits the default handling from a *EDNS Response* except for the response
 items specified below. Unless specified in the test case specification, the items
 in the response are handled using the default handling.
 
-|Response Item |Default handlin                  | Comment                                                        |
+|Response Item |Default handling                 | Comment                                                        |
 |:-------------|:------------------------------- |:---------------------------------------------------------------|
 | EDNS DO flag | Take note if DO flag is missing | Further actions to be specified in the test case specification |
 

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -82,6 +82,7 @@ changes to the Parameters.
 |Parameter             |Default value |Fixed |Comment |
 |:---------------------|:-------------|:-----|:-------|
 |EDNS DO flag          | set          | X    |        |
+|EDNS UDP Message size | 1280         |      |        |
 
 
 ## Default handling of a *DNS Response*

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -113,20 +113,20 @@ to be considered to be a DNS response.
   in the question section in the query, not in the response.
   
 * When fetching records from the answer section, these are the default criteria:
-  * Only records matching the query name and the query type are fetched. Any
-    RRSIG records meeting the next criterium are also fetched.
-  * RRSIG records with the same query name and covering the query type are
+  * Only records matching *Query Name* and *Query Type* are fetched. Any
+    RRSIG records meeting the next criterion are also fetched.
+  * RRSIG records matching *Query Name* and covering *Query Type* are
     fetched.
-  * CNAME records are ignored unless the query type is CNAME.
+  * CNAME records are ignored unless *Query Type* is CNAME.
 
 * When the test case specification states that a CNAME chain is to be followed,
   the default handling is to look for a valid CNAME chain in the answer section
   and fetch all records in that chain. The records in the chain are arranged in
   the logical order. These are the default criteria for a CNAME chain to be
   valid:
-  * The first CNAME in the chain must match the query name.
-  * The last record in the chain must either be a CNAME or a record matching the
-    query type.
+  * The first CNAME in the chain must match *Query Name*.
+  * The last record in the chain must either be a CNAME or a record matching
+    *Query Type*.
   * For each owner name of the CNAME records in the chain there must not be any
     additional CNAME records in the answer section (only one CNAME record per
     owner name).

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -46,7 +46,7 @@ the default value cannot be overidden.
 |RCODE        | "NoError"    | yes  |                              |
 |Query name   | -            |      | Must be defined in test case |
 |Query type   | -            |      | Must be defined in test case |
-|Query class  | "IN"         | yes  |                              |
+|Query class  | "IN"         |      |                              |
 |EDNS         | no           |      | No OPT record is included    |
 
 
@@ -92,22 +92,21 @@ case specification, the items in the response is handled as listed. If a
 "Default handling", must be successful for the response to be considered to be a
 valid DNS response.
 
-|Response Item |Default handling               | Fixed | Comment              |
-|:-------------|:------------------------------|:------|:---------------------|
-|OpCode        | Require value to be "response"| yes   |                      |
-|QR flag       | Require flag to be set        | yes   |                      |
-|AA flag       | -                             |       | Defined in test case |
-|TC flag       | Re-query over TCP if set      |       |                      |
-|RD flag       | ignore                        |       |                      |
-|RA flag       | ignore                        |       |                      |
-|AD flag       | ignore                        |       |                      |
-|CD flag       | ignore                        |       |                      |
-|RCODE         | -                             |       | Defined in test case |
-|Query name    | ignore                        |       |                      |
-|Query type    | ignore                        |       |                      |
-|Query class   | Require value to be "IN"      | yes   |                      |
-|EDNS          | ignore                        |       |                      |
-
+|Response Item |Default handling                          | Fixed | Comment              |
+|:-------------|:-----------------------------------------|:------|:---------------------|
+|OpCode        | Require value to be "response"           | yes   |                      |
+|QR flag       | Require flag to be set                   | yes   |                      |
+|AA flag       | -                                        |       | Defined in test case |
+|TC flag       | Re-query over TCP if set                 |       |                      |
+|RD flag       | ignore                                   |       |                      |
+|RA flag       | ignore                                   |       |                      |
+|AD flag       | ignore                                   |       |                      |
+|CD flag       | ignore                                   |       |                      |
+|RCODE         | -                                        |       | Defined in test case |
+|Query name    | ignore                                   |       |                      |
+|Query type    | ignore                                   |       |                      |
+|Query class   | Require value to be same as in the query | yes   | Normally "IN"        |
+|EDNS          | ignore                                   |       |                      |
 
 * Check against query name and query type is, by default, done against the values
   in the query, not in the response.

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -29,7 +29,7 @@ an explicit reference to this document.
 
 A *DNS Query* has the following default setting. A test case specification can
 refer to a *DNS Query* with one or several changes to the *Parameters*
-overriding the default values. If a *Parameter* is specified as "fixed" (with a
+overriding the default values. If a *Parameter* is specified as "fixed" (with an
 "X" in that column) then the default value cannot be overidden.
 
 |Parameter    |Default value |Fixed |Comment                       |
@@ -53,7 +53,7 @@ overriding the default values. If a *Parameter* is specified as "fixed" (with a
 ## Default setting in *EDNS Query*
 
 An *EDNS Query* inherit the default setting from a *DNS Query* except for the
-parameters specified below. If a *Parameter* is specified as "fixed" (with a
+parameters specified below. If a *Parameter* is specified as "fixed" (with an
 "X" in that column) then the default value cannot be overidden.
 
 A test case specification can refer to an *EDNS Query* with one or several
@@ -73,7 +73,7 @@ changes to the *Parameters*.
 ## Default setting in *DNSSEC Query*
 
 A *DNSSEC Query* inherits the default setting from an *EDNS Query* except for the
-parameter specified below. If a *Parameter* is specified as "fixed" (with a
+parameter specified below. If a *Parameter* is specified as "fixed" (with an
 "X" in that column) then the default value cannot be overidden.
 
 A test case specification can refer to a *DNSSEC Query* with one or several
@@ -88,7 +88,7 @@ changes to the Parameters.
 
 A *DNS Response* is a response to a *DNS Query*. Unless specified in the test
 case specification, the items in the response are handled as listed. If a
-*Response Item* is specified as "fixed" (with a "X" in that column) then the
+*Response Item* is specified as "fixed" (with an "X" in that column) then the
 requirement, as specified under "Default handling", must be successful for the
 response to be considered to be a valid DNS response.
 
@@ -109,7 +109,7 @@ response to be considered to be a valid DNS response.
 |EDNS          | ignore                                   |       |                      |
 
 * Check against query name and query type is, by default, done against the values
-  in the query, not in the response.
+  in the query section in the query, not in the response.
   
 * When fetching records from the answer section, these are the default criteria:
   * Only records matching the query name and the query type are fetched. Any
@@ -118,11 +118,15 @@ response to be considered to be a valid DNS response.
     fetched.
   * CNAME records are ignored unless the query type is CNAME.
 
-* When the test case specification states that CNAME chains are to followed in
-  the the answer section, these are the default criteria:
+* When the test case specification states that CNAME chains are to be followed in
+  the the answer section, these are the default criteria for the chain to be
+  fetched:
   * The first CNAME in the chain must match the query name.
   * The last record in the chain must either be a CNAME or a record matching the
     query type.
+  * For each owner name of the CNAME records in the chain there must not be any
+    additional CNAME records in the answer section (only one CNAME record per
+    owner name).
 
 * Authority and additional sections are by default ignored.
 
@@ -146,12 +150,10 @@ inherits the default handling from a *EDNS Response* except for the response
 items specified below. Unless specified in the test case specification, the items
 in the response are handled using the default handling.
 
-|Response Item |Default handling                       | Comment                                                            |
-|:-------------|:------------------------------------- |:-------------------------------------------------------------------|
-| EDNS DO flag | Issue a message if DO flag is missing | Set to DEBUG level unless specified in the test case specification |
+|Response Item |Default handlin                  | Comment                                                        |
+|:-------------|:------------------------------- |:---------------------------------------------------------------|
+| EDNS DO flag | Take note if DO flag is missing | Further actions to be specified in the test case specification |
 
-The test case implementation should discover a missing DO flag and take some
-action.
 
 
 [Test Cases]:                  README.md#list-of-defined-test-cases

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -44,9 +44,9 @@ overriding the default values. If a *Parameter* is specified as "fixed" (with an
 |AD flag      | unset        |      |                              |
 |CD flag      | unset        |      |                              |
 |RCODE        | "NoError"    | X    |                              |
-|Query name   | -            |      | Must be defined in test case |
-|Query type   | -            |      | Must be defined in test case |
-|Query class  | "IN"         |      |                              |
+|Query Name   | -            |      | Must be defined in test case |
+|Query Type   | -            |      | Must be defined in test case |
+|Query Class  | "IN"         |      |                              |
 |EDNS         | no           |      | No OPT record is included    |
 
 
@@ -104,9 +104,9 @@ to be considered to be a DNS response.
 |AD flag       | ignore                                   |       |                      |
 |CD flag       | ignore                                   |       |                      |
 |RCODE         | -                                        |       | Defined in test case |
-|Query name    | ignore                                   |       |                      |
-|Query type    | ignore                                   |       |                      |
-|Query class   | Require value to be same as in the query |       | Normally "IN"        |
+|Query Name    | ignore                                   |       |                      |
+|Query Type    | ignore                                   |       |                      |
+|Query Class   | Require value to be same as in the query |       | Normally "IN"        |
 |EDNS          | ignore                                   |       |                      |
 
 * Check against query name and query type is, by default, done against the values
@@ -120,18 +120,26 @@ to be considered to be a DNS response.
   * CNAME records are ignored unless *Query Type* is CNAME.
 
 * When the test case specification states that a CNAME chain is to be followed,
-  the default handling is to look for a valid CNAME chain in the answer section
-  and fetch all records in that chain. The records in the chain are arranged in
-  the logical order. These are the default criteria for a CNAME chain to be
-  valid:
-  * The first CNAME in the chain must match *Query Name*.
-  * The last record in the chain must either be a CNAME or a record matching
-    *Query Type*.
-  * For each owner name of the CNAME records in the chain there must not be any
-    additional CNAME records in the answer section (only one CNAME record per
-    owner name).
+  the default handling is to only follow a CNAME, and fetch the records, if the
+  CNAME chain is valid.
+  * The chain is, by default, considered to be valid if the following criteria
+    are met:
+    * It must be possible to arrange all CNAME records from the answer section
+      into a contiguous logical chain with a posisble addition of a non-CNAME
+      record whose owner name matches the RDATA of the last CNAME record.
+    * The owner name of the first CNAME record in the chain must match
+      *Query Name*.
+    * The last record in the chain must either be a CNAME or a record matching
+      *Query Type*.
+    * For each owner name of the CNAME records in the chain there must not be any
+      additional records in the answer section with the same owner name besides
+      RRSIG and NSEC records (that may exist).
+  * CNAME records not part of a valid CNAME chain are by default ignored.
 
 * Authority and additional sections are by default ignored.
+
+The test case specification may prescribe that CNAME records are handled in an a
+different way than the default above.
 
 
 ## Default handling of an *EDNS Response*

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -138,7 +138,7 @@ to be considered to be a DNS response.
 
 * Authority and additional sections are by default ignored.
 
-The test case specification may prescribe that CNAME records are handled in an a
+The test case specification may prescribe that CNAME records are handled in a
 different way than the default above.
 
 

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -66,7 +66,7 @@ changes to the setting items.
 |EDNS Extended RCODE   | no                  |      |        |
 |EDNS Version          | 0                   |      |        |
 |EDNS DO flag          | unset               |      |        |
-|EDNS Z lag            | unset               |      |        |
+|EDNS Z flag           | unset               |      |        |
 |EDNS0 Option          | none                |      |        |
 
 
@@ -88,8 +88,9 @@ changes to the setting items.
 
 A *DNS Response* is a response to a *DNS Query*. Unless specified in the test
 case specification, the items in the response is handled as listed. If a
-*Response Item* is specified as "fixed" then the requirement in default action
-must be successful for the response to be considered to be a valid DNS response.
+*Response Item* is specified as "fixed" then the requirement, as specified under
+"Default handling", must be successful for the response to be considered to be a
+valid DNS response.
 
 |Response Item |Default handling               | Fixed | Comment              |
 |:-------------|:------------------------------|:------|:---------------------|
@@ -134,9 +135,9 @@ the default handling from a *DNS Response* except for the response items
 specified below. Unless specified in the test case specification, the items in
 the response is handled using the default handling.
 
-|Response Item |Default handling                 | Comment                                                              |
-|:-------------|:--------------------------------|:---------------------------------------------------------------------|
-|EDNS          | Raise warning if OPT is missing | Create DEBUG message unless specified in the test case specification |
+|Response Item |Default handling                   | Comment                                                            |
+|:-------------|:----------------------------------|:-------------------------------------------------------------------|
+|EDNS          | Issue a message if OPT is missing | Set to DEBUG level unless specified in the test case specification |
 
 The test case implementation should discover a missing OPT record and take some
 action.
@@ -148,9 +149,9 @@ inherits the default handling from a *EDNS Response* except for the response
 items specified below. Unless specified in the test case specification, the items
 in the response is handled using the default handling.
 
-|Response Item |Default handling                     | Comment                                                              |
-|:-------------|:----------------------------------- |:---------------------------------------------------------------------|
-| EDNS DO flag | Raise warning if DO flag is missing | Create DEBUG message unless specified in the test case specification |
+|Response Item |Default handling                       | Comment                                                            |
+|:-------------|:------------------------------------- |:-------------------------------------------------------------------|
+| EDNS DO flag | Issue a message if DO flag is missing | Set to DEBUG level unless specified in the test case specification |
 
 The test case implementation should discover a missing DO flag and take some
 action.

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -88,10 +88,15 @@ changes to the Parameters.
 ## Default handling of a *DNS Response*
 
 A *DNS Response* is a response to a *DNS Query*. Unless specified in the test
-case specification, the items in the response are handled as listed. If a
-*Response Item* is specified as "fixed" (with an "X" in that column) then the
-requirement, as specified under "Default handling", must be met for the response
-to be considered to be a DNS response.
+case specification, the items in the response are handled as listed in the table
+below. 
+
+
+### Validation of DNS message
+
+If a *Response Item* is specified as "fixed" (with an "X" in that column) then
+the requirement, as specified under "Default handling", must be met for the
+response to be considered to be a DNS response.
 
 |Response Item |Default handling                          | Fixed | Comment              |
 |:-------------|:-----------------------------------------|:------|:---------------------|
@@ -109,6 +114,9 @@ to be considered to be a DNS response.
 |Query Class   | Require value to be same as in the query |       | Normally "IN"        |
 |EDNS          | ignore                                   |       |                      |
 
+
+### Extraction of DNS records
+
 * Owner name and record type of a DNS record are compared, by default, against
   *Query Name* and *Query Type* in the question section in the query, not in the
   response.
@@ -121,8 +129,8 @@ to be considered to be a DNS response.
   * CNAME records are ignored unless *Query Type* is CNAME.
 
 * When the test case specification states that a CNAME chain is to be followed,
-  the default handling is to only follow a CNAME, and fetch the records, if the
-  CNAME chain is valid.
+  the default handling is to only follow a CNAME chain, and fetch the records, if
+  the CNAME chain is valid.
   * The chain is, by default, considered to be valid if the following criteria
     are met:
     * It must be possible to arrange all CNAME records from the answer section

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -36,7 +36,7 @@ overriding the default values. If a *Parameter* is specified as "fixed" (with an
 |:------------|:-------------|:-----|:-----------------------------|
 |Protocol     | UDP          |      |                              |
 |OpCode       | "query"      | X    |                              |
-|QR flag      | unset        | X    | Always unset in a query      |
+|QR flag      | unset        | X    |                              |
 |AA flag      | unset        | X    |                              |
 |TC flag      | unset        | X    |                              |
 |RD flag      | unset        |      |                              |
@@ -125,7 +125,7 @@ to be considered to be a DNS response.
   * The chain is, by default, considered to be valid if the following criteria
     are met:
     * It must be possible to arrange all CNAME records from the answer section
-      into a contiguous logical chain with a posisble addition of a non-CNAME
+      into a contiguous logical chain with a possible addition of a non-CNAME
       record whose owner name matches the RDATA of the last CNAME record.
     * The owner name of the first CNAME record in the chain must match
       *Query Name*.

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -89,8 +89,8 @@ changes to the Parameters.
 A *DNS Response* is a response to a *DNS Query*. Unless specified in the test
 case specification, the items in the response are handled as listed. If a
 *Response Item* is specified as "fixed" (with an "X" in that column) then the
-requirement, as specified under "Default handling", must be successful for the
-response to be considered to be a valid DNS response.
+requirement, as specified under "Default handling", must be met for the response
+to be considered to be a DNS response.
 
 |Response Item |Default handling                          | Fixed | Comment              |
 |:-------------|:-----------------------------------------|:------|:---------------------|

--- a/docs/specifications/tests/DNSQueryAndResponseDefaults.md
+++ b/docs/specifications/tests/DNSQueryAndResponseDefaults.md
@@ -109,8 +109,9 @@ to be considered to be a DNS response.
 |Query Class   | Require value to be same as in the query |       | Normally "IN"        |
 |EDNS          | ignore                                   |       |                      |
 
-* Check against query name and query type is, by default, done against the values
-  in the question section in the query, not in the response.
+* Owner name and record type of a DNS record are compared, by default, against
+  *Query Name* and *Query Type* in the question section in the query, not in the
+  response.
   
 * When fetching records from the answer section, these are the default criteria:
   * Only records matching *Query Name* and *Query Type* are fetched. Any


### PR DESCRIPTION
## Purpose

This PR adds a specification for the default setting of the DNS queries that the test cases emit. Test cases are to refer to this specification and use the default setting or specify the deviation.

1. By having a shared specification the test cases will be more consistent.
2. The test case specifications do not have to specify the DNS query when default values are used.

The specification also has default handling of the response, and that will give consistent handling in the test cases.