### PR TITLE
Rewrite of Connectivity02 (TCP connectivity)

### DIFF
--- a/docs/specifications/tests/Connectivity-TP/connectivity02.md
+++ b/docs/specifications/tests/Connectivity-TP/connectivity02.md
@@ -23,8 +23,9 @@ TCP is a protocol to reach a general purpose name server hosting a zone, "All
 general-purpose DNS implementations MUST support [...] TCP transport"
 ([RFC 7766][RFC 7766#5], section 5).
 
-This Test Case will verify if the name servers in the delegation of and zone of
-*Child Zone* are reachable over TCP.
+This Test Case will verify if the name servers of *Child Zone* are reachable over
+TCP. The name servers tested are both those in the delegation of *Child Zone* and
+those in the NS records in the *Child Zone* itself.
 
 This Test Case will mimic the tests done by [Connectivity01], but over TCP
 instead:

--- a/docs/specifications/tests/Connectivity-TP/connectivity02.md
+++ b/docs/specifications/tests/Connectivity-TP/connectivity02.md
@@ -149,8 +149,7 @@ In other cases, no message or only messages with severity level
 ## Special procedural requirements
 
 If either IPv4 or IPv6 transport is disabled, skip sending queries over that
-transport protocol. A message will be outputted reporting that the transport
-protocol has been skipped.
+transport protocol.
 
 
 ## Intercase dependencies

--- a/docs/specifications/tests/Connectivity-TP/connectivity02.md
+++ b/docs/specifications/tests/Connectivity-TP/connectivity02.md
@@ -1,48 +1,196 @@
-# CONNECTIVITY02: TCP connectivity
+# CONNECTIVITY02: TCP connectivity to name servers
 
 ## Test case identifier
-
 **CONNECTIVITY02**
+
+
+## Table of contents
+
+* [Objective](#objective)
+* [Scope](#scope)
+* [Inputs](#inputs)
+* [Summary](#summary)
+* [Test procedure](#test-procedure)
+* [Outcome(s)](#outcomes)
+* [Special procedural requirements](#special-procedural-requirements)
+* [Intercase dependencies](#intercase-dependencies)
+* [Terminology](#terminology)
+
 
 ## Objective
 
-DNS queries are sent using TCP on port 53, as described in
-[RFC 1035][RFC 1035#section-4.2.2], section 4.2.2. As specified in
-[RFC 7766][RFC 7766#section-1], section 1, support of TCP is mandatory.
+TCP is a protocol to reach a general purpose name server hosting a zone, "All
+general-purpose DNS implementations MUST support [...] TCP transport"
+([RFC 7766][RFC 7766#5], section 5).
 
-The objective for this test is that all the authoritative name servers for
-the domain are accessible over TCP on port 53.
+This test case will verify if the name servers in the delegation of and zone of
+*Child Zone* are reachable over TCP.
+
+This test case will mimic the tests done by [Connectivity01], but over TCP
+instead:
+
+* Name Server responding to a query.
+* Name Server including SOA record of *Child Zone* in the answer section in the
+  response on a SOA query for *Child Zone*.
+* Name Server including NS record of *Child Zone* in the answer section in the
+  response on an NS query for *Child Zone*.
+* Name Server setting the AA flag in a response with SOA or NS in answer section.
+* Name Server responding with expected [RCODE Name] ("NoError") on query for SOA
+  or NS for *Child Zone*.
+
+
+## Scope
+
+The only TCP port defined for DNS is port 53 ([RFC 1035][RFC 1035#4.2.1], section
+4.2.1), and that is the only port used by this and other test cases for DNS
+queries to the name servers.
+
+UPD connectivity is tested by test case [Connectivity01].
+
 
 ## Inputs
 
-The domain to be tested.
+* "Child Zone" - The domain name to be tested.
 
-## Ordered description of steps to be taken to execute the test case
 
-1. Obtains the IP addresses of the name servers from [Method4] and
-   [Method5].
-2. A SOA query is sent over TCP to distinct IP address of each name server
-   found in step 1.
-3. If all queries in step 2 receive a DNS answer (bogus response are not
-   checked here) then the test case succeed.
+## Summary
+
+Message Tag                         |Level  |Arguments  | Message ID for message tag
+:-----------------------------------|:------|:----------|:---------------------------------------------------------------------------------------
+CN02_MISSING_NS_RECORD_TCP          |WARNING| ns        | Nameserver {ns} reponds to a NS query with no NS records in the answer section over TCP.
+CN02_MISSING_SOA_RECORD_TCP         |WARNING| ns        | Nameserver {ns} reponds to a SOA query with no SOA records in the answer section over TCP.
+CN02_NO_RESPONSE_NS_QUERY_TCP       |WARNING| ns        | Nameserver {ns} does not respond to NS queries over TCP.
+CN02_NO_RESPONSE_SOA_QUERY_TCP      |WARNING| ns        | Nameserver {ns} does not respond to SOA queries over TCP.
+CN02_NO_RESPONSE_TCP                |WARNING| ns        | Nameserver {ns} does not respond to any queries over TCP.
+CN02_NS_RECORD_NOT_AA_TCP           |WARNING| ns        | Nameserver {ns} does not give an authoritative response on an NS query over TCP.
+CN02_SOA_RECORD_NOT_AA_TCP          |WARNING| ns        | Nameserver {ns} does not give an authoritative response on an SOA query over TCP.
+CN02_UNEXPECTED_RCODE_NS_QUERY_TCP  |WARNING| ns, rcode | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an NS query over TCP.
+CN02_UNEXPECTED_RCODE_SOA_QUERY_TCP |WARNING| ns, rcode | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an SOA query over TCP.
+CN02_WRONG_NS_RECORD_TCP            |WARNING| ns        | Nameserver {ns} responds with a wrong owner name ({owner} instead of {name}) on NS queries over TCP.
+CN02_WRONG_SOA_RECORD_TCP           |WARNING| ns        | Nameserver {ns} responds with a wrong owner name ({owner} instead of {name}) on SOA queries over TCP.
+
+
+The value in the Level column is the default severity level of the message. The
+severity level can be changed in the [Zonemaster-Engine profile]. Also see the
+[Severity Level Definitions] document.
+
+The argument names in the Arguments column lists the arguments used in the
+message. The argument names are defined in the [argument list].
+
+
+## Test procedure
+
+In this section and unless otherwise specified below, the term "[DNS Query]"
+follows the specification for DNS queries as specified in
+[DNS Query and Response Defaults]. The handling of the DNS responses on the DNS
+queries follow, unless otherwise specified below, what is specified for
+[DNS Response] in the same specification.
+
+1. Create [DNS Queries][DNS Query]:
+   1. Query type SOA and query name *Child Zone* over TCP ("SOA Query TCP").
+   1. Query type NS and query name *Child Zone* over TCP ("NS Query TCP").
+
+2. Obtain the set of name server IP addresses using [Method4] and [Method5]
+   ("Name Server IP").
+
+3. For each name server in *Name Server IP* do:
+
+   1. Send *SOA Query TCP* and *NS Query TCP* to the name server and collect
+      the [DNS Responses][DNS Response].
+   2. If there is no DNS response on neither query, then:
+      1. Output *[CN02_NO_RESPONSE_TCP]* with name and IP address of the name
+         server.
+      2. Go to next server.
+   3. Else:
+      1. Process the response on *SOA Query TCP*:
+         1. If there is no [DNS response], then output
+            *[CN02_NO_RESPONSE_SOA_QUERY_TCP]* with name and IP address of the
+            name server.
+         2. Else, if [RCODE Name] is not "NoError" then output
+            *[CN02_UNEXPECTED_RCODE_SOA_QUERY_TCP]* with [RCODE Name] and name
+            and IP address of the name server.
+         3. Else, if there is no SOA record in the answer section, then
+            output *[CN02_MISSING_SOA_RECORD_TCP]* with name and IP address of
+            the
+            name server.
+         4. Else, if the SOA record has owner name other than *Child Zone*
+            then output *[CN02_WRONG_SOA_RECORD_TCP]* with name and IP address of
+            the name server.
+         5. Else, AA flag is unset, then output *[CN02_SOA_RECORD_NOT_AA_TCP]*
+            with name and IP address of the name server.
+      2. Process the response on *NS Query TCP*:
+         1. If there is no [DNS Response], then output
+            *[CN02_NO_RESPONSE_NS_QUERY_TCP]* with name and IP address of the
+            name server.
+         2. Else, if [RCODE Name] is not "NoError" then output
+            *[CN02_UNEXPECTED_RCODE_NS_QUERY_TCP]* with [RCODE Name] and name and
+            IP address of the name server.
+         3. Else, if there is no NS record in the answer section, then
+            output *[CN02_MISSING_NS_RECORD_TCP]* with name and IP address of the
+            name server.
+         4. Else, if the NS record has owner name other than *Child Zone*
+            then output *[CN02_WRONG_NS_RECORD_TCP]* with name and IP address of
+            the name server.
+         5. Else, AA flag is unset, then output *[CN02_NS_RECORD_NOT_AA_TCP]*
+            with name and IP address of the name server.
+
 
 ## Outcome(s)
 
-If there is any name server that fails to answer queries over port 53 using
-TCP, this test case fails.
+The outcome of this Test Case is "fail" if there is at least one message
+with the severity level *[ERROR]* or *[CRITICAL]*.
+
+The outcome of this Test Case is "warning" if there is at least one message
+with the severity level *[WARNING]*, but no message with severity level
+*ERROR* or *CRITICAL*.
+
+In other cases, no message or only messages with severity level
+*[INFO]* or *[NOTICE]*, the outcome of this Test Case is "pass".
+
 
 ## Special procedural requirements
 
-If either IPv4 or IPv6 transport is disabled, ignore the evaluation of the
-result of any test using this transport protocol. Log a message reporting
-on the ignored result.
+If either IPv4 or IPv6 transport is disabled, skip sending queries over that
+transport protocol. A message will be outputted reporting that the transport
+protocol has been skipped.
+
 
 ## Intercase dependencies
 
-None
+None.
 
-[Method4]:                                   ../Methods.md#method-4-obtain-glue-address-records-from-parent
-[Method5]:                                   ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
-[RFC 1035#section-4.2.2]:                    https://tools.ietf.org/html/rfc1035#section-4.2.2
-[RFC 7766#section-1]:                        https://tools.ietf.org/html/rfc7766#section-1
 
+## Terminology
+
+No special terminology for this test case.
+
+
+[Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[CN02_MISSING_NS_RECORD_TCP]:                                     #summary
+[CN02_MISSING_SOA_RECORD_TCP]:                                    #summary
+[CN02_NO_RESPONSE_NS_QUERY_TCP]:                                  #summary
+[CN02_NO_RESPONSE_SOA_QUERY_TCP]:                                 #summary
+[CN02_NO_RESPONSE_TCP]:                                           #summary
+[CN02_NS_RECORD_NOT_AA_TCP]:                                      #summary
+[CN02_SOA_RECORD_NOT_AA_TCP]:                                     #summary
+[CN02_UNEXPECTED_RCODE_NS_QUERY_TCP]:                             #summary
+[CN02_UNEXPECTED_RCODE_SOA_QUERY_TCP]:                            #summary
+[CN02_WRONG_NS_RECORD_TCP]:                                       #summary
+[CN02_WRONG_SOA_RECORD_TCP]:                                      #summary
+[CRITICAL]:                                                       ../SeverityLevelDefinitions.md#critical
+[Connectivity01]:                                                 connectivity01.md
+[DEBUG]:                                                          ../SeverityLevelDefinitions.md#notice
+[DNS Query and Response Defaults]:                                ../DNSQueryAndResponseDefaults.md
+[DNS Query]:                                                      ../DNSQueryAndResponseDefaults.md#default-setting-in-dns-query
+[DNS Response]:                                                   ../DNSQueryAndResponseDefaults.md#default-handling-of-a-dns-response
+[ERROR]:                                                          ../SeverityLevelDefinitions.md#error
+[INFO]:                                                           ../SeverityLevelDefinitions.md#info
+[Method4]:                                                        ../Methods.md#method-4-obtain-glue-address-records-from-parent
+[Method5]:                                                        ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
+[NOTICE]:                                                         ../SeverityLevelDefinitions.md#notice
+[RCODE Name]:                                                     https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
+[RFC 1035#4.2.1]:                                                 https://www.rfc-editor.org/rfc/rfc1035#section-4.2.1
+[RFC 7766#5]:                                                     https://www.rfc-editor.org/rfc/rfc7766#section-5
+[Severity Level Definitions]:                                     ../SeverityLevelDefinitions.md
+[WARNING]:                                                        ../SeverityLevelDefinitions.md#warning
+[Zonemaster-Engine profile]:                                      https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md

--- a/docs/specifications/tests/Connectivity-TP/connectivity02.md
+++ b/docs/specifications/tests/Connectivity-TP/connectivity02.md
@@ -66,8 +66,8 @@ CN02_NS_RECORD_NOT_AA_TCP           |WARNING| ns        | Nameserver {ns} does n
 CN02_SOA_RECORD_NOT_AA_TCP          |WARNING| ns        | Nameserver {ns} does not give an authoritative response on an SOA query over TCP.
 CN02_UNEXPECTED_RCODE_NS_QUERY_TCP  |WARNING| ns, rcode | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an NS query over TCP.
 CN02_UNEXPECTED_RCODE_SOA_QUERY_TCP |WARNING| ns, rcode | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an SOA query over TCP.
-CN02_WRONG_NS_RECORD_TCP            |WARNING| ns        | Nameserver {ns} responds with a wrong owner name ({domain_found} instead of {domain_expected}) on NS queries over TCP.
-CN02_WRONG_SOA_RECORD_TCP           |WARNING| ns        | Nameserver {ns} responds with a wrong owner name ({domain_found} instead of {domain_expected}) on SOA queries over TCP.
+CN02_WRONG_NS_RECORD_TCP            |WARNING| ns, , domain_found, domain_expected | Nameserver {ns} responds with a wrong owner name ({domain_found} instead of {domain_expected}) on NS queries over TCP.
+CN02_WRONG_SOA_RECORD_TCP           |WARNING| ns, , domain_found, domain_expected | Nameserver {ns} responds with a wrong owner name ({domain_found} instead of {domain_expected}) on SOA queries over TCP.
 
 The value in the Level column is the default severity level of the message. The
 severity level can be changed in the [Zonemaster-Engine profile]. Also see the

--- a/docs/specifications/tests/Connectivity-TP/connectivity02.md
+++ b/docs/specifications/tests/Connectivity-TP/connectivity02.md
@@ -23,10 +23,10 @@ TCP is a protocol to reach a general purpose name server hosting a zone, "All
 general-purpose DNS implementations MUST support [...] TCP transport"
 ([RFC 7766][RFC 7766#5], section 5).
 
-This test case will verify if the name servers in the delegation of and zone of
+This Test Case will verify if the name servers in the delegation of and zone of
 *Child Zone* are reachable over TCP.
 
-This test case will mimic the tests done by [Connectivity01], but over TCP
+This Test Case will mimic the tests done by [Connectivity01], but over TCP
 instead:
 
 * Name Server responding to a query.
@@ -42,10 +42,10 @@ instead:
 ## Scope
 
 The only TCP port defined for DNS is port 53 ([RFC 1035][RFC 1035#4.2.1], section
-4.2.1), and that is the only port used by this and other test cases for DNS
+4.2.1), and that is the only port used by this and other Test Cases for DNS
 queries to the name servers.
 
-UPD connectivity is tested by test case [Connectivity01].
+UDP connectivity is tested by Test Case [Connectivity01].
 
 
 ## Inputs
@@ -66,9 +66,8 @@ CN02_NS_RECORD_NOT_AA_TCP           |WARNING| ns        | Nameserver {ns} does n
 CN02_SOA_RECORD_NOT_AA_TCP          |WARNING| ns        | Nameserver {ns} does not give an authoritative response on an SOA query over TCP.
 CN02_UNEXPECTED_RCODE_NS_QUERY_TCP  |WARNING| ns, rcode | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an NS query over TCP.
 CN02_UNEXPECTED_RCODE_SOA_QUERY_TCP |WARNING| ns, rcode | Nameserver {ns} responds with an unexpected RCODE ({rcode}) on an SOA query over TCP.
-CN02_WRONG_NS_RECORD_TCP            |WARNING| ns        | Nameserver {ns} responds with a wrong owner name ({owner} instead of {name}) on NS queries over TCP.
-CN02_WRONG_SOA_RECORD_TCP           |WARNING| ns        | Nameserver {ns} responds with a wrong owner name ({owner} instead of {name}) on SOA queries over TCP.
-
+CN02_WRONG_NS_RECORD_TCP            |WARNING| ns        | Nameserver {ns} responds with a wrong owner name ({domain_found} instead of {domain_expected}) on NS queries over TCP.
+CN02_WRONG_SOA_RECORD_TCP           |WARNING| ns        | Nameserver {ns} responds with a wrong owner name ({domain_found} instead of {domain_expected}) on SOA queries over TCP.
 
 The value in the Level column is the default severity level of the message. The
 severity level can be changed in the [Zonemaster-Engine profile]. Also see the
@@ -100,7 +99,7 @@ queries follow, unless otherwise specified below, what is specified for
    2. If there is no DNS response on neither query, then:
       1. Output *[CN02_NO_RESPONSE_TCP]* with name and IP address of the name
          server.
-      2. Go to next server.
+      2. Go to next name server.
    3. Else:
       1. Process the response on *SOA Query TCP*:
          1. If there is no [DNS response], then output
@@ -111,12 +110,11 @@ queries follow, unless otherwise specified below, what is specified for
             and IP address of the name server.
          3. Else, if there is no SOA record in the answer section, then
             output *[CN02_MISSING_SOA_RECORD_TCP]* with name and IP address of
-            the
-            name server.
+            the name server.
          4. Else, if the SOA record has owner name other than *Child Zone*
             then output *[CN02_WRONG_SOA_RECORD_TCP]* with name and IP address of
-            the name server.
-         5. Else, AA flag is unset, then output *[CN02_SOA_RECORD_NOT_AA_TCP]*
+            the name server, the SOA record owner name and *Child Zone*.
+         5. Else, if AA flag is unset, then output *[CN02_SOA_RECORD_NOT_AA_TCP]*
             with name and IP address of the name server.
       2. Process the response on *NS Query TCP*:
          1. If there is no [DNS Response], then output
@@ -130,8 +128,8 @@ queries follow, unless otherwise specified below, what is specified for
             name server.
          4. Else, if the NS record has owner name other than *Child Zone*
             then output *[CN02_WRONG_NS_RECORD_TCP]* with name and IP address of
-            the name server.
-         5. Else, AA flag is unset, then output *[CN02_NS_RECORD_NOT_AA_TCP]*
+            the name server, the NS record owner name and *Child Zone*.
+         5. Else, if AA flag is unset, then output *[CN02_NS_RECORD_NOT_AA_TCP]*
             with name and IP address of the name server.
 
 
@@ -162,7 +160,7 @@ None.
 
 ## Terminology
 
-No special terminology for this test case.
+No special terminology for this Test Case.
 
 
 [Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md


### PR DESCRIPTION
## Purpose

This PR is a complete rewrite of the test case. The main body of the the specification is copied from the rewritten Connectivity01 (#1097). 

## How to test this PR

This documentation only. Testing is done by reviewing and manual running the test case.
