### PR TITLE
In release process merge master back into develop

### DIFF
--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -18,7 +18,7 @@ Release process - Release
 * [13. Update Zonemaster repository main _README.md_](#13-update-zonemaster-repository-main-readmemd)
 * [14. Generate documents](#14-generate-documents)
 * [15. Upload to CPAN](#15-upload-to-cpan)
-* [16. Merge develop and master branches](#16-merge-develop-and-master-branches)
+* [16. Merge develop branch into master](#16-merge-develop-branch-into-master)
 * [17. Create Docker images and upload image to Docker Hub](#17-create-docker-images-and-upload-image-to-docker-hub)
 * [18. Tag the release with git](#18-tag-the-release-with-git)
 * [19. Announce the release](#19-announce-the-release)
@@ -266,7 +266,7 @@ Currently we use the organizational account [ZNMSTR] on [PAUSE] for doing
 this.
 
 
-## 16. Merge develop and master branches
+## 16. Merge develop branch into master
 
 > For the steps in this section, it is assumed that the git "remote"
 > which is called "origin" points at "zonemaster/zonemaster.git",
@@ -280,7 +280,6 @@ Make sure you're up to date and your working directory is completely clean:
 
 > **Note:** To throw away any and all changes to tracked and untracked files you
 > can run `git clean -dfx ; git reset --hard`.
-
 
 Create a new branch named `merge-develop-into-master` with both *master* and
 *develop* as ancestors and with the exact contents from *develop*:

--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -22,7 +22,7 @@ Release process - Release
 * [17. Create Docker images and upload image to Docker Hub](#17-create-docker-images-and-upload-image-to-docker-hub)
 * [18. Tag the release with git](#18-tag-the-release-with-git)
 * [19. Announce the release](#19-announce-the-release)
-* [20. Merge master into develop](#20-merge-masetr-into-develop)
+* [20. Merge master into develop](#20-merge-master-into-develop)
 * [Appendix A on version number in Makefile.PL](#appendix-a-on-version-number-in-makefilepl)
 * [Appendix B on how to verify merge develop branch into master branch](#appendix-b-on-how-to-verify-merge-develop-branch-into-master-branch)
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -298,6 +298,9 @@ Create a new branch named `merge-develop-into-master` with both *master* and
 Create a pull request from `merge-develop-into-master` into `master` and have it
 merged through the normal process.
 
+Create a pull request from `master` on github back into `develop` and have it
+merged through the normal process.
+
 In [Appendix B] it is shown how `merge-develop-into-master` can be verified.
 
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -18,7 +18,7 @@ Release process - Release
 * [13. Update Zonemaster repository main _README.md_](#13-update-zonemaster-repository-main-readmemd)
 * [14. Generate documents](#14-generate-documents)
 * [15. Upload to CPAN](#15-upload-to-cpan)
-* [16. Merge develop branch into master](#16-merge-develop-branch-into-master)
+* [16. Merge develop and master branches](#16-merge-develop-and-master-branches)
 * [17. Create Docker images and upload image to Docker Hub](#17-create-docker-images-and-upload-image-to-docker-hub)
 * [18. Tag the release with git](#18-tag-the-release-with-git)
 * [19. Announce the release](#19-announce-the-release)
@@ -265,7 +265,7 @@ Currently we use the organizational account [ZNMSTR] on [PAUSE] for doing
 this.
 
 
-## 16. Merge develop branch into master
+## 16. Merge develop and master branches
 
 > For the steps in this section, it is assumed that the git "remote"
 > which is called "origin" points at "zonemaster/zonemaster.git",
@@ -298,10 +298,10 @@ Create a new branch named `merge-develop-into-master` with both *master* and
 Create a pull request from `merge-develop-into-master` into `master` and have it
 merged through the normal process.
 
+In [Appendix B] it is shown how `merge-develop-into-master` can be verified.
+
 Create a pull request from `master` on github back into `develop` and have it
 merged through the normal process.
-
-In [Appendix B] it is shown how `merge-develop-into-master` can be verified.
 
 
 ## 17. Create Docker images and upload image to Docker Hub

--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -280,6 +280,9 @@ Make sure you're up to date and your working directory is completely clean:
 > **Note:** To throw away any and all changes to tracked and untracked files you
 > can run `git clean -dfx ; git reset --hard`.
 
+
+### 16.1 Merge develop into master
+
 Create a new branch named `merge-develop-into-master` with both *master* and
 *develop* as ancestors and with the exact contents from *develop*:
 
@@ -300,8 +303,12 @@ merged through the normal process.
 
 In [Appendix B] it is shown how `merge-develop-into-master` can be verified.
 
-Create a pull request from `master` on github back into `develop` and have it
-merged through the normal process.
+
+### 16.2 Merge master into develop
+
+When the previous pull request has been merged, create a pull request from
+`master` on github back into `develop` and have it merged through the normal
+process.
 
 
 ## 17. Create Docker images and upload image to Docker Hub

--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -22,6 +22,7 @@ Release process - Release
 * [17. Create Docker images and upload image to Docker Hub](#17-create-docker-images-and-upload-image-to-docker-hub)
 * [18. Tag the release with git](#18-tag-the-release-with-git)
 * [19. Announce the release](#19-announce-the-release)
+* [20. Merge master into develop](#20-merge-masetr-into-develop)
 * [Appendix A on version number in Makefile.PL](#appendix-a-on-version-number-in-makefilepl)
 * [Appendix B on how to verify merge develop branch into master branch](#appendix-b-on-how-to-verify-merge-develop-branch-into-master-branch)
 
@@ -281,8 +282,6 @@ Make sure you're up to date and your working directory is completely clean:
 > can run `git clean -dfx ; git reset --hard`.
 
 
-### 16.1 Merge develop into master
-
 Create a new branch named `merge-develop-into-master` with both *master* and
 *develop* as ancestors and with the exact contents from *develop*:
 
@@ -302,13 +301,6 @@ Create a pull request from `merge-develop-into-master` into `master` and have it
 merged through the normal process.
 
 In [Appendix B] it is shown how `merge-develop-into-master` can be verified.
-
-
-### 16.2 Merge master into develop
-
-When the previous pull request has been merged, create a pull request from
-`master` on github back into `develop` and have it merged through the normal
-process.
 
 
 ## 17. Create Docker images and upload image to Docker Hub
@@ -343,6 +335,12 @@ The releases pages:
 ## 19. Announce the release
 
 Send emails to the mailing lists `zonemaster-users` and `zonemaster-announce`.
+
+
+## 20. Merge master into develop
+
+Create a pull request from `master` on github back into `develop` and have it
+merged through the normal process.
 
 
 ## Appendix A on version number in Makefile.PL


### PR DESCRIPTION
## Purpose

This PR makes `git describe --tags origin/develop` find the latest release tag. This is very helpful when you're marking up dist files during release testing.

## Context

N/A

## Changes

Adds another step to the release process.

## How to test this PR

Running the following commands, notice how the first `describe` command references an older release and counts a greater number of subsequent commits while the second `describe` command references the latest release and counts a lesser number of subsequent commits.

```sh
git co -b test origin/develop
git describe --tags
git merge origin/master -m "Merge master back into develop"
git describe --tags
```