### PR TITLE
Updates Basic01

### DIFF
--- a/docs/specifications/tests/Basic-TP/basic01.md
+++ b/docs/specifications/tests/Basic-TP/basic01.md
@@ -14,7 +14,7 @@
 * [Outcome(s)](#outcomes)
 * [Special procedural requirements](#special-procedural-requirements)
 * [Intercase dependencies](#intercase-dependencies)
-* [terminology](#terminology)
+* [Terminology](#terminology)
 
 
 ## Objective

--- a/docs/specifications/tests/Basic-TP/basic01.md
+++ b/docs/specifications/tests/Basic-TP/basic01.md
@@ -37,7 +37,7 @@ can be run even if the child zone is not delegated.
 
 ## Scope
 
-The algorithm in this test case must match the argorithm in method
+The algorithm in this test case must match the algorithm in method
 [Get parent zone].
 
 
@@ -50,20 +50,19 @@ Input for this Test Case:
   "normal test".
 
 
-
 ## Summary
 
 Message Tag                | Level | Arguments                    | Message ID for message tag
 :--------------------------|:------|:-----------------------------|:--------------------------
-B01_CHILD_IS_ALIAS         |NOTICE |domain_c, domain_t, ns_ip_list| "{domain_c}" is not a zone. It is an alias for "{domain_t}". Run a test of "{domain_t}" instead. Found on name server "{ns_ip_list}.
+B01_CHILD_IS_ALIAS         |NOTICE |domain_c, domain_t, ns_ip_list| "{domain_c}" is not a zone. It is an alias for "{domain_t}". Run a test for "{domain_t}" instead. Returned from name servers "{ns_ip_list}.
 B01_CHILD_FOUND            |INFO   | domain                       | The zone "{domain}" is found.
-B01_CHILD_NOT_DELEGATED    |INFO   | domain                       | "{domain}" is not delegated and the zone does not exist.
+B01_CHILD_NOT_EXIST        |INFO   | domain                       | "{domain}" does not exist as it is not delegated.
 B01_INCONSISTENT_ALIAS     |ERROR  | domain                       | The alias for "{domain}" is inconsistent between name servers.
-B01_INCONSISTENT_DELEGATION|ERROR  |domain_c, domain_p, ns_ip_list| The name servers for parent zone "{domain_p}" gives inconsistent delegation of "{domain_c}". Name serververs: "{ns_ip_list}".
+B01_INCONSISTENT_DELEGATION|ERROR  |domain_c, domain_p, ns_ip_list| The name servers for parent zone "{domain_p}" give inconsistent delegation of "{domain_c}". Returned from name serververs "{ns_ip_list}".
 B01_NO_CHILD               |ERROR  | domain_c, domain_s           | "{domain_c}" does not exist as a DNS zone. Try to test "{domain_s}" instead.
-B01_PARENT_FOUND           |INFO   | domain, ns_ip_list           | The parent zone is "{domain}" as found on name servers "{ns_ip_list}".
+B01_PARENT_FOUND           |INFO   | domain, ns_ip_list           | The parent zone is "{domain}" as returned from name servers "{ns_ip_list}".
 B01_PARENT_INDETERMINED    |WARNING| ns_ip_list                   | The parent zone cannot be determined on name servers "{ns_ip_list}".
-B01_UNEXPECTED_NS_RESPONSE |WARNING|domain_c, domain_p, ns_ip_list| Name servers for parent domain "{domain_p}" gives an incorrect response on SOA query for "{domain_c}". Name server IP addresses are {ns_ip_list}.
+B01_UNEXPECTED_NS_RESPONSE |WARNING|domain_c, domain_p, ns_ip_list| Name servers for parent domain "{domain_p}" give an incorrect response on SOA query for "{domain_c}". Returned from name servers {ns_ip_list}.
 
 
 The value in the Level column is the default severity level of the message. The
@@ -232,7 +231,7 @@ DNS queries follow, unless otherwise specified below, what is specified for
     1. If *Test Type* is "normal test" then do:
        1. Create "Superdomain" as the domain just above *Child Zone*.
        2. Output *[B01_NO_CHILD]* with *Child zone* and *Superdomain*.
-    2. If *Test Type* is "[undelegated test]", output *[B01_CHILD_NOT_DELEGATED]*
+    2. If *Test Type* is "[undelegated test]", output *[B01_CHILD_NOT_EXIST]*
        with *Child Zone*.
 
 11. If the *AA DNAME Found* set is non-empty then do:
@@ -284,7 +283,7 @@ a specific name server.
 [Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
 [B01_CHILD_FOUND]:                                                #outcomes
 [B01_CHILD_IS_ALIAS]:                                             #outcomes
-[B01_CHILD_NOT_DELEGATED]:                                        #outcomes
+[B01_CHILD_NOT_EXIST]:                                            #outcomes
 [B01_INCONSISTENT_ALIAS]:                                         #outcomes
 [B01_INCONSISTENT_DELEGATION]:                                    #outcomes
 [B01_INCONSISTENT_DELEGATION]:                                    #outcomes

--- a/docs/specifications/tests/Basic-TP/basic01.md
+++ b/docs/specifications/tests/Basic-TP/basic01.md
@@ -1,199 +1,279 @@
-## BASIC01: The domain must have a parent domain
+# BASIC01: Check for the parent zone and the zone itself
 
-### Test case identifier
+## Test case identifier
 **BASIC01**
 
-### Objective
 
-In order for a domain (zone) to work, it must be delegated from a 
-zone higher up in the DNS hierarchy (a parent domain/zone). 
-This Test Case will determine if parent and child zones exist.
+## Table of contents
+
+* [Objective](#Objective)
+* [Scope](#Scope)
+* [Inputs](#Inputs)
+* [Summary](#Summary)
+* [Test procedure](#Test-procedure)
+* [Outcome(s)](#Outcomes)
+* [Special procedural requirements](#Special-procedural-requirements)
+* [Intercase dependencies](#Intercase-dependencies)
+* [Terminology](#terminology)
+
+
+## Objective
+
+In order for a domain (zone) to work, it must be delegated from a
+zone higher up in the DNS hierarchy (a parent domain or zone).
+This Test Case will determine if parent zone and child zones,
+respectively, exist.
 
 If the zone to be tested is the root zone, it has no parent or
 delegation and will always pass this Test Case.
 
 If no parent can be determined, there cannot be any delegation.
 
-If the child zone does not exist (is not delegated), the only 
-test case to be run after this test case is BASIC03. However, 
-if the test type is an undelegated test, then all other test cases 
+If the child zone does not exist (is not delegated), the only
+test case to be run after this test case is [BASIC03]. However,
+if the test type is an [undelegated test], then all other test cases
 can be run even if the child zone is not delegated.
 
-### Inputs
+
+## Scope
+
+The algorithm in this test case must match the argorithm in method
+[Get parent zone].
+
+
+## Inputs
 
 Input for this Test Case:
 * "Child Zone" - The label of the domain name (zone) to be tested
-* "Root Name Servers" - The IANA [List of Root Servers] 
-* "Test Type" - The test type with values "undelegated test" or 
+* "Root Name Servers" - The IANA [List of Root Servers]
+* "Test Type" - The test type with values "[undelegated test]" or
   "normal test".
 
-### Ordered description of steps to be taken to execute the test case
 
-1. If the *Child Zone* is the root zone ("."):
-   1. The parent zone is set to the root zone (".") and the zone to be 
-      tested is assumed to exist. 
-   2. Output *[ROOT_HAS_NO_PARENT]* and exit.
 
-2. Find the parent zone of the *Child Zone* by performing recursive 
-   lookup for the SOA record of the *Child Zone* with the RD bit unset.
-   Start by using a nameserver from the *Root Name Servers*.
+## Summary
 
-3. Continue, step by step, until the parent zone (of the *Child Zone*) has 
-   been reached by using the referrals (delegations) found.
+Message Tag                | Level | Arguments                    | Message ID for message tag
+:--------------------------|:------|:-----------------------------|:--------------------------
+B01_CHILD_IS_ALIAS         |NOTICE |domain_c, domain_t, ns_ip_list| "{domain_c}" is not a zone. It is an alias for "{domain_t}". Run a test of "{domain_t}" instead. Found on name server "{ns_ip_list}.
+B01_CHILD_FOUND            |INFO   | domain                       | The zone "{domain}" is found.
+B01_CHILD_NOT_DELEGATED    |INFO   | domain                       | "{domain}" is not delegated and the zone does not exist.
+B01_INCONSISTENT_ALIAS     |ERROR  | domain                       | The alias for "{domain}" is inconsistent between name servers.
+B01_INCONSISTENT_DELEGATION|ERROR  |domain_c, domain_p, ns_ip_list| The name servers for parent zone "{domain_p}" gives inconsistent delegation of "{domain_c}". Name serververs: "{ns_ip_list}".
+B01_NO_CHILD               |ERROR  | domain_c, domain_s           | "{domain_c}" does not exist as a DNS zone. Try to test "{domain_s}" instead.
+B01_PARENT_FOUND           |INFO   | domain, ns_ip_list           | The parent zone is "{domain}" as found on name servers "{ns_ip_list}".
+B01_PARENT_INDETERMINED    |WARNING| ns_ip_list                   | The parent zone cannot be determined on name servers "{ns_ip_list}".
+B01_UNEXPECTED_NS_RESPONSE |WARNING|domain_c, domain_p, ns_ip_list| Name servers for parent domain "{domain_p}" gives an incorrect response on SOA query for "{domain_c}". Name server IP addresses are {ns_ip_list}.
 
-4. If the lookup reaches a name server that responds with a referral 
-   (delegation) directly to the requested *Child Zone*:
-   1. The zone in which the delegation was found is defined to be the 
-      parent zone. Output *[PARENT_FOUND]*.
-   2. The existence of the *Child Zone* has been determined. Output 
-      *[CHILD_FOUND]*.
-   3. Repeat the SOA query for the *Child Zone* to the remaining name 
-      servers for the parent zone.
-      1. If any server returns NXDOMAIN, NODATA or CNAME, then
-      	 output *[INCONSISTENT_DELEGATION]*. 
-   4. Exit.
 
-5. If the lookup reaches a name server that authoritatively responds
-   (AA flag set) and either with NXDOMAIN for the *Child Zone* or
-   with NOERROR and no record in the answer section (NODATA): 
-   1. The zone returning NXDOMAIN or NODATA is defined to be the parent 
-      zone. Output *[PARENT_FOUND]*.
-   2. Repeat the SOA query for the *Child Zone* to the remaining name 
-      servers for the parent zone.
-      1. If any server returns a referral (delegation) directly to the *Child
-      	 Zone*, then output *[INCONSISTENT_DELEGATION]* and go back to 
-         step 4 with the found delegation.
-   3. The non-existence of the *Child Zone* has been determined. 
-      1. If *Test Type* is "normal test", then output *[NO_CHILD]* 
-         and exit.
-      2. Or, if *Test Type* is "undelegated test", then output 
-         *[CHILD_NOT_DELEGATED]* and exit.
+The value in the Level column is the default severity level of the message. The
+severity level can be changed in the [Zonemaster-Engine profile]. Also see the
+[Severity Level Definitions] document.
 
-6. If the lookup reaches a name server that non-authoritatively responds
-   (AA flag unset) with a CNAME record in the answer section:
-   1. A CNAME query with the RD flag unset is sent to the same server.
-   2. If the lookup returns an authoritative answer with a CNAME with
-      *Child Zone* name as owner name, then continue to step 7, else repeat 
-      from step 3 using the next server. 
+The argument names in the Arguments column lists the arguments used in the
+message. The argument names are defined in the [argument list].
 
-7. If the lookup reaches a name server that authoritatively responds
-   (AA flag set) with a CNAME record in the answer section:
-   1. The zone returning authoritative data is defined to be the parent zone. 
-      Output *[PARENT_FOUND]*.
-   2. Repeat the SOA query for the *Child Zone* to the remaining name servers 
-      for the parent zone.
-      1. If any server returns a referral (delegation) directly to the *Child
-      	 Zone*, then output *[INCONSISTENT_DELEGATION]* and go back to step 4 
-         with the found delegation.
-   3. The non-existence of the *Child Zone* has been determined. 
-      1. If *Test Type* is "normal test", then output *[NO_CHILD]*
-         and exit. 
-      2. Or, if *Test Type* is "undelegated test", then output 
-         *[CHILD_NOT_DELEGATED]* and exit.
 
-8. If the lookup reaches a name server that authoritatively responds
-   (AA flag set) with an SOA record with *Child Zone* as the owner name 
-   in the answer section, then:
-   1. The zone in the previous delegation is defined to be the parent 
-      zone. Output *[PARENT_FOUND]*.
-   2. The existence of the *Child Zone* has been determined. Output
-      *[CHILD_FOUND]*.
-   3. Repeat the SOA query for the *Child Zone* to remaining name servers 
-      for the parent zone.
-      1. If any server returns a referral (delegation) directly to the *Child
-      	 Zone*, then go back to step 4 with the found delegation.
-      2. Or, if any server returns NXDOMAIN, NODATA or CNAME, then output 
-      	 *[INCONSISTENT_DELEGATION]*.
-   4. Exit.
+## Test procedure
 
-9. If the server does not respond, the response contains an unexpected RCODE or
-    any other error, repeat from step 3 using the next server. 
+In this section and unless otherwise specified below, the terms "[DNS Query]"
+follow the specification for DNS queries as specified in
+[DNS Query and Response Defaults]. The handling of the DNS responses on the
+DNS queries follow, unless otherwise specified below, what is specified for
+[DNS Response] in the same specification.
 
-10. If delegation to a zone at a higher level than *Child Zone* is returned, 
-    then follow the delegation.
+1. If the *Child Zone* is the root zone (".") then:
+   1. Output *[B01_CHILD_FOUND]* with zone name (".").
+   2. Exit the test case.
 
-11. If all servers above are exhausted: 
-    1. Output *[PARENT_INDETERMINED]*.
-    1. If *Test Type* is "normal test", output *[NO_CHILD]*.
-    2. If *Test Type* is "undelegated test", output *[CHILD_NOT_DELEGATED]*.
+2. Create [DNS queries][DNS Query]:
+   1. Query type SOA and query name *Child Zone* ("SOA Query").
+   2. Query type DNAME and query name *Child Zone* ("DNAME Query").
 
-### Test Type and existence of parent and child 
+3. Create the following empty set:
+   1. Parent name server IP and parent zone name ("Parent Name Server IP").
+   2. Parent name server IP and parent zone name ("Parent Found").
+   3. Parent name server IP and parent zone name ("Delegation Found").
+   4. Parent name server IP and parent zone name ("Non-AA Non-Delegation Found")
+   5. Parent name server IP and parent zone name ("AA NXDOMAIN Found").
+   6. Parent name server IP and parent zone name ("AA SOA Found").
+   7. Parent name server IP and parent zone name ("AA CNAME Found").
+   8. Parent name server IP, parent zone name and DNAME target
+      ("AA DNAME Found").
+   9. Parent name server IP and parent zone name ("AA NODATA Found").
 
-Parent zone     |*Child Zone*      |Run "normal test"?|Run "undelegated test"?
-----------------|------------------|------------------|--------------------
-Determined      |Exists            |Yes               |Yes (1)
-Determined      |Does not exist (2)|No                |Yes (3)
-Indetermined (4)|Indetermined      |No                |Yes (3)
+4. Find the parent zone of the *Child Zone* by iteratively
+   [sending](#terminology) *SOA Query* to all name servers found. Start by using
+   the nameservers from the *Root Name Servers*.
+   1. Follow all paths from root and downwards by following the referrals
+      (non-AA response with empty answer section and NS records in the authority
+      section).
+   2. When one of the following criteria is met (not both), then stop the lookup
+      up in that branch and save the name server IP address, zone name for which
+      the server is name server (parent zone) and the DNS response to the
+      *SOA Query* to the *Parent Name Server IP* set. Criteria:
+      * The DNS response is a referral to *Child Zone* (owner name of the NS
+        records is *Child Zone*), or
+      * The DNS response has the AA flag set.
+   3. If the lookup reaches a name server that does not responds at all, with
+      an invalid DNS response or with an RCODE besides NOERROR and NXDOMAIN, then
+      ignore it.
+   4. If the lookup reaches a name server that responds with a
+      non-referral and the AA bit unset, then add the name server IP and its
+      zone name to the *Non-AA Non-Delegation Found* set.
+   5. Continue until all paths are exhausted.
 
-1. Undelegated tests are run based on the submitted data and not
-   the existing zone.
-2. Parent zone returns an authoritative NXDOMAIN or NODATA on the 
-   *Child Zone* name and SOA record.
-3. When *Test Type* is "undelegated test" the *Child Zone* is
-   defined to exist even if there is no delegation.
-4. Server or zone error prevents determination of parent zone.
+> *Note that the "parent zone name" is the name of the zone that the name server
+> in question is NS for (owner name of NS). The name of the name server is
+> irrelevant.*
 
-### Outcome(s)
 
-The outcome of this Test Case is "fail" if there is at least one message 
-with the severity level ERROR or CRITICAL.
+5. For each name server IP in *Parent Name Server IP* extract
+   parent zone name and the DNS response.
 
-The outcome of this Test Case is "warning" if there is at least one 
-message with the severity level WARNING, but no message with severity level 
-ERROR or CRITICAL.
+   1.  If the response is a referral (delegation) to the requested *Child Zone*:
+       1. Save the name server IP and parent zone name to the *Parent Found* set.
+       2. Save the name server IP and parent zone name to the *Delegation Found*
+          set.
+   2.  If the response has the AA flag set and with RCODE NXDOMAIN, then
+       1. Save the name server IP and parent zone name to the *Parent Found*
+          set.
+       2. Save the name server IP and parent zone name to the
+          *AA NXDOMAIN Found* set.
+   3.  If the response has the AA flag set and with an SOA record with
+       *Child Zone* as owner name in the answer section, then
+       1. If *Child Zone* is a direct subdomain to parent zone name then save the
+          name server IP and parent zone name to the *Parent Found* set.
+       2. Save the name server IP and parent zone name to the *AA SOA Found* set.
+   4.  If the response has the AA flag set and with a CNAME record with
+       *Child Zone* as owner name in the answer section, then
+       1. Save the name server IP and parent zone name to the *Parent Found* set.
+       2. Save the name server IP and parent zone name to the *AA CNAME Found*
+          set.
+   5.  If response has the AA flag set and with an empty answer section (NODATA),
+       then
+       1. [Send](#terminology) a *DNAME Query* to the name server IP address.
+       2. If there is a response with the AA flag set, RCODE NOERROR and with a
+          DNAME record with *Child Zone* as owner name in the answer section,
+          then
+          1. Save the name server IP and parent zone name to the *Parent Found*
+            set.
+          2. Save the name server IP, parent zone name and the DNAME target
+            (RDATA value) to the *AA DNAME Found* set.
+       3. Else, if no *DNAME Query* is sent or if there is no response or some
+          other response than above then do:
+          1. Save the name server IP and parent zone name to the *Parent Found*
+             set.
+          2. Save the name server IP and parent zone name to the
+             *AA NODATA Found* set.
 
-In other cases the outcome of this Test Case is "pass".
+6. If the *Parent Found* set is non-empty, then
+   1. For each parent zone name output *[B01_PARENT_FOUND]*, parent zone name
+      and the set of name server IP addresses for that name.
+   2. If not all members of the set have the same parent zone then output
+      *[B01_PARENT_INDETERMINED]* and the whole set of name server IP addresses.
 
-The name of the parent zone (or empty if it cannot be determined), plus
-verification of whether or not the *Child Zone* exists is returned together 
-with relevant messages.
+7. If both of the *Parent Found* and the *AA SOA Found* sets are empty, then
+   output *[B01_PARENT_INDETERMINED]* and the whole set of name server IP
+   addresses from *Parent Name Server IP*.
 
-Message                        |Default severity level of message
--------------------------------|----------------------------------------------
-ROOT_HAS_NO_PARENT             |INFO
-PARENT_FOUND                   |INFO
-PARENT_INDETERMINED            |NOTICE
-CHILD_FOUND                    |INFO
-NO_CHILD                       |ERROR
-CHILD_NOT_DELEGATED            |INFO
-INCONSISTENT_DELEGATION        |ERROR
+8. If one or both of the *Delegation Found* and the *AA SOA Found* sets are
+   non-empty, then do:
+   1. Output *[B01_CHILD_FOUND]* with *Child Zone*.
+   2. If one or more of the following sets are also non-empty then output
+      *[B01_INCONSISTENT_DELEGATION]* with *Child Zone*, parent zone name and
+      the combined set of name server IP addresses from all six sets.
+         * *AA NXDOMAIN Found*
+         * *AA CNAME Found*
+         * *AA DNAME Found*
+         * *AA NODATA Found*
+   3. Else, if the *Delegation Found* set is empty, then do
+      1. For each parent zone name in the *AA SOA Found* set do if *Child Zone*
+         is not a direct subdomain to parent zone name then output
+         *[B01_PARENT_FOUND]*, parent zone name and the set of name server IP
+         addresses for that name.
+      2. If not all parent zone name in *AA SOA Found* are not equal then output
+         *[B01_PARENT_INDETERMINED]* and the whole set of name server IP
+         addresses from the *AA SOA Found* set,
 
-### Special procedural requirements
+9. If both of the *Delegation Found* and the *AA SOA Found* sets are empty, then
+   do:
+    1. If *Test Type* is "normal test" then do:
+       1. Create "Superdomain" as the domain just above *Child Zone*.
+       2. Output *[B01_NO_CHILD]* with *Child zone* and *Superdomain*.
+    2. If *Test Type* is "[undelegated test]", output *[B01_CHILD_NOT_DELEGATED]*
+       with *Child Zone*.
+
+10. If the *AA DNAME Found* set is non-empty then do:
+    1. For each DNAME target in the set output *[B01_CHILD_IS_ALIAS]* with name
+       server IP list, *Child Zone* and the DNAME target.
+    2. If not all members of the set have the same DNAME target, output
+       *[B01_INCONSISTENT_ALIAS]* with *Child Zone*.
+
+11. If the *Non-AA Non-Delegation Found* set is non-empty then for each parent
+    zone name from the set do:
+    1. Output *[B01_UNEXPECTED_NS_RESPONSE]* with parent zone name, *Child Zone*
+       and list of name server IP addresses.
+
+
+## Outcome(s)
+
+The outcome of this Test Case is "fail" if there is at least one message with
+the severity level *[ERROR]* or *[CRITICAL]*.
+
+The outcome of this Test Case is "warning" if there is at least one message
+with the severity level *[WARNING]*, but no message with severity level
+*ERROR* or *CRITICAL*.
+
+In other cases, no message or only messages with severity level *[INFO]* or
+*[NOTICE]*, the outcome of this Test Case is "pass".
+
+
+## Special procedural requirements
+
+If either IPv4 or IPv6 transport is disabled, skip [sending](#terminology)
+queries over that transport protocol. A message will be outputted reporting that
+the transport protocol has been skipped.
+
+The *Child Zone* must be a valid name meeting
+"[Requirements and normalization of domain names in input]".
+
+
+## Intercase dependencies
 
 None.
 
-### Intercase dependencies
 
-[BASIC00] must have been run with "pass" outcome before this test case
-can be run.
+## Terminology
 
-### Special considerations
-
-The Test Case must, in general, use the same algorithm as Method
-[Get-Parent-Zone].
+The term "send" (to an IP address) is used when a DNS query is sent to
+a specific name server.
 
 
-[List of Root Servers]: https://www.iana.org/domains/root/servers
-
-[BASIC00]: basic00.md
-
-[BASIC03]: basic03.md
-
-[ROOT_HAS_NO_PARENT]: #outcomes
-
-[PARENT_FOUND]: #outcomes
-
-[PARENT_INDETERMINED]: #outcomes
-
-[UNDEL_AND_PARENT_INDETERMINED]: #outcomes
-
-[CHILD_FOUND]: #outcomes
-
-[NO_CHILD]: #outcomes
-
-[CHILD_NOT_DELEGATED]: #outcomes
-
-[INCONSISTENT_DELEGATION]: #outcomes
-
-[Get-Parent-Zone]: ../Methods.md#method-get-parent-zone
+[Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[B01_CHILD_FOUND]:                                                #outcomes
+[B01_CHILD_IS_ALIAS]:                                             #outcomes
+[B01_CHILD_NOT_DELEGATED]:                                        #outcomes
+[B01_INCONSISTENT_ALIAS]:                                         #outcomes
+[B01_INCONSISTENT_DELEGATION]:                                    #outcomes
+[B01_INCONSISTENT_DELEGATION]:                                    #outcomes
+[B01_NO_CHILD]:                                                   #outcomes
+[B01_PARENT_FOUND]:                                               #outcomes
+[B01_PARENT_INDETERMINED]:                                        #outcomes
+[B01_UNEXPECTED_NS_RESPONSE]:                                     #outcomes
+[Basci03]:                                                        basic03.md
+[CRITICAL]:                                                       ../SeverityLevelDefinitions.md#critical
+[DNS Query and Response Defaults]:                                ../DNSQueryAndResponseDefaults.md
+[DNS Query]:                                                      ../DNSQueryAndResponseDefaults.md#default-setting-in-dns-query
+[DNS Response]:                                                   ../DNSQueryAndResponseDefaults.md#default-handling-of-a-dns-response
+[ERROR]:                                                          ../SeverityLevelDefinitions.md#error
+[Get parent zone]:                                                ../MethodsV2.md#method-get-parent-zone
+[INFO]:                                                           ../SeverityLevelDefinitions.md#info
+[List of Root Servers]:                                           https://www.iana.org/domains/root/servers
+[NOTICE]:                                                         ../SeverityLevelDefinitions.md#notice
+[Requirements and normalization of domain names in input]:        ../RequirementsAndNormalizationOfDomainNames.md
+[Severity Level Definitions]:                                     ../SeverityLevelDefinitions.md
+[Undelegated test]:                                               ../../test-types/undelegated-test.md
+[WARNING]:                                                        ../SeverityLevelDefinitions.md#warning
+[Zonemaster-Engine profile]:                                      https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
 

--- a/docs/specifications/tests/Basic-TP/basic01.md
+++ b/docs/specifications/tests/Basic-TP/basic01.md
@@ -93,45 +93,42 @@ DNS queries follow, unless otherwise specified below, what is specified for
    2. Query type DNAME and query name *Child Zone* ("DNAME Query").
 
 3. Create the following empty sets:
-   1. Parent name server IP, parent zone name and DNS response
-      ("Parent Name Server IP").
-   2. Parent name server IP and parent zone name ("Parent Found").
-   3. Parent name server IP and parent zone name ("Delegation Found").
-   4. Parent name server IP and parent zone name ("Non-AA Non-Delegation Found")
-   5. Parent name server IP and parent zone name ("AA NXDomain Found").
-   6. Parent name server IP and parent zone name ("AA SOA Found").
-   7. Parent name server IP and parent zone name ("AA CNAME Found").
-   8. Parent name server IP, parent zone name and DNAME target
-      ("AA DNAME Found").
-   9. Parent name server IP and parent zone name ("AA NODATA Found").
-   10. Name server IP and zone name ("Remaining Servers").
-   11. Name server IP ("Handled Servers").
-
-> *Note that a referral is a DNS response with [RCODE Name] NoError, AA flag
-> unset and NS records in the authority section. The answer section is empty
-> or with CNAME record or records. If the query type is CNAME, then the answer
-> section must be empty. The additional section may contain address records
-> (A and AAAA) for the name server names from the NS (glue records).*
+   1.  Name server IP and zone name ("Remaining Servers").
+   2.  Name server IP ("Handled Servers").
+   3.  Parent name server IP, parent zone name and DNS response
+       ("Parent Name Server IP").
+   4.  Parent name server IP and parent zone name ("Parent Found").
+   5.  Parent name server IP and parent zone name ("Delegation Found").
+   6.  Parent name server IP and parent zone name ("Non-AA Non-Delegation Found")
+   7.  Parent name server IP and parent zone name ("AA NXDomain Found").
+   8.  Parent name server IP and parent zone name ("AA SOA Found").
+   9.  Parent name server IP and parent zone name ("AA CNAME Found").
+   10. Parent name server IP and parent zone name ("CNAME with Referral Found").
+   11. Parent name server IP, parent zone name and DNAME target
+       ("AA DNAME Found").
+   12. Parent name server IP and parent zone name ("AA NODATA Found").
 
 4. Insert all addresses from *Root Name Servers* and the root zone name into the
    *Remaining Servers* set.
+
 5. While the *Remaining Servers* is non-empty pick next name server IP address
    and zone name from the set ("Server Address" and "Zone Name") and do:
    1. Remove the IP address from *Remaining Servers*.
    2. Insert *Server Address* into *Handled Servers*
-   3. [Send](#terminology) *SOA Child Query* to *Server Address*.
-   4. If *Server Address* does not respond at all, with an invalid DNS response
-      or with an [RCODE Name] besides NoError and NXDomain, then ignore it.
-   5. If *Server Address* responds with a non-referral and the AA bit unset, then
-      add the name server IP and its zone name to the
+   3. [Send] *SOA Child Query* to *Server Address*.
+   4. If *Server Address* does not respond with a DNS response or with an
+      [RCODE Name] besides NoError and NXDomain, then ignore it.
+   5. If *Server Address* responds with a [Non-Referral] and the AA
+      bit unset, then add the name server IP and its zone name to the
       *Non-AA Non-Delegation Found* set.
-   6. If *Server Address* responds with a referral idential to *Zone Name*, then
-      ignore it.
-   7. If *Server Address* responds with a referral longer than *Zone Name* but
-      shorter than *Child Zone* then do:
+   6. If *Server Address* responds with a [Referral] to a domain
+      name identical to *Zone Name*, then  ignore it.
+   7. If *Server Address* responds with a [Referral] to a name that is a subdomain
+      (one or several steps) of *Zone Name* and at the same time a superdomain
+      (one or several steps) of *Child Zone* then do:
       1. Extract the NS record set owner name ("Referral Zone Name").
       2. Extract the name server names from the NS records and any glue records.
-      3. Do [DNS Lookup](#terminology) of name server names (A and AAAA) not
+      3. Do [DNS Lookup] of name server names (A and AAAA) not
          already listed as glue record or records.
       4. For each IP address (glue and looked-up) add the IP address and
          *Referral Zone Name* to the *Remaining Servers* set unless the IP
@@ -140,8 +137,10 @@ DNS queries follow, unless otherwise specified below, what is specified for
       IP address, zone name for which the server is name server (parent zone) and
       the DNS response to the *SOA Child Query* into the *Parent Name Server IP*
       set. Criteria:
-      * The DNS response is a referral to *Child Zone* (owner name of the NS
+      * The DNS response is a [Referral] to *Child Zone* (owner name of the NS
         records is *Child Zone*), or
+      * The DNS response is a [Referral] with at least one CNAME record in the
+        answer section where one CNAME record has *Child Zone* as owner name.
       * The DNS response has the AA flag set.
 
 > *Note that the "parent zone name" is the name of the zone that the name server
@@ -161,31 +160,31 @@ DNS queries follow, unless otherwise specified below, what is specified for
    5. For each NS record extract the name server name ("Name Server Name") in
       the RDATA field and do:
       1. Create a [DNS Query] with query type A, *Name Server Name* as query
-         name and RD flag set, and do a [DNS Lookup](#terminology).
+         name and RD flag set, and do a [DNS Lookup].
       2. If the [DNS Response], if any, contains a list of A records (follow
          any CNAME chain) in the answer section then create a set of the IPv4
          addresses from the A records ("NS IPv4 Addresses").
       3. Create a [DNS Query] with query type AAAA, *Name Server Name* as
-         query name and RD flag set, and do a [DNS lookup](#terminology).
+         query name and RD flag set, and do a [DNS lookup].
       4. If the [DNS Response], if any, contains a list of AAAA records
          (follow any CNAME chain) in the answer section then create a set of
          the IPv6 addresses from the AAAA records ("NS IPv6 Addresses").
       5. If the *NS IPv4 Addresses* set or the *NS IPv6 Addresses* set is
          non-empty, then then for each IP address in the two sets do if the
          address is not already listed in the *Parent Name Server IP* set:
-         1. [Send](#terminology) *SOA Child Query* to the IP address.
+         1. [Send] *SOA Child Query* to the IP address.
          2. If the [DNS Response], if any, meets exactly one of the
             following two criteria then save the IP address, the parent
             zone name and the DNS response to the *Parent Name Server IP* set.
             Criteria:
-            * The [DNS response] is a referral to *Child Zone* (owner name
+            * The [DNS response] is a [Referral] to *Child Zone* (owner name
               of the NS records in authority section is *Child Zone*), or
             * The [DNS response] has the AA flag set and the [RCODE Name]
               NoError.
 
 7. For each name server IP in *Parent Name Server IP* extract
    parent zone name and the DNS response.
-   1.  If the response is a referral (delegation) to the requested *Child Zone*:
+   1.  If the response is a [Referral] to the requested *Child Zone*:
        1. Save the name server IP and parent zone name to the *Parent Found* set.
        2. Save the name server IP and parent zone name to the *Delegation Found*
           set.
@@ -195,28 +194,32 @@ DNS queries follow, unless otherwise specified below, what is specified for
           set.
        2. Save the name server IP and parent zone name to the
           *AA NXDomain Found* set.
-   3.  If the response has the AA flag set and with an SOA record with
+   3.  If the response has the AA flag set and an SOA record with
        *Child Zone* as owner name in the answer section, then
-       1. If *Child Zone* is a direct subdomain to parent zone name then save the
+       1. If *Child Zone* is a [Direct Subdomain] to parent zone name then save the
           name server IP and parent zone name to the *Parent Found* set.
        2. Save the name server IP and parent zone name to the *AA SOA Found* set.
-   4.  If the response has the AA flag set and with a CNAME record with
+   4.  If the response has the AA flag set and a CNAME record with
        *Child Zone* as owner name in the answer section, then
        1. Save the name server IP and parent zone name to the *Parent Found* set.
        2. Save the name server IP and parent zone name to the *AA CNAME Found*
           set.
-   5.  If response has the AA flag set and with an empty answer section (NODATA),
+   5.  If the response is a [Referral] with a CNAME record with *Child Zone* as
+       owner name in the answer section, then
+       1. Save the name server IP and parent zone name to the *Parent Found* set.
+       2. Save the name server IP and parent zone name to the
+          *CNAME with Referral Found* set.
+   5.  If the response has the AA flag set and an empty answer section (NODATA),
        then
-       1. [Send](#terminology) a *DNAME Query* to the name server IP address.
+       1. [Send] a *DNAME Query* to the name server IP address.
        2. If there is a response with the AA flag set, the [RCODE Name] NoError
-          and with a DNAME record with *Child Zone* as owner name in the answer
+          and a DNAME record with *Child Zone* as owner name in the answer
           section, then
           1. Save the name server IP and parent zone name to the *Parent Found*
             set.
           2. Save the name server IP, parent zone name and the DNAME target
             (RDATA value) to the *AA DNAME Found* set.
-       3. Else, if no *DNAME Query* is sent or if there is no response or some
-          other response than above then do:
+       3. Else (no response or some other response than above), then do:
           1. Save the name server IP and parent zone name to the *Parent Found*
              set.
           2. Save the name server IP and parent zone name to the
@@ -240,11 +243,12 @@ DNS queries follow, unless otherwise specified below, what is specified for
         the combined set of name server IP addresses from all six sets.
           * *AA NXDomain Found*
           * *AA CNAME Found*
+          * *CNAME with Referral Found*
           * *AA DNAME Found*
           * *AA NODATA Found*
     3. Else, if the *Delegation Found* set is empty, then do
        1. For each parent zone name in the *AA SOA Found* set do if *Child Zone*
-          is not a direct subdomain to parent zone name then output
+          is not a [Direct Subdomain] to parent zone name then output
           *[B01_PARENT_FOUND]*, parent zone name and the set of name server IP
           addresses for that name.
        2. If not all parent zone name in *AA SOA Found* are not equal then output
@@ -286,7 +290,7 @@ In other cases, no message or only messages with severity level *[INFO]* or
 
 ## Special procedural requirements
 
-If either IPv4 or IPv6 transport is disabled, skip [sending](#terminology)
+If either IPv4 or IPv6 transport is disabled, skip [Sending][Send]
 queries over that transport protocol. A message will be outputted reporting that
 the transport protocol has been skipped.
 
@@ -301,12 +305,25 @@ None.
 
 ## Terminology
 
-* "Send" - The term "send" (to an IP address) is used when a DNS query is sent to
-a specific name server.
+* "Direct Subdomain" - Domain A is considered to be a "direct Subdomain" to
+  domain B if domain A is just the addition of one label at the least significant
+  side, e.g. "foo.domain.com" is a direct subdomain to "domain.com".
 
 * "DNS Lookup" - The term is used when a recursive lookup is used, though
 any changes to the DNS tree introduced by an [undelegated test] must be
 respected.
+
+* "Non-Referral" - See "Referral" above.
+
+* "Referral" - The term refers to a DNS response with [RCODE Name] NoError, AA
+flag unset and NS records in the authority section. The answer section is empty
+or with CNAME record or records. If the query type is CNAME, then the answer
+section must be empty (does not apply to this test case). The additional section
+may contain address records (A and AAAA) for the name server names from the NS
+(glue records).
+
+* "Send" - The term "send" (to an IP address) is used when a DNS query is sent to
+a specific name server.
 
 
 [Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
@@ -322,6 +339,8 @@ respected.
 [B01_UNEXPECTED_NS_RESPONSE]:                                     #outcomes
 [Basic03]:                                                        basic03.md
 [CRITICAL]:                                                       ../SeverityLevelDefinitions.md#critical
+[Direct Subdomain]:                                               #terminology
+[DNS Lookup]:                                                     #terminology
 [DNS Query and Response Defaults]:                                ../DNSQueryAndResponseDefaults.md
 [DNS Query]:                                                      ../DNSQueryAndResponseDefaults.md#default-setting-in-dns-query
 [DNS Response]:                                                   ../DNSQueryAndResponseDefaults.md#default-handling-of-a-dns-response
@@ -330,10 +349,12 @@ respected.
 [INFO]:                                                           ../SeverityLevelDefinitions.md#info
 [List of Root Servers]:                                           https://www.iana.org/domains/root/servers
 [NOTICE]:                                                         ../SeverityLevelDefinitions.md#notice
+[Non-referral]:                                                   #terminology
 [RCODE Name]:                                                     https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
+[Referral]:                                                       #terminology
 [Requirements and normalization of domain names in input]:        ../RequirementsAndNormalizationOfDomainNames.md
+[Send]:                                                           #terminology
 [Severity Level Definitions]:                                     ../SeverityLevelDefinitions.md
 [Undelegated test]:                                               ../../test-types/undelegated-test.md
 [WARNING]:                                                        ../SeverityLevelDefinitions.md#warning
 [Zonemaster-Engine profile]:                                      https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
-

--- a/docs/specifications/tests/Basic-TP/basic01.md
+++ b/docs/specifications/tests/Basic-TP/basic01.md
@@ -254,9 +254,9 @@ DNS queries follow, unless otherwise specified below, what is specified for
 10. If one or both of the *Delegation Found* and the *AA SOA Found* sets are
     non-empty, then do:
     1. Output *[B01_CHILD_FOUND]* with *Child Zone*.
-    2. If one or more of the following sets are also non-empty then output
+    2. If one or more of the following five sets are also non-empty then output
        *[B01_INCONSISTENT_DELEGATION]* with *Child Zone*, parent zone name and
-        the combined set of name server IP addresses from all six sets.
+       the combined set of name server IP addresses from all five sets.
           * *AA NXDomain Found*
           * *AA CNAME Found*
           * *CNAME with Referral Found*
@@ -323,11 +323,11 @@ None.
 
 * "Direct Subdomain" - Domain A is considered to be a "direct Subdomain" to
   domain B if domain A is just the addition of one label at the least significant
-  side, e.g. "foo.domain.com" is a direct subdomain to "domain.com".
+  (left) side, e.g. "foo.domain.com" is a direct subdomain to "domain.com".
 
 * "DNS Lookup" - The term is used when a recursive lookup is used, though
 any changes to the DNS tree introduced by an [undelegated test] must be
-respected. Cf. "[Send]".
+respected. Compare with "[Send]".
 
 * "Non-Referral" - See "[Referral]".
 
@@ -339,7 +339,7 @@ address records (A and AAAA) for the name server names from the NS (glue
 records).
 
 * "Send" - The term "send" (to an IP address) is used when a DNS query is sent to
-a specific name server. Cf. "[DNS Lookup]".
+a specific name server. Compare with "[DNS Lookup]".
 
 
 [Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md

--- a/docs/specifications/tests/Basic-TP/basic01.md
+++ b/docs/specifications/tests/Basic-TP/basic01.md
@@ -6,15 +6,15 @@
 
 ## Table of contents
 
-* [Objective](#Objective)
-* [Scope](#Scope)
-* [Inputs](#Inputs)
-* [Summary](#Summary)
-* [Test procedure](#Test-procedure)
-* [Outcome(s)](#Outcomes)
-* [Special procedural requirements](#Special-procedural-requirements)
-* [Intercase dependencies](#Intercase-dependencies)
-* [Terminology](#terminology)
+* [Objective](#objective)
+* [Scope](#scope)
+* [Inputs](#inputs)
+* [Summary](#summary)
+* [Test procedure](#test-procedure)
+* [Outcome(s)](#outcomes)
+* [Special procedural requirements](#special-procedural-requirements)
+* [Intercase dependencies](#intercase-dependencies)
+* [terminology](#terminology)
 
 
 ## Objective
@@ -65,7 +65,7 @@ B01_INCONSISTENT_DELEGATION|ERROR  |domain_child, domain_parent, ns_ip_list| The
 B01_NO_CHILD               |ERROR  | domain_child, domain_super            | "{domain_child}" does not exist as a DNS zone. Try to test "{domain_super}" instead.
 B01_PARENT_FOUND           |INFO   | domain, ns_ip_list                    | The parent zone is "{domain}" as returned from name servers "{ns_ip_list}".
 B01_PARENT_UNDETERMINED    |WARNING| ns_ip_list                            | The parent zone cannot be determined on name servers "{ns_ip_list}".
-B01_UNEXPECTED_NS_RESPONSE |WARNING|domain_child, domain_parent, ns_ip_list| Name servers for parent domain "{domain_parent}" give an incorrect response on SOA query for "{domain_child}". Returned from name servers {ns_ip_list}.
+B01_UNEXPECTED_NS_RESPONSE |WARNING|domain_child, domain_parent, ns_ip_list| Name servers for parent domain "{domain_parent}" give an incorrect response on SOA query for "{domain_child}". Returned from name servers "{ns_ip_list}".
 
 
 The value in the Level column is the default severity level of the message. The
@@ -112,7 +112,7 @@ DNS queries follow, unless otherwise specified below, what is specified for
    *Remaining Servers* set.
 
 > *In the loop below the steps tries to capture the name of the parent zone of
-> of **Child Zone** and the IP addresses of the name servers for that parent zone
+> **Child Zone** and the IP addresses of the name servers for that parent zone
 > by collecting those IP addresses and the parent zone name that the server is
 > name server for. Here collection is done, further down (below the loop) the
 > steps will check and compare the found parent zone names.*


### PR DESCRIPTION
## Purpose

This is an update of the test case.

* Follow the test case template.
* Use and refer to "DNS Query and Response Defaults".
* Better capture all possible situations.
* Handle DNAME in reasonable way
  * #1075 
  * #472

## Context

Today Zonemaster ignores DNAME which means that domains that are delegated using DNAME instead of NS will not be discovered. Issues #1075 and #472 ask for a better handling of DNAME.

The test case was updated by PR #642 but that update was never implemented, see issue zonemaster/zonemaster-engine#568.


## Changes

Specification of test case Basic01.

## How to test this PR

This change is documentation only, but must result in an update of the implementation.