### PR TITLE
Test case Zone09: always output found MX records on success

### DIFF
--- a/docs/specifications/tests/Zone-TP/zone09.md
+++ b/docs/specifications/tests/Zone-TP/zone09.md
@@ -208,10 +208,11 @@ queries follow, unless otherwise specified below, what is specified for
              of MX records.
           2. If the preference of the [Null MX] is non-zero then output
              *[Z09_NULL_MX_NON_ZERO_PREF]*.
-       2. If *Child Zone* is a [TLD] with a [non-Null MX][Null MX] then
+       2. Else, if *Child Zone* is a [TLD] with a [non-Null MX][Null MX] then
           output *[Z09_TLD_EMAIL_DOMAIN]*.
-       3. If *Child Zone* is the root zone with a [non-Null MX][Null MX] then
+       3. Else, if *Child Zone* is the root zone with a [non-Null MX][Null MX] then
           output *[Z09_ROOT_EMAIL_DOMAIN]*.
+       4. Else, output *[Z09_MX_DATA]*.
 
 11. Else, if the *No MX RRset* set is non-empty then do:
     * Output *[Z09_MISSING_MAIL_TARGET]* unless

--- a/docs/specifications/tests/Zone-TP/zone09.md
+++ b/docs/specifications/tests/Zone-TP/zone09.md
@@ -212,7 +212,8 @@ queries follow, unless otherwise specified below, what is specified for
           output *[Z09_TLD_EMAIL_DOMAIN]*.
        3. Else, if *Child Zone* is the root zone with a [non-Null MX][Null MX] then
           output *[Z09_ROOT_EMAIL_DOMAIN]*.
-       4. Else, output *[Z09_MX_DATA]*.
+       4. Else, output *[Z09_MX_DATA]* with the mail targets from the RDATA and
+          the associated name server IP addresses in the set.
 
 11. Else, if the *No MX RRset* set is non-empty then do:
     * Output *[Z09_MISSING_MAIL_TARGET]* unless


### PR DESCRIPTION
## Purpose

PR #870 does not explicitly ask for a message to be outputted when all nameservers answer with the same RR set of MXs. Such message could have value since it lists all configured MX records. This is about updating the spec so that Zonemaster outputs an INFO message with the list of configured MX on success.

## Context

Follow-up on #870 

## Changes

* Test case Zone09

## How to test this PR

When the test case succeeds and when there are some MX records, a message Z09_MX_DATA of level INFO with the list of found records should be outputted.
