### PR TITLE
Update basic04

### DIFF
--- a/docs/specifications/tests/Basic-TP/basic04.md
+++ b/docs/specifications/tests/Basic-TP/basic04.md
@@ -3,6 +3,20 @@
 ## Test case identifier
 **BASIC04**
 
+
+## Table of contents
+
+* [Objective](#Objective)
+* [Scope](#Scope)
+* [Inputs](#Inputs)
+* [Summary](#Summary)
+* [Test procedure](#Test-procedure)
+* [Outcome(s)](#Outcomes)
+* [Special procedural requirements](#Special-procedural-requirements)
+* [Intercase dependencies](#Intercase-dependencies)
+* [Terminology](#terminology)
+
+
 ## Objective
 
 Many test cases will query the name servers in the delegation or the
@@ -23,15 +37,44 @@ report problems found in the following areas:
 * Name Server responding with unexpected RCODE (any except "NOERROR")
   on query for SOA or NS for *Child Zone*.
 
+
+## Scope
+
 This test case is expected to run before [Basic02] but neither its
 execution nor outcome are dependent on the order.
+
 
 ## Inputs
 
 * "Child Zone" - The domain name to be tested.
 
 
-## Ordered description of steps to be taken to execute the test case
+## Summary
+
+Message Tag                       | Level   | Arguments            | Message ID for message tag
+:---------------------------------|:--------|:---------------------|:---------------------------------------------------------------------------------
+B04_MISSING_NS_RECORD             | WARNING | ns                   | Nameserver {ns} reponds to a NS query with no NS records in the answer section.
+B04_MISSING_SOA_RECORD            | WARNING | ns                   | Nameserver {ns} reponds to a SOA query with no SOA records in the answer section.
+B04_NO_RESPONSE                   | WARNING | ns                   | Nameserver {ns} does not respond over neither UDP nor TCP.
+B04_NO_RESPONSE_NS_QUERY          | WARNING | ns                   | Nameserver {ns} does not respond to NS queries.
+B04_NO_RESPONSE_SOA_QUERY         | WARNING | ns                   | Nameserver {ns} does not respond to SOA queries.
+B04_NS_RECORD_NOT_AA              | WARNING | ns                   | Nameserver {ns} does not give an authoritative response on an NS query.
+B04_RESPONSE_TCP_NOT_UDP          | WARNING | ns                   | Nameserver {ns} does not respond over UDP.
+B04_SOA_RECORD_NOT_AA             | WARNING | ns                   | Nameserver {ns} does not give an authoritative response on an SOA query.
+B04_UNEXPECTED_RCODE_NS_QUERY     | WARNING | ns                   | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an NS query.
+B04_UNEXPECTED_RCODE_SOA_QUERY    | WARNING | ns                   | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an SOA query.
+B04_WRONG_NS_RECORD               | WARNING | ns                   | Nameserver {ns} responds with a wrong owner name ({owner} instead of {name}) on NS queries.
+B04_WRONG_SOA_RECORD              | WARNING | ns                   | Nameserver {ns} responds with a wrong owner name ({owner} instead of {name}) on SOA queries.
+
+The value in the Level column is the default severity level of the message. The
+severity level can be changed in the [Zonemaster-Engine profile]. Also see the
+[Severity Level Definitions] document.
+
+The argument names in the Arguments column lists the arguments used in the
+message. The argument names are defined in the [argument list].
+
+
+## Test procedure
 
 1. Create a SOA query for the *Child Zone* without any OPT record (no EDNS).
 
@@ -71,54 +114,60 @@ execution nor outcome are dependent on the order.
             then output *[B04_WRONG_NS_RECORD]*.
          5. Else, AA flag is unset, then output *[B04_NS_RECORD_NOT_AA]*.
 
+
 ## Outcome(s)
 
 The outcome of this Test Case is "fail" if there is at least one message
-with the severity level *ERROR* or *CRITICAL*.
+with the severity level *[ERROR]* or *[CRITICAL]*.
 
 The outcome of this Test Case is "warning" if there is at least one message
-with the severity level *WARNING*, but no message with severity level
+with the severity level *[WARNING]*, but no message with severity level
 *ERROR* or *CRITICAL*.
 
-The outcome of this Test case is "pass" in all other cases.
+In other cases, no message or only messages with severity level
+*[INFO]* or *[NOTICE]*, the outcome of this Test Case is "pass".
 
-Message                           | Default severity level of message
-:---------------------------------|:-----------------------------------
-B04_MISSING_NS_RECORD             | WARNING
-B04_MISSING_SOA_RECORD            | WARNING
-B04_NO_RESPONSE                   | WARNING
-B04_NO_RESPONSE_NS_QUERY          | WARNING
-B04_NO_RESPONSE_SOA_QUERY         | WARNING
-B04_NS_RECORD_NOT_AA              | WARNING
-B04_RESPONSE_TCP_NOT_UDP          | WARNING
-B04_SOA_RECORD_NOT_AA             | WARNING
-B04_UNEXPECTED_RCODE_NS_QUERY     | WARNING
-B04_UNEXPECTED_RCODE_SOA_QUERY    | WARNING
-B04_WRONG_NS_RECORD               | WARNING
-B04_WRONG_SOA_RECORD              | WARNING
 
 ## Special procedural requirements	
 
-If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
-result of any test using this transport protocol and log a message reporting
-the ignored result.
+If either IPv4 or IPv6 transport is disabled, skip sending queries over that
+transport protocol. A message will be outputted reporting that the transport
+protocol has been skipped.
+
 
 ## Intercase dependencies
 
 None.
 
-[B04_MISSING_NS_RECORD]:          #outcomes
-[B04_MISSING_SOA_RECORD]:         #outcomes
-[B04_NO_RESPONSE]:                #outcomes
-[B04_NO_RESPONSE_NS_QUERY]:       #outcomes
-[B04_NO_RESPONSE_SOA_QUERY]:      #outcomes
-[B04_NS_RECORD_NOT_AA]:           #outcomes
-[B04_RESPONSE_TCP_NOT_UDP]:       #outcomes
-[B04_SOA_RECORD_NOT_AA]:          #outcomes
-[B04_UNEXPECTED_RCODE_NS_QUERY]:  #outcomes
-[B04_UNEXPECTED_RCODE_SOA_QUERY]: #outcomes
-[B04_WRONG_NS_RECORD]:            #outcomes
-[B04_WRONG_SOA_RECORD]:           #outcomes
+
+## Terminology
+
+No special terminology for this test case.
+
+
+[Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[B04_MISSING_NS_RECORD]:          #summary
+[B04_MISSING_SOA_RECORD]:         #summary
+[B04_NO_RESPONSE]:                #summary
+[B04_NO_RESPONSE_NS_QUERY]:       #summary
+[B04_NO_RESPONSE_SOA_QUERY]:      #summary
+[B04_NS_RECORD_NOT_AA]:           #summary
+[B04_RESPONSE_TCP_NOT_UDP]:       #summary
+[B04_SOA_RECORD_NOT_AA]:          #summary
+[B04_UNEXPECTED_RCODE_NS_QUERY]:  #summary
+[B04_UNEXPECTED_RCODE_SOA_QUERY]: #summary
+[B04_WRONG_NS_RECORD]:            #summary
+[B04_WRONG_SOA_RECORD]:           #summary
 [Basic02]:                        basic02.md
+[CRITICAL]:                                                       ../SeverityLevelDefinitions.md#critical
+[DEBUG]:                                                          ../SeverityLevelDefinitions.md#notice
+[ERROR]:                                                          ../SeverityLevelDefinitions.md#error
+[INFO]:                                                           ../SeverityLevelDefinitions.md#info
 [Method4]:                        ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]:                        ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NOTICE]:                                                         ../SeverityLevelDefinitions.md#notice
+[Severity Level Definitions]:                                     ../SeverityLevelDefinitions.md
+[WARNING]:                                                        ../SeverityLevelDefinitions.md#warning
+[Zonemaster-Engine profile]:                                      https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
+
+

--- a/docs/specifications/tests/Basic-TP/basic04.md
+++ b/docs/specifications/tests/Basic-TP/basic04.md
@@ -76,27 +76,35 @@ message. The argument names are defined in the [argument list].
 
 ## Test procedure
 
-1. Create a SOA query for the *Child Zone* without any OPT record (no EDNS).
+In this section and unless otherwise specified below, the term "[DNS Query]"
+follows the specification for DNS queries as specified in
+[DNS Query and Response Defaults]. The handling of the DNS responses on the DNS
+queries follow, unless otherwise specified below, what is specified for
+[DNS Response] in the same specification.
 
-2. Create a NS query for the *Child Zone* without any OPT record (no EDNS).
+1. Create [DNS Queries][DNS Query] over UDP:
+   1. Query type SOA and query name *Child Zone* ("SOA Query UDP").
+   1. Query type NS and query name *Child Zone* ("NS Query UDP").
+
+2. Create [DNS Query] over TCP:
+   1. Query type SOA and query name *Child Zone* ("SOA Query TCP").
 
 3. Obtain the set of name server IP addresses using [Method4] and [Method5]
    ("Name Server IP").
 
 4. For each name server in *Name Server IP* do:
 
-   1. Send the SOA query over UDP and the NS query over UDP to the name server
-      and collect the responses.
-   2. If there is no DNS response on neither query (UDP), then:
-      1. Send the SOA query over TCP to the name server and collect the
-         response.
-      2. If there is no DNS response on the TCP query, then output
-         *[B04_NO_RESPONSE]* and go to next server.
-      3. Else (there is a DNS response over TCP), then output 
-         *[B04_RESPONSE_TCP_NOT_UDP]* and go to next server.
+   1. Send *SOA Query UDP* and *NS Query UDP* to the name server and collect
+      the [DNS Responses][DNS Response].
+   2. If there is no DNS response on neither query), then:
+      1. Send *SOA Query TCP* to the name server and collect the [DNS Response].
+      2. If there is no [DNS Response], then output *[B04_NO_RESPONSE]* and go
+         to next server.
+      3. Else, then output *[B04_RESPONSE_TCP_NOT_UDP]* and go to next server.
    3. Else:
-      1. Process the response on the SOA query (UDP):
-         1. If there is no response, then output *[B04_NO_RESPONSE_SOA_QUERY]*.
+      1. Process the response on *SOA Query UDP*:
+         1. If there is no [DNS response], then output
+            *[B04_NO_RESPONSE_SOA_QUERY]*.
          2. Else, if the RCODE is not "NOERROR" then output
             *[B04_UNEXPECTED_RCODE_SOA_QUERY]*.
          3. Else, if there is no SOA record in the answer section, then
@@ -104,8 +112,9 @@ message. The argument names are defined in the [argument list].
          4. Else, if the SOA record has owner name other than *Child Zone*
             then output *[B04_WRONG_SOA_RECORD]*.
          5. Else, AA flag is unset, then output *[B04_SOA_RECORD_NOT_AA]*.
-      2. Process the response on the NS query (UDP):
-         1. If there is no response, then output *[B04_NO_RESPONSE_NS_QUERY]*.
+      2. Process the response on *NS Query UDP*:
+         1. If there is no [DNS Response], then output
+            *[B04_NO_RESPONSE_NS_QUERY]*.
          2. Else, if the RCODE is not "NOERROR" then output
             *[B04_UNEXPECTED_RCODE_NS_QUERY]*.
          3. Else, if there is no NS record in the answer section, then
@@ -161,6 +170,9 @@ No special terminology for this test case.
 [Basic02]:                                                        basic02.md
 [CRITICAL]:                                                       ../SeverityLevelDefinitions.md#critical
 [DEBUG]:                                                          ../SeverityLevelDefinitions.md#notice
+[DNS Query and Response Defaults]:                                ../DNSQueryAndResponseDefaults.md
+[DNS Query]:                                                      ../DNSQueryAndResponseDefaults.md#default-setting-in-dns-query
+[DNS Response]:                                                   ../DNSQueryAndResponseDefaults.md#default-handling-of-a-dns-response
 [ERROR]:                                                          ../SeverityLevelDefinitions.md#error
 [INFO]:                                                           ../SeverityLevelDefinitions.md#info
 [Method4]:                                                        ../Methods.md#method-4-obtain-glue-address-records-from-parent

--- a/docs/specifications/tests/Basic-TP/basic04.md
+++ b/docs/specifications/tests/Basic-TP/basic04.md
@@ -146,25 +146,25 @@ No special terminology for this test case.
 
 
 [Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
-[B04_MISSING_NS_RECORD]:          #summary
-[B04_MISSING_SOA_RECORD]:         #summary
-[B04_NO_RESPONSE]:                #summary
-[B04_NO_RESPONSE_NS_QUERY]:       #summary
-[B04_NO_RESPONSE_SOA_QUERY]:      #summary
-[B04_NS_RECORD_NOT_AA]:           #summary
-[B04_RESPONSE_TCP_NOT_UDP]:       #summary
-[B04_SOA_RECORD_NOT_AA]:          #summary
-[B04_UNEXPECTED_RCODE_NS_QUERY]:  #summary
-[B04_UNEXPECTED_RCODE_SOA_QUERY]: #summary
-[B04_WRONG_NS_RECORD]:            #summary
-[B04_WRONG_SOA_RECORD]:           #summary
-[Basic02]:                        basic02.md
+[B04_MISSING_NS_RECORD]:                                          #summary
+[B04_MISSING_SOA_RECORD]:                                         #summary
+[B04_NO_RESPONSE]:                                                #summary
+[B04_NO_RESPONSE_NS_QUERY]:                                       #summary
+[B04_NO_RESPONSE_SOA_QUERY]:                                      #summary
+[B04_NS_RECORD_NOT_AA]:                                           #summary
+[B04_RESPONSE_TCP_NOT_UDP]:                                       #summary
+[B04_SOA_RECORD_NOT_AA]:                                          #summary
+[B04_UNEXPECTED_RCODE_NS_QUERY]:                                  #summary
+[B04_UNEXPECTED_RCODE_SOA_QUERY]:                                 #summary
+[B04_WRONG_NS_RECORD]:                                            #summary
+[B04_WRONG_SOA_RECORD]:                                           #summary
+[Basic02]:                                                        basic02.md
 [CRITICAL]:                                                       ../SeverityLevelDefinitions.md#critical
 [DEBUG]:                                                          ../SeverityLevelDefinitions.md#notice
 [ERROR]:                                                          ../SeverityLevelDefinitions.md#error
 [INFO]:                                                           ../SeverityLevelDefinitions.md#info
-[Method4]:                        ../Methods.md#method-4-obtain-glue-address-records-from-parent
-[Method5]:                        ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[Method4]:                                                        ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                                                        ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 [NOTICE]:                                                         ../SeverityLevelDefinitions.md#notice
 [Severity Level Definitions]:                                     ../SeverityLevelDefinitions.md
 [WARNING]:                                                        ../SeverityLevelDefinitions.md#warning

--- a/docs/specifications/tests/Basic-TP/basic04.md
+++ b/docs/specifications/tests/Basic-TP/basic04.md
@@ -21,7 +21,7 @@
 
 Many test cases will query the name servers in the delegation or the
 name servers appointed by the NS records in the zone for the NS or SOA
-record, or both. Reporting problem is crucial, but instead of letting
+record, or both. It is crucial that problems are reported, but instead of letting
 several test cases report the same problems found, most test cases
 assume that this test case has been run. Only this test case will
 report problems found in the following areas:
@@ -34,7 +34,7 @@ report problems found in the following areas:
   section in the response on an NS query for *Child Zone*.
 * Name Server not setting the AA flag in a response with SOA or NS in
   answer section.
-* Name Server responding with unexpected [RCODE Name] (any except "NeError")
+* Name Server responding with unexpected [RCODE Name] (any except "NoError")
   on query for SOA or NS for *Child Zone*.
 
 

--- a/docs/specifications/tests/Basic-TP/basic04.md
+++ b/docs/specifications/tests/Basic-TP/basic04.md
@@ -53,6 +53,8 @@ execution nor outcome are dependent on the order.
 
 Message Tag                       | Level   | Arguments            | Message ID for message tag
 :---------------------------------|:--------|:---------------------|:---------------------------------------------------------------------------------
+B04_IPV4_DISABLED                 | NOTICE  | ns_list              | IPv4 is disabled. No DNS queries have been sent to these name servers: "{ns_list}".
+B04_IPV6_DISABLED                 | NOTICE  | ns_list              | IPv6 is disabled. No DNS queries have been sent to these name servers: "{ns_list}".
 B04_MISSING_NS_RECORD             | WARNING | ns                   | Nameserver {ns} reponds to a NS query with no NS records in the answer section.
 B04_MISSING_SOA_RECORD            | WARNING | ns                   | Nameserver {ns} reponds to a SOA query with no SOA records in the answer section.
 B04_NO_RESPONSE                   | WARNING | ns                   | Nameserver {ns} does not respond over neither UDP nor TCP.
@@ -65,6 +67,7 @@ B04_UNEXPECTED_RCODE_NS_QUERY     | WARNING | ns                   | Nameserver 
 B04_UNEXPECTED_RCODE_SOA_QUERY    | WARNING | ns                   | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an SOA query.
 B04_WRONG_NS_RECORD               | WARNING | ns                   | Nameserver {ns} responds with a wrong owner name ({owner} instead of {name}) on NS queries.
 B04_WRONG_SOA_RECORD              | WARNING | ns                   | Nameserver {ns} responds with a wrong owner name ({owner} instead of {name}) on SOA queries.
+
 
 The value in the Level column is the default severity level of the message. The
 severity level can be changed in the [Zonemaster-Engine profile]. Also see the
@@ -92,7 +95,17 @@ queries follow, unless otherwise specified below, what is specified for
 3. Obtain the set of name server IP addresses using [Method4] and [Method5]
    ("Name Server IP").
 
-4. For each name server in *Name Server IP* do:
+4. If IPv4 is disabled then do:
+   1. Extract all name servers with IPv4 address from *Name Server IP*.
+   2. If the set of IPv4 name serververs is non-empty then output
+      *[B04_IPV4_DISABLED]* with the set of IPv4 name servers.
+
+5. If IPv6 is disabled then do:
+   1. Extract all name servers with IPv6 address from *Name Server IP*.
+   2. If the set of IPv6 name serververs is non-empty then output
+      *[B04_IPV6_DISABLED]* with the set of IPv6 name servers.
+
+6. For each name server in *Name Server IP* do:
 
    1. Send *SOA Query UDP* and *NS Query UDP* to the name server and collect
       the [DNS Responses][DNS Response].
@@ -155,6 +168,8 @@ No special terminology for this test case.
 
 
 [Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[B04_IPV4_DISABLED]:                                              #summary
+[B04_IPV6_DISABLED]:                                              #summary
 [B04_MISSING_NS_RECORD]:                                          #summary
 [B04_MISSING_SOA_RECORD]:                                         #summary
 [B04_NO_RESPONSE]:                                                #summary

--- a/docs/specifications/tests/Basic-TP/basic04.md
+++ b/docs/specifications/tests/Basic-TP/basic04.md
@@ -57,11 +57,11 @@ B04_IPV4_DISABLED                 | NOTICE  | ns_list              | IPv4 is dis
 B04_IPV6_DISABLED                 | NOTICE  | ns_list              | IPv6 is disabled. No DNS queries have been sent to these name servers: "{ns_list}".
 B04_MISSING_NS_RECORD             | WARNING | ns                   | Nameserver {ns} reponds to a NS query with no NS records in the answer section.
 B04_MISSING_SOA_RECORD            | WARNING | ns                   | Nameserver {ns} reponds to a SOA query with no SOA records in the answer section.
-B04_NO_RESPONSE                   | WARNING | ns                   | Nameserver {ns} does not respond over neither UDP nor TCP.
+B04_NO_RESPONSE                   | WARNING | ns                   | Nameserver {ns} does not respond to any queries (UDP or TCP).
 B04_NO_RESPONSE_NS_QUERY          | WARNING | ns                   | Nameserver {ns} does not respond to NS queries.
 B04_NO_RESPONSE_SOA_QUERY         | WARNING | ns                   | Nameserver {ns} does not respond to SOA queries.
 B04_NS_RECORD_NOT_AA              | WARNING | ns                   | Nameserver {ns} does not give an authoritative response on an NS query.
-B04_RESPONSE_TCP_NOT_UDP          | WARNING | ns                   | Nameserver {ns} does not respond over UDP.
+B04_RESPONSE_TCP_NOT_UDP          | WARNING | ns                   | Nameserver {ns} only responds over TCP, and not UDP, which in most cases makes it unreachable.
 B04_SOA_RECORD_NOT_AA             | WARNING | ns                   | Nameserver {ns} does not give an authoritative response on an SOA query.
 B04_UNEXPECTED_RCODE_NS_QUERY     | WARNING | ns                   | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an NS query.
 B04_UNEXPECTED_RCODE_SOA_QUERY    | WARNING | ns                   | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an SOA query.
@@ -97,19 +97,19 @@ queries follow, unless otherwise specified below, what is specified for
 
 4. If IPv4 is disabled then do:
    1. Extract all name servers with IPv4 address from *Name Server IP*.
-   2. If the set of IPv4 name serververs is non-empty then output
+   2. If the set of IPv4 name servers is non-empty then output
       *[B04_IPV4_DISABLED]* with the set of IPv4 name servers.
 
 5. If IPv6 is disabled then do:
    1. Extract all name servers with IPv6 address from *Name Server IP*.
-   2. If the set of IPv6 name serververs is non-empty then output
+   2. If the set of IPv6 name servers is non-empty then output
       *[B04_IPV6_DISABLED]* with the set of IPv6 name servers.
 
 6. For each name server in *Name Server IP* do:
 
    1. Send *SOA Query UDP* and *NS Query UDP* to the name server and collect
       the [DNS Responses][DNS Response].
-   2. If there is no DNS response on neither query), then:
+   2. If there is no DNS response on neither query, then:
       1. Send *SOA Query TCP* to the name server and collect the [DNS Response].
       2. If there is no [DNS Response], then output *[B04_NO_RESPONSE]* and go
          to next server.

--- a/docs/specifications/tests/Basic-TP/basic04.md
+++ b/docs/specifications/tests/Basic-TP/basic04.md
@@ -21,7 +21,7 @@
 
 Many test cases will query the name servers in the delegation or the
 name servers appointed by the NS records in the zone for the NS or SOA
-record or both. Reporting problem is crucial, but instead of letting
+record, or both. Reporting problem is crucial, but instead of letting
 several test cases report the same problems found, most test cases
 assume that this test case has been run. Only this test case will
 report problems found in the following areas:
@@ -34,7 +34,7 @@ report problems found in the following areas:
   section in the response on an NS query for *Child Zone*.
 * Name Server not setting the AA flag in a response with SOA or NS in
   answer section.
-* Name Server responding with unexpected RCODE (any except "NOERROR")
+* Name Server responding with unexpected [RCODE Name] (any except "NeError")
   on query for SOA or NS for *Child Zone*.
 
 
@@ -118,7 +118,7 @@ queries follow, unless otherwise specified below, what is specified for
       1. Process the response on *SOA Query UDP*:
          1. If there is no [DNS response], then output
             *[B04_NO_RESPONSE_SOA_QUERY]*.
-         2. Else, if the RCODE is not "NOERROR" then output
+         2. Else, if [RCODE Name] is not "NoError" then output
             *[B04_UNEXPECTED_RCODE_SOA_QUERY]*.
          3. Else, if there is no SOA record in the answer section, then
             output *[B04_MISSING_SOA_RECORD]*.
@@ -128,7 +128,7 @@ queries follow, unless otherwise specified below, what is specified for
       2. Process the response on *NS Query UDP*:
          1. If there is no [DNS Response], then output
             *[B04_NO_RESPONSE_NS_QUERY]*.
-         2. Else, if the RCODE is not "NOERROR" then output
+         2. Else, if [RCODE Name] is not "NoError" then output
             *[B04_UNEXPECTED_RCODE_NS_QUERY]*.
          3. Else, if there is no NS record in the answer section, then
             output *[B04_MISSING_NS_RECORD]*.
@@ -196,5 +196,4 @@ No special terminology for this test case.
 [Severity Level Definitions]:                                     ../SeverityLevelDefinitions.md
 [WARNING]:                                                        ../SeverityLevelDefinitions.md#warning
 [Zonemaster-Engine profile]:                                      https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
-
-
+[RCODE Name]:                                                     https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6


### PR DESCRIPTION
## Purpose

The purpose of this PR is to add a specific message when IPv4 or IPv6 has been disabled. The default message is too verbose and to be kept on DEBUG level.

Editorial updates have also been done. Below it is specified what changes have any impact on the implementation in Zonemaster::Engine.

* Updated specification - b729a2d96408 - *This update has no impact on implementation.*
  * Updates to match template.
  * No logical changes.
  * No changes that requires updated implementation.
  * msgid has been copied from implementation.
* Editorial update: adjusted link list - 07089023013d7 - *This update has no impact on implementation.*
* Adds reference to "DNS Query and Response Defaults" but no change of logic. - a001b793184b80 - *This update has no impact on implementation.*
* Adds specific messages when IPv4 or IPv6 has been disabled. - b5d62a2a4 - **This update requires an update to the implementation.**

## Context

zonemaster/zonemaster-engine/pull/790 increased the verbosity of the standard messages, which makes it necessary to move them to the DEBUG level also for Basic.

## How to test this PR

This is a document change, and the resulting update in implementation should be tested.
