### PR TITLE
Add style guide item on lowercasing fragments in Markdown documents

### DIFF
--- a/docs/internal-documentation/maintenance/StyleGuide.md
+++ b/docs/internal-documentation/maintenance/StyleGuide.md
@@ -14,3 +14,6 @@ specified below.
 * For variable names in test case specifications each word is capitalized (e.g.
   "Domain Part"). If a word is an abbreviation, it is usually written with all
   capitals, e.g. "DNS".
+* When writing Markdown documents, use lower case fragments when referring to
+  internal headings' anchors, i.e. use `#objective` not `#Objective` to create
+  a link to the "Objective" section.


### PR DESCRIPTION
## Purpose

Add a style guide when using fragments to internal headings' anchors in Markdown documents. The fragments should be written in lower case so that all Markdown to HTML engines support them.

## Context

Follow-up on #1094, see https://github.com/zonemaster/zonemaster/pull/1094#issuecomment-1235828362

## Changes

Update StyleGuide.md

## How to test this PR

n/a
