### PR TITLE
update node version

### DIFF
--- a/docs/internal-documentation/distrib-testing/Ubuntu-Node.js-build-environment.md
+++ b/docs/internal-documentation/distrib-testing/Ubuntu-Node.js-build-environment.md
@@ -15,8 +15,8 @@ been tested on Ubuntu 18.04, which we use here.
    ```
 
 3. Install packagages needed
+   > Image manipulation librairies are indirect dependencies of the e2e tests modules
    ```sh
-   # Image manipulation librairies are indirect dependencies of the e2e tests modules
    sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
    ```
 
@@ -36,7 +36,7 @@ been tested on Ubuntu 18.04, which we use here.
 6. Install the last stable version of Google Chrome to be able to run the e2e tests
    ```sh
    wget -O /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-   apt install /tmp/google-chrome-stable_current_amd64.deb
+   sudo apt install /tmp/google-chrome-stable_current_amd64.deb
    ```
 
 [known issue]:                          https://github.com/nvm-sh/nvm#troubleshooting-on-linux

--- a/docs/internal-documentation/distrib-testing/Ubuntu-Node.js-build-environment.md
+++ b/docs/internal-documentation/distrib-testing/Ubuntu-Node.js-build-environment.md
@@ -16,14 +16,15 @@ been tested on Ubuntu 18.04, which we use here.
 
 3. Install packagages needed
    ```sh
-   sudo apt-get install build-essential
+   # Image manipulation librairies are indirect dependencies of the e2e tests modules
+   sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
    ```
 
 4. Install Node.js by using [NVM], a node version manager.
    ```sh
    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-   nvm install stable
-   nvm use stable
+   nvm install 16
+   nvm use 16
    ```
 
 5. After installation, log out and log in again to handle [known issue], or just:


### PR DESCRIPTION
## Purpose

Change node version to the latest LTS (16)

## Context

Downgrade from 17 to 16 to avoid broken installation

## Changes

* Change from stable to 16 (explicitly to avoid unwanted upgrade)
* Install image manipulation libs as required by [node-canvas](https://github.com/Automattic/node-canvas/wiki/Installation:-Ubuntu-and-other-Debian-based-systems) (indirect dependency of protractor-image-comparison)

## How to test this PR

* Install from a clean environment and run the gui tests (https://app.travis-ci.com/github/zonemaster/zonemaster-gui/builds/242421961)
