### PR TITLE
Supported OS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,37 +72,36 @@ and processor architecture listed below.
 
 ### Supported operating system versions
 
-* [CentOS Linux] 7
 * [Debian] 11
 * [Docker]
-* [FreeBSD] 13.1
+* [FreeBSD] 13
+* [Rocky Linux] 8
+* [Rocky Linux] 9
+* [Ubuntu] 20.04
 * [Ubuntu] 22.04
-* [Rocky Linux] 8.7
 
-Only the latest long-term supported version of Debian, FreeBSD and Ubuntu,
-respectively, is supported. Zonemaster supports Rocky Linux 8.7, not 9.1, due to
-issues with LDNS and OpenSSL on Rocky Linux 9.1. The plan is to change to Rocky
-Linux 9 in the v2023.1 release. Support for CentOS Linux 7 will be dropped by
-Zonemaster release v2023.1.
+For Debian the "stable" version is supported. For FreeBSD one of the FreeBSD
+supported major versions is supported. For Rocky Linux and Ubuntu long-term
+supported versions are supported unless its support ends before next expected
+release of Zonemaster.
 
 Only the Docker images provided by the Zonemaster project on [Docker Hub] are
 supported. Currently only Zonemaster-CLI is supported on Docker. Docker itself
 can run on any of the [Docker] supported OSs (Linux, MacOS and Windows).
 
-[Rocky Linux] has replaced CentOS in Zonemaster version v2021.2 since CentOS 8
-is not supported anymore and CentOS 7 is old and does not support modern OpenSSL
-required by Zonemaster. Rocky Linux is also a Red Hat derivative and is available
-at large cloud providers.
+[Rocky Linux] has replaced CentOS in Zonemaster version v2021.2. Rocky Linux is
+also a Red Hat derivative and is available at large cloud providers.
 
 ### Supported database engine versions
 
 Operating System | MariaDB | PostgreSQL
 ---------------- | --------| ---------------
-CentOS Linux 7   | 5.5     | *not supported*
 Debian 11        | 10.5    | 13.8
 Docker           | n/a     | n/a
-FreeBSD 13.1     | 5.7 (*) | 13.9
-Rocky Linux 8.7  | 10.3    | 10.21
+FreeBSD 13       | 5.7 (*) | 13.9
+Rocky Linux 8    | 10.3    | 10.21
+Rocky Linux 9    | ???     | ???
+Ubuntu 20.04     | ???     | ???
 Ubuntu 22.04     | 10.6    | 14.5
 
 * (*) FreeBSD uses MySQL, not MariaDB.
@@ -118,11 +117,12 @@ Ubuntu 22.04     | 10.6    | 14.5
 
 Operating System | Perl
 ---------------- | ----
-CentOS Linux 7   | 5.16
 Debian 11        | 5.32
 Docker           | (*)
-FreeBSD 13.1     | 5.32
-Rocky Linux 8.7  | 5.26
+FreeBSD 13       | 5.32
+Rocky Linux 8    | 5.26
+Rocky Linux 9    | 5.32 ??
+Ubuntu 20.04     | ???
 Ubuntu 22.04     | 5.34
 
 * Zonemaster requires Perl version 5.16 or higher.
@@ -158,10 +158,7 @@ installation instructions given for Zonemaster have been followed. A test of the
 domains `ed25519.nl` and `superdns.nl` will reveal if the Zonemaster
 installation has the support or not for algorithms 15 and 16, respectively.
 
-All supported OSs, except CentOS Linux 7, support algorithms 15 and 16 out of the
-box. To get the support in CentOS Linux 7 a newer version of OpenSSL has to be
-installed and Zonemaster-LDNS has to be installed following special instructions
-found in the [Zonemaster-Engine] installation instructions.
+All supported OSs support algorithms 15 and 16 out of the box.
 
 ## Translation
 
@@ -266,7 +263,6 @@ This is free software under a 2-clause BSD license. The full text of the license
 be found in the [LICENSE](LICENSE) file included in this respository.
 
 
-[CentOS Linux]:                        https://centos.org/centos-linux/
 [CPAN]:                                https://www.cpan.org/
 [Connectivity03]:                      docs/specifications/tests/Connectivity-TP/connectivity03.md
 [Contact and mailing lists]:           docs/contact-and-mailing-lists.md

--- a/docs/internal-documentation/maintenance/SupportCriteria.md
+++ b/docs/internal-documentation/maintenance/SupportCriteria.md
@@ -19,7 +19,7 @@ testing is currently done on ARM architecture.
 
 ## Operating systems
 
-Zonesmaster is actively tested on the following operating systems:
+Zonemaster is actively tested on the following operating systems:
 
 * Debian
 * FreeBSD
@@ -68,10 +68,10 @@ system that is supported:
     (scroll down to "Supported FreeBSD releases").
 
 * Rocky Linux:
-  * All major versions that has not reached EOL are supported.
+  * All major versions that have not reached EOL are supported.
     * If the the EOL of a major version is within the expected lifetime of the
       Zonemaster release then that major version is not supported.
-  * Only the newest point releas is tested.
+  * Only the newest point release is tested.
   * Active releases are listed on <https://rockylinux.org/download>.
 
 * Ubuntu:

--- a/docs/internal-documentation/maintenance/SupportCriteria.md
+++ b/docs/internal-documentation/maintenance/SupportCriteria.md
@@ -13,18 +13,20 @@ tuples.
 
 ## Architectures
 
-Zonemaster is actively tested on the amd64/x86_64 processor architecture.
+Zonemaster is actively tested on the amd64/x86_64 processor architecture. No
+testing is currently done on ARM architecture.
 
 
 ## Operating systems
 
