### PR TITLE
Adds Docker image creation to the release process

### DIFF
--- a/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
@@ -23,7 +23,7 @@ Zonemaster-Engine and Zonemaster-CLI are covered here.
 
 ## 2. Prerequsite
 
-The steps in this documents are assumet to be executed on a computer installed
+The steps in this documents are assumed to be executed on a computer installed
 as an [Ubuntu Build Environment] computer. It could work on another OS as long
 as the same support is available.
 
@@ -132,13 +132,13 @@ docker push zonemaster/cli:v0.0.0
 Zonemaster-LDNS:
 
 ```sh
-docker run --rm --entrypoint=perl zonemaster/ldns:local -MZonemaster::LDNS -E 'say Zonemaster::LDNS->new("9.9.9.9")->query("zonemaster.net")->string'
+docker run --rm zonemaster/ldns:local perl -MZonemaster::LDNS -E 'say Zonemaster::LDNS->new("9.9.9.9")->query("zonemaster.net")->string'
 ```
 
 Zonemaster-Engine:
 
 ```sh
-docker run --rm --entrypoint=perl zonemaster/engine:local -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_module("BASIC", "zonemaster.net")'
+docker run --rm zonemaster/engine:local perl -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_module("BASIC", "zonemaster.net")'
 ```
 
 Zonemaster-CLI:

