### PR TITLE
Clarifies Zone09

### DIFF
--- a/docs/specifications/tests/Zone-TP/zone09.md
+++ b/docs/specifications/tests/Zone-TP/zone09.md
@@ -194,7 +194,8 @@ queries follow, unless otherwise specified below, what is specified for
     3. Output *[Z09_MX_FOUND]* with the name server IP addresses from the
        *MX RRset* set.
 
-10. If the *MX RRset* set is non-empty, then do:
+10. If the *MX RRset* set is non-empty (the *No MX RRset* set is empty or
+    non-empty), then do:
     1. If the RRsets in *MX RRset* are not equal for all name servers then do:
        1. Output *[Z09_INCONSISTENT_MX_DATA]*.
        2. For each RRset in *MX RRset*, output *[Z09_MX_DATA]* with the mail
@@ -215,8 +216,8 @@ queries follow, unless otherwise specified below, what is specified for
        4. Else, output *[Z09_MX_DATA]* with the mail targets from the RDATA and
           the associated name server IP addresses in the set.
 
-11. Else, if the *No MX RRset* set is non-empty then do:
-    * Output *[Z09_MISSING_MAIL_TARGET]* unless
+11. If the *No MX RRset* set is non-empty and the *MX RRset* set is empty, then
+    output *[Z09_MISSING_MAIL_TARGET]* unless
       1. *Child Zone* is the root zone ("."), or
       1. *Child Zone* is a [TLD], or
       2. *Child Zone* is a zone in the .ARPA tree.

--- a/docs/specifications/tests/Zone-TP/zone09.md
+++ b/docs/specifications/tests/Zone-TP/zone09.md
@@ -219,8 +219,8 @@ queries follow, unless otherwise specified below, what is specified for
 11. If the *No MX RRset* set is non-empty and the *MX RRset* set is empty, then
     output *[Z09_MISSING_MAIL_TARGET]* unless
       1. *Child Zone* is the root zone ("."), or
-      1. *Child Zone* is a [TLD], or
-      2. *Child Zone* is a zone in the .ARPA tree.
+      2. *Child Zone* is a [TLD], or
+      3. *Child Zone* is a zone in the .ARPA tree.
 
 
 ## Outcome(s)


### PR DESCRIPTION
## Purpose

In current version of the specification it is not completely clear when Z09_MISSING_MAIL_TARGET. This PR does not require any change of implementation.

## Changes

Updates the specification.

## How to test this PR

Review only.