### PR TITLE
Adds missing dependencies to FreeBSD build system 

### DIFF
--- a/docs/internal-documentation/distrib-testing/FreeBSD-build-environment.md
+++ b/docs/internal-documentation/distrib-testing/FreeBSD-build-environment.md
@@ -62,7 +62,7 @@ This instruction is for creating it on FreeBSD. See other files for other OSs.
 
 9. Install some tools
     ```sh
-    pkg install gmake gettext-tools git-lite p5-Locale-PO p5-App-cpanminus p5-Module-Install libtool autoconf automake
+    pkg install gmake gettext-tools git-lite p5-Locale-PO p5-App-cpanminus p5-Module-Install libtool autoconf automake p5-Devel-CheckLib p5-Module-Install-XSUtil libidn libidn2
     ```
 
 10. Install other tools needed, e.g. editor


### PR DESCRIPTION
## Purpose

The list of dependencies to install is not complete. This PR fixes that.

## How to test this PR

Follow the instructions.