--- a/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
@@ -1,0 +1,195 @@
+Release Process - Create Docker Image
+=====================================
+
+## Table of contents
+
+* [1. Overview](#1-overview)
+* [2. Prerequsite](#2-prerequsite)
+* [3. Create Docker images](#3-create-docker-images)
+* [4. Upload images to Docker Hub](#4-upload-images-to-docker-hub)
+* [5. Image sanity checks][sanity checks]
+* [6. Handy Docker commands](#6-handy-docker-commands)
+
+## 1. Overview
+
+This document covers two stages in the release processes:
+
+1. Creating Docker images for testing.
+2. Creating Docker image for publishing on Docker Hub
+
+Presently only Zonemaster-CLI is published, and therefore only Zonemaster-LDNS,
+Zonemaster-Engine and Zonemaster-CLI are covered here.
+
+
+## 2. Prerequsite
+
+The steps in this documents are assumet to be executed on a computer installed
+as an [Ubuntu Build Environment] computer. It could work on another OS as long
+as the same support is available.
+
+All commands in this instruction are assumed to be executed from the one and the
+same directory. If you run `cd`, then you have to run `cd` back to the start
+directory.
+
+
+## 3. Create Docker images
+
+Clone the three repositories:
+
+```sh
+git clone https://github.com/zonemaster/zonemaster-ldns
+git clone https://github.com/zonemaster/zonemaster-engine
+git clone https://github.com/zonemaster/zonemaster-cli
+```
+
+Check out right branch depending on the use case.
+
+* Check out `develop` branch when creating an image for release testing:
+
+```sh
+git -C zonemaster-ldns checkout origin/develop
+git -C zonemaster-engine checkout origin/develop
+git -C zonemaster-cli checkout origin/develop
+```
+
+* Check out `master` branch when creating an image for Docker Hub at release, or
+when creating an image based on release version:
+
+```sh
+git -C zonemaster-ldns checkout origin/master
+git -C zonemaster-engine checkout origin/master
+git -C zonemaster-cli checkout origin/master
+```
+
+Create `Makefile` in all three repositories
+
+```sh
+(cd zonemaster-ldns; git clean -dfx; perl Makefile.PL)
+```
+```sh
+(cd zonemaster-engine; git clean -dfx; perl Makefile.PL)
+```
+```sh
+(cd zonemaster-cli; git clean -dfx; perl Makefile.PL)
+```
+
+Create an image for each repository. That image will be tagged "local". The
+images must be created in order since there is a dependency on the previous
+image in each step.
+```sh
+make -C zonemaster-ldns all dist docker-build
+```
+```sh
+make -C zonemaster-engine all docker-build
+```
+```sh
+make -C zonemaster-cli all docker-build
+```
+
+For the Zonemaster-CLI image, add a version tag and a tag "latest".
+
+* Add version tag:
+```sh
+make -C zonemaster-cli docker-tag-version
+```
+
+* Add tag "latest":
+```sh
+make -C zonemaster-cli docker-tag-latest
+```
+
+All the created images can now be listed. Also consider doing [sanity checks] to
+verify that all images work. List images:
+
+```sh
+docker images
+```
+
+## 4. Upload images to Docker Hub
+
+To upload an image to the Zonemaster Docker Hub organization you have to have
+a Docker Hub account and the authorization to upload images.
+
+```sh
+docker login -u $DOCKERUSER
+```
+
+The same image is pushed twice with different tags. Verify in the listing
+above that they have the same ID.
+
+* Push latest.
+```sh
+docker push zonemaster/cli:latest
+```
+
+* Set correct version (see listing) and push image with version tag:
+```sh
+docker push zonemaster/cli:v0.0.0
+```
+
+## 5. Image sanity checks
+
+Zonemaster-LDNS:
+
+```sh
+docker run --rm --entrypoint=perl zonemaster/ldns:local -MZonemaster::LDNS -E 'say Zonemaster::LDNS->new("9.9.9.9")->query("zonemaster.net")->string'
+```
+
+Zonemaster-Engine:
+
+```sh
+docker run --rm --entrypoint=perl zonemaster/engine:local -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_module("BASIC", "zonemaster.net")'
+```
+
+Zonemaster-CLI:
+
+```sh
+docker run --rm zonemaster/cli:local zonemaster.net
+```
+
+## 6. Handy Docker commands
+
+List all containers, including stopped containers.
+
+```sh
+docker ps -a
+```
+
+List all images
+```sh
+docker images
+```
+
+Remove container indentified as "ID"
+```sh
+docker rm ID
+```
+
+Remove image identified as "ID"
+```sh
+docer rmi ID
+```
+
+Remove all containers
+```sh
+docker rm -f $(docker ps -a -q)
+```
+
+Remove all images
+```sh
+docker image prune -a
+```
+
+Save an image to a tar file
+```sh
+docker save -o docker-zonemaster-cli.tar zonemaster/engine
+```
+
+Load an image from a tar file
+```sh
+docker load -i docker-zonemaster-cli.tar
+```
+
+
+[Ubuntu Build Environment]:               ../distrib-testing/Ubuntu-build-environment.md
+[sanity checks]:                          #5-image-sanity-checks

--- a/docs/internal-documentation/maintenance/ReleaseProcess-create-test-distribution.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-create-test-distribution.md
@@ -1,17 +1,34 @@
 Release process - Create Test Distribution
 ==========================================
 
+## Table of contents
+
+* [1. Overview](#1-overview)
+* [2. Prepare a build environment](#2-prepare-a-build-environment)
+* [3. Create a clean environment](#3-create-a-clean-environment)
+* [4. Generate Makefile, META.yml and others](#4-generate-makefile-metayml-and-others)
+* [5. Verify that MANIFEST is up to date and that tarball can be built](#5-verify-that-manifest-is-up-to-date-and-that-tarball-can-be-built)
+* [6. Produce distribution tarballs](#6-produce-distribution-tarballs)
+* [7. Produce distribution zip file](#7-produce-distribution-zip-file)
+* [8. Produce Docker image](#8-produce-docker-image)
+* [9. Verify that Zonemaster works when installed](#9-verify-that-zonemaster-works-when-installed)
+* [10. Restart testing](#10-restart-testing)
+
+## 1. Overview
+
 The purpose of this part is to create the test distributions that can be
 used in QA testing for a release. It can also be used to create test
 distributions to verify a pull request.
 
+> **Note:** *Normally, the develop branch version of this document should be used.*
 
-## 1. Prepare a build environment
+## 2. Prepare a build environment
+
 Set up build system to be used for the test distribution creation. See
 [Build Environment Preparation] for how to set it up.
 
 
-## 2. Create a clean environment
+## 3. Create a clean environment
 
 Make sure that you have checked out the correct git branch, normally
 the `develop` branch and that your clone is up-to-date.
@@ -41,7 +58,7 @@ All branches called "develop":
     git branch -av --list "*develop"
 
 
-## 3. Generate Makefile, META.yml and others
+## 4. Generate Makefile, META.yml and others
 
 > This section is not relevant for Zonemaster-GUI.
 
@@ -60,7 +77,7 @@ All branches called "develop":
 > * Missing prerequisite (only needed on target system), e.g.:
 >   * "Warning: prerequisite JSON::XS 0 not found."
 
-## 4. Verify that MANIFEST is up to date and that tarball can be built
+## 5. Verify that MANIFEST is up to date and that tarball can be built
 
 > This section is not relevant for Zonemaster-GUI.
 
@@ -75,15 +92,14 @@ MANIFEST.SKIP, i.e. no missing or extra files:
     make distcheck
 
 
-## 5. Produce distribution tarballs
+## 6. Produce distribution tarballs
 
 > This section is not relevant for Zonemaster-GUI.
 
     make dist
 
 
-
-## 6. Produce distribution zip file
+## 7. Produce distribution zip file
 
 > This section is relevant for Zonemaster-GUI only.
 
@@ -114,28 +130,33 @@ The distribution zip file is in the root level of the zonemaster-gui folder.
 Its name is `zonemaster_web_gui.zip`.
 
 
-## 7. Verify that Zonemaster works when installed
+## 8. Produce Docker image
+
+Follow the instructions in [Create Docker Image] to build CLI Docker image for
+testing.
+
+## 9. Verify that Zonemaster works when installed
 
 Verify that Zonemaster works when installed according to the documented
 installation procedures
 
-Using the *preliminary distribution tarballs* produced in step 5 above
-and the *preliminary distribution zip file* produced in step 6 above,
-follow the procedures in [SystemTesting].
+Using the *preliminary distribution tarballs* produced in step 6 above, the
+*preliminary distribution zip file* produced in step 7 above and the Docker
+image produced in step 8, follow the procedures in [SystemTesting].
 
-## 8. Restart testing
+## 10. Restart testing
 
 If the system testing fails in a way that requires updated distribution
-tarballs or zip file:
+tarballs, zip file or Docker image:
  1. Get the changes merged.
- 2. Consider whether the actions taken in steps 1–6 above need amendment.
- 3. Resume this document from step 7 above.
+ 2. Consider whether the actions taken in steps 2–8 above need amendment.
+ 3. Resume this document from step 9 above.
 
 
-<!-- Zonemaster links point on purpose on the develop branch. -->
-[Build Environment Preparation]:        https://github.com/zonemaster/zonemaster/blob/develop/docs/internal-documentation/distrib-testing/BuildEnvironmentPreparation.md
-[Build environment for Node.js]:        https://github.com/zonemaster/zonemaster/blob/develop/docs/internal-documentation/distrib-testing/Ubuntu-Node.js-build-environment.md
-[NVM]:                                  https://github.com/nvm-sh/nvm
-[Node.js]:                              https://nodejs.org/en/
-[SystemTesting]:                        https://github.com/zonemaster/zonemaster/blob/develop/docs/internal-documentation/maintenance/SystemTesting.md
+[Build Environment Preparation]:              ../distrib-testing/BuildEnvironmentPreparation.md
+[Build environment for Node.js]:              ../distrib-testing/Ubuntu-Node.js-build-environment.md
+[Create Docker Image]:                        ReleaseProcess-create-docker-image.md
+[NVM]:                                        https://github.com/nvm-sh/nvm
+[Node.js]:                                    https://nodejs.org/en/
+[SystemTesting]:                              https://github.com/zonemaster/zonemaster/blob/develop/docs/internal-documentation/maintenance/SystemTesting.md
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -1,13 +1,41 @@
 Release process - Release
 =========================
 
+## Table of contents
+
+* [1. Overview](#1-overview)
+* [2. Applicable components](#2-applicable-components)
+* [3. Updates to repositories](#3-updates-to-repositories)
+* [4. Determine the new version number](#4-determine-the-new-version-number)
+* [5. Update the Changes file](#5-update-the-changes-file)
+* [6. Set all version numbers](#6-set-all-version-numbers)
+* [7. Update Makefile.PL with required version](#7-update-makefilepl-with-required-version)
+* [8. Create a clean Git working area of *develop branch*](#8-create-a-clean-git-working-area-of-develop-branch)
+* [9. Generate Makefile, META.yml and others](#9-generate-makefile-metayml-and-others)
+* [10. Verify that MANIFEST is up to date and that tarball can be built](#10-verify-that-manifest-is-up-to-date-and-that-tarball-can-be-built)
+* [11. Produce distribution tarballs](#11-produce-distribution-tarballs)
+* [12. Produce distribution zip file](#12-produce-distribution-zip-file)
+* [13. Update Zonemaster repository main _README.md_](#13-update-zonemaster-repository-main-readmemd)
+* [14. Generate documents](#14-generate-documents)
+* [15. Upload to CPAN](#15-upload-to-cpan)
+* [16. Merge develop branch into master](#16-merge-develop-branch-into-master)
+* [17. Create Docker images and upload image to Docker Hub](#17-create-docker-images-and-upload-image-to-docker-hub)
+* [18. Tag the release with git](#18-tag-the-release-with-git)
+* [19. Announce the release](#19-announce-the-release)
+* [Appendix A on version number in Makefile.PL](#appendix-a-on-version-number-in-makefilepl)
+* [Appendix B on how to verify merge develop branch into master branch](#appendix-b-on-how-to-verify-merge-develop-branch-into-master-branch)
+
+## 1. Overview
+
 The steps in this document executes the actual release. They assume that
 development, the preparation steps and the QA testing have been concluded.
 To run the steps below a build system is needed. See 
 [Build Environment Preparation] for how to set it up.
 
+> **Note:** *Normally, the develop branch version of this document should be used.*
 
-## 1. Applicable components
+
+## 2. Applicable components
 
 Every applicable step below should be run for each component. If there are no
 changes in a component (no release) it should be skipped. The main component
@@ -22,13 +50,13 @@ The components should be released in the following order:
  * Zonemaster/Zonemaster
 
 
-## 2. Updates to repositories
+## 3. Updates to repositories
 
 All updates to *develop branch* and *master branch* should go via pull
 requests following the usual process. That is just assumed here.
 
 
-## 3. Determine the new version number
+## 4. Determine the new version number
 
 The version number of the new release should be chosen according to
 [Versions and Releases] document.
@@ -38,7 +66,7 @@ Product (Zonemaster/Zonemaster) version number also refer to the version
 of the other components.
 
 
-## 4. Update the Changes file
+## 5. Update the Changes file
 
 Any changes since the last release must be documented in the Changes files.
 Refer to any Github issues or pull requests related to the change by the
@@ -54,7 +82,7 @@ The updates to the *Changes* file are done to the *develop branch*.
  * Zonemaster/Zonemaster - [Changes Zonemaster]
  
 
-## 5. Set all version numbers
+## 6. Set all version numbers
 
 > This section is not relevant for Zonemaster/Zonemaster.
 
@@ -77,7 +105,7 @@ The GUI has no Perl. Update the following files in the *develop branch*:
    should point at the version number in both files.
 
 
-## 5. Update Makefile.PL with required version
+## 7. Update Makefile.PL with required version
 
 > This section is relevant for Zonemaster-Engine, Zonemaster-CLI and
 > Zonemaster-Backend.
@@ -93,18 +121,14 @@ If a component will not be updated by this release, then it can continue to
 require the previous version unless it must be change to resolve some issue,
 and then the version of the requiring component must also be updated.
 
-### Zonemaster-Engine
-
-In [Zonemaster-Engine Makefile.PL] set the lowest version of Zonemaster-LDNS
+In **[Zonemaster-Engine Makefile.PL]** set the lowest version of Zonemaster-LDNS
 that Zonemaster-Engine requires. E.g.
 
 ```
 requires 'Zonemaster::LDNS'   => 2.001;
 ```
 
-### Zonemaster-CLI and Zonemaster-Backend
-
-In [Zonemaster-CLI Makefile.PL] and [Zonemaster-Backend Makefile.PL],
+In **[Zonemaster-CLI Makefile.PL]** and **[Zonemaster-Backend Makefile.PL]**,
 set the minimum required versions of Zonemaster-LDNS and Zonemaster-Engine.
 E.g.
 
@@ -113,7 +137,7 @@ requires 'Zonemaster::Engine' => 4.000;
 requires 'Zonemaster::LDNS'   => 2.001;
 ```
 
-## 6. Create a clean Git working area of *develop branch*
+## 8. Create a clean Git working area of *develop branch*
 
 Make sure that you have checked out the `develop` branch and
 that your clone is up-to-date.
@@ -131,7 +155,7 @@ To clean:
        git reset --hard
 
 
-## 7. Generate Makefile, META.yml and others
+## 9. Generate Makefile, META.yml and others
 
 > This section is not relevant for Zonemaster-GUI or Zonemaster/Zonemaster
 
@@ -151,7 +175,7 @@ To clean:
 >   * "Warning: prerequisite JSON::XS 0 not found."
 
 
-## 8. Verify that MANIFEST is up to date and that tarball can be built
+## 10. Verify that MANIFEST is up to date and that tarball can be built
 
 > This section is not relevant for Zonemaster-GUI or Zonemaster/Zonemaster
 
@@ -166,14 +190,14 @@ MANIFEST.SKIP, i.e. no missing or extra files:
     make distcheck
 
 
-## 9. Produce distribution tarballs
+## 11. Produce distribution tarballs
 
 > This section is not relevant for Zonemaster-GUI or Zonemaster/Zonemaster
 
     make dist
 
 
-## 10. Produce distribution zip file
+## 12. Produce distribution zip file
 
 > This section is relevant for Zonemaster-GUI only.
 
@@ -203,7 +227,7 @@ The distribution zip file is in the root level of the zonemaster-gui folder.
 Its name is `zonemaster_web_gui.zip`.
 
 
-## 11. Update Zonemaster repository main _README.md_
+## 13. Update Zonemaster repository main _README.md_
 
 > This section is relevant for Zonemaster/Zonemaster only.
 
@@ -213,7 +237,7 @@ If needed, update the following section of the Zonemaster repository main
 * Notable bugs and issues
 
 
-## 12. Generate documents
+## 14. Generate documents
 
 > This section is relevant for Zonemaster/Zonemaster only.
 
@@ -231,7 +255,7 @@ updated this section can be skipped.
    should be added to the *develop branch* via a pull request.
 
 
-## 11. Upload to CPAN
+## 15. Upload to CPAN
 
 > This section is not relevant for Zonemaster-GUI or Zonemaster/Zonemaster.
 
@@ -241,7 +265,7 @@ Currently we use the organizational account [ZNMSTR] on [PAUSE] for doing
 this.
 
 
-## 12. Merge develop branch into master
+## 16. Merge develop branch into master
 
 > For the steps in this section, it is assumed that the git "remote"
 > which is called "origin" points at "zonemaster/zonemaster.git",
@@ -277,7 +301,14 @@ merged through the normal process.
 In [Appendix B] it is shown how `merge-develop-into-master` can be verified.
 
 
-## 13. Tag the release with git
+## 17. Create Docker images and upload image to Docker Hub
+
+1. Follow the instructions in [Create Docker Image] to build a Docker images.
+2. Upload the Zonemaster-CLI image to [Docker Hub] for Zonemaster using the
+   instructions in [Create Docker Image].
+
+
+## 18. Tag the release with git
 
 For each repository, go to "releases" in Github and select "draft a new release".
 Use the version number as tag and create a new release description. Use the
@@ -299,7 +330,7 @@ The releases pages:
 * [Zonemaster Product Releases]
 
 
-## 14. Announce the release
+## 19. Announce the release
 
 Send emails to the mailing lists `zonemaster-users` and `zonemaster-announce`.
 
@@ -367,8 +398,8 @@ branch `merge-develop-into-master` is correct, and a pull request into
 [Appendix A]:                              #appendix-a-on-version-number-in-makefilepl
 [Appendix B]:                              #appendix-b-on-how-to-verify-merge-develop-branch-into-master-branch
 [Backend.pm]:                              https://github.com/zonemaster/zonemaster-backend/blob/develop/lib/Zonemaster/Backend.pm
-[Build environment for Node.js]:           https://github.com/zonemaster/zonemaster/blob/develop/docs/internal-documentation/distrib-testing/Ubuntu-Node.js-build-environment.md
-[Build Environment Preparation]:           https://github.com/zonemaster/zonemaster/blob/develop/docs/internal-documentation/distrib-testing/BuildEnvironmentPreparation.md
+[Build Environment Preparation]:           ../distrib-testing/BuildEnvironmentPreparation.md
+[Build environment for Node.js]:           ../distrib-testing/Ubuntu-Node.js-build-environment.md
 [CI]:                                      https://github.com/travis-ci/travis-ci
 [CLI.pm]:                                  https://github.com/zonemaster/zonemaster-cli/blob/develop/lib/Zonemaster/CLI.pm
 [CPAN]:                                    https://www.cpan.org/
@@ -378,16 +409,20 @@ branch `merge-develop-into-master` is correct, and a pull request into
 [Changes GUI]:                             https://github.com/zonemaster/zonemaster-gui/blob/develop/Changes
 [Changes LDNS]:                            https://github.com/zonemaster/zonemaster-ldns/blob/develop/Changes
 [Changes Zonemaster]:                      https://github.com/zonemaster/zonemaster-gui/blob/develop/Changes
+[Create Docker Image]:                     ReleaseProcess-create-docker-image.md
+[Docker Hub]:                              https://hub.docker.com/u/zonemaster
 [Engine.pm]:                               https://github.com/zonemaster/zonemaster-engine/blob/develop/lib/Zonemaster/Engine.pm
 [Installation.md GUI]:                     https://github.com/zonemaster/zonemaster-gui/blob/develop/docs/Installation.md
 [LDNS.pm]:                                 https://github.com/zonemaster/zonemaster-ldns/blob/develop/lib/Zonemaster/LDNS.pm
 [NVM]:                                     https://github.com/nvm-sh/nvm
 [Node.js]:                                 https://nodejs.org/en/
 [PAUSE]:                                   https://pause.perl.org/
-[Versions and releases]:                   https://github.com/zonemaster/zonemaster/blob/develop/docs/design/Versions%20and%20Releases.md
+[Versions and releases2]:                   https://github.com/zonemaster/zonemaster/blob/develop/docs/design/Versions%20and%20Releases.md
+[Versions and releases]:                   ../../design/Versions%20and%20Releases.md
 [ZNMSTR]:                                  https://metacpan.org/author/ZNMSTR
 [Zonemaster Product Releases]:             https://github.com/zonemaster/zonemaster/releases
-[Zonemaster main README]:                  https://github.com/zonemaster/zonemaster/blob/develop/README.md
+[Zonemaster main README]:                  ../../../README.md
+[Zonemaster utils README]:                 ../../../utils/README.md
 [Zonemaster-Backend Makefile.PL]:          https://github.com/zonemaster/zonemaster-backend/blob/develop/Makefile.PL
 [Zonemaster-Backend Releases]:             https://github.com/zonemaster/zonemaster-backend/releases
 [Zonemaster-CLI Makefile.PL]:              https://github.com/zonemaster/zonemaster-cli/blob/develop/Makefile.PL
@@ -396,13 +431,12 @@ branch `merge-develop-into-master` is correct, and a pull request into
 [Zonemaster-Engine Releases]:              https://github.com/zonemaster/zonemaster-engine/releases
 [Zonemaster-GUI Releases]:                 https://github.com/zonemaster/zonemaster-gui/releases
 [Zonemaster-LDNS Releases]:                https://github.com/zonemaster/zonemaster-ldns/releases
-[declaration of prerequisites]:            https://github.com/zonemaster/zonemaster/blob/develop/README.md#prerequisites
+[declaration of prerequisites]:            ../../../README.md#prerequisites
 [environment.prod.ts GUI]:                 https://github.com/zonemaster/zonemaster-gui/blob/develop/src/environments/environment.prod.ts
 [environment.ts GUI]:                      https://github.com/zonemaster/zonemaster-gui/blob/develop/src/environments/environment.ts
 [license string]:                          https://metacpan.org/pod/CPAN::Meta::Spec#license
 [package.json GUI]:                        https://github.com/zonemaster/zonemaster-gui/blob/develop/package.json
-[utils Zonemaster]:                        https://github.com/zonemaster/zonemaster/tree/develop/utils
-[Zonemaster utils README]:                 https://github.com/zonemaster/zonemaster/blob/develop/utils/README.md
+[utils Zonemaster]:                        ../../../utils/
 
 
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -417,7 +417,6 @@ branch `merge-develop-into-master` is correct, and a pull request into
 [NVM]:                                     https://github.com/nvm-sh/nvm
 [Node.js]:                                 https://nodejs.org/en/
 [PAUSE]:                                   https://pause.perl.org/
-[Versions and releases2]:                   https://github.com/zonemaster/zonemaster/blob/develop/docs/design/Versions%20and%20Releases.md
 [Versions and releases]:                   ../../design/Versions%20and%20Releases.md
 [ZNMSTR]:                                  https://metacpan.org/author/ZNMSTR
 [Zonemaster Product Releases]:             https://github.com/zonemaster/zonemaster/releases


### PR DESCRIPTION
## Purpose

Zonemaster will be published as Docker image on Docker Hub from release v2021.2. This PR adds instructions for creation of Docker image and uploading it to Docker Hub.

In the updated files table of contents has been added and section numbering has been corrected.

## Context

This PR assumes that #1010 is also is installed as it adds instructions for creating an environment for image creation.

## Changes

* One new file is created:
  * docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
* Two files are updated with the main purpose to refer to the new file:
  * docs/internal-documentation/maintenance/ReleaseProcess-create-test-distribution.md
  * docs/internal-documentation/maintenance/ReleaseProcess-release.md

## How to test this PR

Follow the instructions and make sure everything comes out right.