### PR TITLE
Use latest stable version of Node

### DIFF
--- a/docs/internal-documentation/distrib-testing/Ubuntu-Node.js-build-environment.md
+++ b/docs/internal-documentation/distrib-testing/Ubuntu-Node.js-build-environment.md
@@ -22,8 +22,8 @@ been tested on Ubuntu 18.04, which we use here.
 4. Install Node.js by using [NVM], a node version manager.
    ```sh
    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-   nvm install 14.17.0
-   nvm use 14.17.0
+   nvm install stable
+   nvm use stable
    ```
 
 5. After installation, log out and log in again to handle [known issue], or just:


### PR DESCRIPTION
## Purpose

I ran into problems when I used the Node version specified in the Ubuntu-Node.js-build-environment document. I don't remember the exact error message or when it happened but the solution was to upgrade to a newer version of Node, so I picked the latest stable. I guess it's probably a good idea to specify that in the build environment document instead.

I'd very much like a second opinion on this from someone who's more up to speed with Node development.

## Context

This was discovered during releaste testing of v2021.2.
I looked for anything about raising the minimum supported version of Node in the files in the root directory of zonemaster-gui (including the change log), but I couldn't find anything.
The README just prescribes the installation of the latest version.

I did find a4708f3a64ad4bee4fcbaf9ae4d97fd53f6d2bed where Node.js 10 is declared as minimum version, I couldn't find any such declaration in our current documentation.

## Changes

The alias `stable` is used instead of specific versions in Ubuntu-Node.js-build-environment.

## How to test this PR

1. Start with a machine without Node.js installed,
2. Follow the Ubuntu-Node.js-build-environment document.
3. Follow the ReleaseProcess-create-test-distribution document to "produce a distribution zip file".