### PR TITLE
Use Ubuntu 22.04 for Docker build etc

### DIFF
--- a/docs/internal-documentation/distrib-testing/Ubuntu-build-environment.md
+++ b/docs/internal-documentation/distrib-testing/Ubuntu-build-environment.md
@@ -31,7 +31,7 @@ needs for testing and releasing Zonemaster:
 3. Install prerequisites (binaries)
 
    ```sh
-   sudo apt-get install cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libmodule-install-xsutil-perl libssl-dev libidn2-dev libldns-dev” libtool
+   sudo apt-get install cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libmodule-install-xsutil-perl libssl-dev libidn2-dev libldns-dev libtool
    ```
 
    > On Ubuntu 22.04 internal LDNS cannot be built on Zonemaster-LDNS. It must be

--- a/docs/internal-documentation/distrib-testing/Ubuntu-build-environment.md
+++ b/docs/internal-documentation/distrib-testing/Ubuntu-build-environment.md
@@ -20,7 +20,7 @@ needs for testing and releasing Zonemaster:
 
 ## Instructions
 
-1. Make a clean installation of [Ubuntu 20.04]
+1. Make a clean installation of [Ubuntu] 22.04.
 
 2. Update the package database.
 
@@ -31,8 +31,12 @@ needs for testing and releasing Zonemaster:
 3. Install prerequisites (binaries)
 
    ```sh
-   sudo apt-get install cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libmodule-install-xsutil-perl libssl-dev libidn11-dev libtool
+   sudo apt-get install cpanminus gettext autoconf automake build-essential libdevel-checklib-perl libmodule-install-xsutil-perl libssl-dev libidn2-dev libldns-dev” libtool
    ```
+
+   > On Ubuntu 22.04 internal LDNS cannot be built on Zonemaster-LDNS. It must be
+   > be built with `--no-internal-ldns` and LDNS libraries must be installed
+   > (included above).
 
 4. Install Docker - *only needed if Docker images are to be built*
 
@@ -69,6 +73,6 @@ needs for testing and releasing Zonemaster:
 [Install Docker Engine on Ubuntu]:         https://docs.docker.com/engine/install/ubuntu/
 [Installation instructions]:               https://github.com/zonemaster/zonemaster-engine/blob/develop/docs/Installation.md
 [Instructions for translators]:            https://github.com/zonemaster/zonemaster-engine/blob/develop/docs/Translation-translators.md#software-preparation
-[Ubuntu 20.04]:                            https://ubuntu.com/
+[Ubuntu]:                                  https://ubuntu.com/
 [Utils README]:                            ../../../utils/README.md
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
@@ -73,8 +73,9 @@ git -C zonemaster-cli checkout origin/master
 Create `Makefile` in all three repositories
 
 ```sh
-(cd zonemaster-ldns; git clean -dfx; git reset --hard; perl Makefile.PL)
+(cd zonemaster-ldns; git clean -dfx; git reset --hard; perl Makefile.PL --no-internal-ldns)
 ```
+> Ubuntu 22.04 does not currently have support for internal LDNS.
 ```sh
 (cd zonemaster-engine; git clean -dfx; git reset --hard; perl Makefile.PL)
 ```


### PR DESCRIPTION
## Purpose

Ubuntu 20.04 is not supported by Zonemaster. Shift to 22.04.

## Context

* Shifts to Ubuntu 22.04
* Updates to libidn2
* Adds libldns (required by Ubuntu 22.04)
* Builds Zonemaster-LDNS with "--no-internal-ldns" (required by Ubuntu 22.04)

## How to test this PR

Documentation only.