### PR TITLE
Update translation instruction for translators

### DIFF
--- a/docs/internal-documentation/maintenance/Instructions-for-translators.md
+++ b/docs/internal-documentation/maintenance/Instructions-for-translators.md
@@ -338,19 +338,15 @@ is to make a copy of an existing file.
   grep xx_ /etc/locale.gen  # Works in Debian and Ubuntu
   ```
 
-* Go to the *share* directory and use an existing PO file, say sv.po, and make a
-  copy of that to the new file name. Update it and "add" it to `git` before
-  working on it.
+* Go to the *share* directory and create a new blank PO file. Then "add" it
+  to `git` before working on it.
   ```
   cd share
-  cp sv.po xx.po
-  ./update-po xx.po
+  make POLANG=xx new-po
   git add xx.po
   ```
 
-* When you do the update of the new PO file you have to replace all *msgstr*
-  in Swedish with the translation in the new language, but also update the
-  "Language" field in the header.
+* Verify and update the file header if needed.
 
 * Now you go back to section "[Translation steps]" and continue in the same way
   as with an existing language.

--- a/docs/internal-documentation/maintenance/Instructions-for-translators.md
+++ b/docs/internal-documentation/maintenance/Instructions-for-translators.md
@@ -215,11 +215,12 @@ same for all three repositories.
   ../util/check-msg-args xx.po
   ```
 
-* When the update of all *msgstr* is complete run the update command again to
-  create a consistent formatation of the PO file. Do this again if you do further
-  updates.
+* When the update of all *msgstr* is complete run the `tidy-po` command to
+  create a consistent formatation of the PO file. Do this again if you do
+  further updates.
+
   ```
-  ./update-po xx.po
+  make POFILES=xx.po tidy-po
   ```
 
 * You can check all updates that have been done to the xx.po file. That includes


### PR DESCRIPTION
## Purpose

Update documentation for translator to use the newly created `new-po` rule.

## Context

Addresses https://github.com/zonemaster/zonemaster/issues/1131 and https://github.com/zonemaster/zonemaster-engine/pull/1185

## Changes

Instruction for translators

## How to test this PR

Verify that the instructions are clear enough.