### PR TITLE
Updated build instructions

### DIFF
--- a/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-create-docker-image.md
@@ -70,10 +70,10 @@ git -C zonemaster-engine checkout origin/master
 git -C zonemaster-cli checkout origin/master
 ```
 
-Create `Makefile` in all three repositories
+Make sure repositories are clean and create `Makefile` in all three repositories
 
 ```sh
-(cd zonemaster-ldns; git clean -dfx; git reset --hard; perl Makefile.PL --no-internal-ldns)
+(cd zonemaster-ldns; git submodule update; git clean -dfx; git reset --hard; perl Makefile.PL --no-internal-ldns)
 ```
 > Ubuntu 22.04 does not currently have support for internal LDNS.
 ```sh

--- a/docs/internal-documentation/maintenance/ReleaseProcess-create-test-distribution.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-create-test-distribution.md
@@ -36,14 +36,15 @@ the `develop` branch and that your clone is up-to-date.
        git fetch --all
        git branch
 
+For Zonemaster-LDNS only - reset submodule (LDNS):
+
+       git submodule update
+
 Make sure your working directory is clean.
 
        git status --ignored
 
-> **Note:** To throw away any and all changes to tracked and untracked files you
-> can run `git clean -dfx ; git reset --hard`.
-
-To clean:
+To clean (throw away untracked changes or files):
 
        git clean -dfx
        git reset --hard

--- a/docs/internal-documentation/maintenance/ReleaseProcess-create-test-distribution.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-create-test-distribution.md
@@ -36,7 +36,7 @@ the `develop` branch and that your clone is up-to-date.
        git fetch --all
        git branch
 
-For Zonemaster-LDNS only - reset submodule (LDNS):
+For Zonemaster-LDNS only - check out submodule to the right commit (LDNS):
 
        git submodule update
 

--- a/docs/internal-documentation/maintenance/ReleaseProcess-preparation.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-preparation.md
@@ -38,7 +38,8 @@ Makefile.PL must be updated.
      git clean -dfx
      git reset --hard
 ```
-  2. Check out the `develop` branch.
+  2. Check out the `develop` branch. Check out the right commit
+     of the submodule (LDNS) if Zonemaster-LDNS.
 ```
      git checkout origin/develop
      git submodule update # Zonemaster-LDNS only

--- a/docs/internal-documentation/maintenance/ReleaseProcess-preparation.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-preparation.md
@@ -33,8 +33,16 @@ is up to date with the [supported Perl versions] in main README.md.
 META.yml is created by Makefile.PL so if META.yml is not correct, then
 Makefile.PL must be updated.
 
-  1. Make a clean clone for each repo.
+  1. Make a clean clone for each reposistory
+```
+     git clean -dfx
+     git reset --hard
+```
   2. Check out the `develop` branch.
+```
+     git checkout origin/develop
+     git submodule update # Zonemaster-LDNS only
+```
   3. Run
 ```
      perl Makefile.PL --no-ed25519 # zonemaster-ldns only

--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -154,6 +154,9 @@ git fetch --all
 git branch
 ```
 ```
+git submodule update # Zonemaster-LDNS only
+```
+```
 git status --ignored
 ```
 ```

--- a/docs/internal-documentation/maintenance/ReleaseProcess-release.md
+++ b/docs/internal-documentation/maintenance/ReleaseProcess-release.md
@@ -148,17 +148,20 @@ requires 'Zonemaster::LDNS'   => 2.001;
 ## 8. Create a clean Git working area of *develop branch*
 
 Make sure that you have checked out the `develop` branch and that your clone is
-up-to-date. Make sure your working directory is clean. Or clean it.
+up-to-date.
 ```
 git fetch --all
 git branch
 ```
+Check out the right commit of the submodule (LDNS). Zonemaster-LDNS only.
 ```
-git submodule update # Zonemaster-LDNS only
+git submodule update
 ```
+Make sure your working directory is clean.
 ```
 git status --ignored
 ```
+Or clean it.
 ```
 git clean -dfx
 git reset --hard


### PR DESCRIPTION
## Purpose

This applies for the build instructions for Zonemaster-LDNS. That repository has a submodule to LDNS. If the submodule is checked out and the version is changed in the branch checked out, then then submodule must be updated. If changing between branches with different version of the submodule, then the submodule must also be updated.

The changes in this PR assumes that https://github.com/zonemaster/zonemaster-ldns/pull/158 is merged.

## How to test this PR

Review and test using the documents.