-Zonesmaster is actively tested on these operating systems:
+Zonesmaster is actively tested on the following operating systems:
 
 * Debian
 * FreeBSD
 * Rocky Linux
 * Ubuntu
 
+CentOS is no longer supported and has been replaced by Rocky Linux.
 
 ## Operating system versions
 
@@ -41,33 +43,44 @@ system that is supported:
   * Minor version/point release/patch level should not be specified.
   * Operating system versions without long term support form their
     vendor should not be supported.
-  * Only the latest long term version is supported.
-  * Operating system versions that have reached their end-of-life should not be
-    supported.
+  * Operating system versions that have reached their end-of-life (or end of
+    general support) should not be supported.
+  * Operating system versions that are expected to reach their end-of-life (or
+    end of general support) within the lifetime of the Zonemaster version should
+    not be supported.
   * Operating system versions that do not provide the prerequisites for
     Zonemaster should not be supported.
 
 ### Operating system specific guidelines
 
-* CentOS:
-  * Base Distributions are listed here:
-    <https://en.wikipedia.org/wiki/CentOS#End-of-support_schedule>
-
 * Debian:
-  * Current versions of "stable" and "oldstable" are listed here:
-    <https://wiki.debian.org/DebianReleases#Current_Releases.2FRepositories>
+  * Only the current "stable" release is supported.
+  * Current "stable" is listed on
+    <https://wiki.debian.org/DebianReleases#Current_Releases.2FRepositories>.
 
 * FreeBSD:
-  * Supported releases are listed here:
-    <https://www.freebsd.org/security/>
+  * One major branch is supported. The selected major branch is supported for
+    its lifetime, and then replaced by the newest major branch. The replacement
+    is done when EOL will be reached within the expected lifetime of the
+    Zonemaster release.
+  * For the selected major release, only the newest point release is tested.
+  * The active major branches are found on <https://www.freebsd.org/security/>
+    (scroll down to "Supported FreeBSD releases").
 
 * Rocky Linux:
-  * Supported releases are listed here:
-    <https://rockylinux.org/download>
+  * All major versions that has not reached EOL are supported.
+    * If the the EOL of a major version is within the expected lifetime of the
+      Zonemaster release then that major version is not supported.
+  * Only the newest point releas is tested.
+  * Active releases are listed on <https://rockylinux.org/download>.
 
 * Ubuntu:
-  * LTS releases are listed here:
-    <https://wiki.ubuntu.com/Releases>
+  * All LTS versions that have not reached the "End of Standard Support" are
+    supported.
+    * If the "End of Standard Support" for an LTS version is within the expected
+      lifetime of the Zonemaster release then that LTS version is not supported.
+  * For each LTS version, only the newest point release is tested.
+  * LTS releases are listed on <https://wiki.ubuntu.com/Releases>.
 
 
 ## Database engines
@@ -95,9 +108,14 @@ Database engine versions that lack required features cannot be supported.
   * <https://packages.debian.org/search?searchon=names&keywords=sqlite3>
 
 * Database engine versions provided FreeBSD are listed here:
-  * <https://www.freebsd.org/cgi/ports.cgi?stype=name&sektion=databases&query=mariadb>
+  * <https://www.freebsd.org/cgi/ports.cgi?query=mysql&stype=name&sektion=databases>
+    and look for "mysql??-server-*" (FreeBSD does not support MariaDB in a
+    default Backend installation).
   * <https://www.freebsd.org/cgi/ports.cgi?stype=name&sektion=databases&query=postgresql>
-  * <https://www.freebsd.org/cgi/ports.cgi?stype=name&sektion=databases&query=sqlite3>
+  * <https://www.freebsd.org/cgi/ports.cgi?query=p5-DBD-SQLite-&stype=name&sektion=databases>
+    (then SQLite binary is included in the Perl package).
+
+* Database engine versions provided by each version of Rocky Linux are listed here: TBP
 
 * Database engine versions provided by each version of Ubuntu are listed here:
   * <https://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=mariadb-server>
@@ -125,14 +143,13 @@ version should be supported.
 
 The point release should not be specified.
 
-* Perl versions provided by CentOS 7 are listed here:
-  * <http://mirror.centos.org/centos/7/os/x86_64/Packages/>
-
 * Perl versions provided by each version of Debian are listed here:
   * <https://packages.debian.org/search?searchon=names&keywords=perl>
 
 * Perl versions provided FreeBSD are listed here:
   * <https://www.freebsd.org/cgi/ports.cgi?stype=name&sektion=lang&query=perl>
+
+* Perl versions provided by each version of Rocky Linux are listed here: TBP
 
 * Perl versions provided by each version of Ubuntu are listed here:
   * <https://packages.ubuntu.com/search?suite=default&section=all&arch=any&searchon=names&keywords=perl>
@@ -140,6 +157,5 @@ The point release should not be specified.
 
 ## Nice-to-have resources
 
-* [CentOS minor releases](https://wiki.centos.org/Download)
 * [Debian point releases](https://wiki.debian.org/DebianReleases/PointReleases)
 * [Ubuntu patch levels](https://wiki.ubuntu.com/Releases)


### PR DESCRIPTION
## Purpose

Issue #1125 raises the issue of short Zonemaster support of Ubuntu LTS versions, in practice only two years of the five-year LTS support.

This PR adjusts the support criteria and adds support for more Ubuntu LTS versions and more Rocky Linux major versions. The changes here are based on the agreement in the Zonemaster Work Group 2023-01-09.

## Changes

* Support Criteria document
* Main README document

## How to test this PR

Documentation only. Review and verify that it is correct.