### PR TITLE
Fix typos and inconsistencies in DNSSEC16 and DNSSEC17 specifications

### DIFF
--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec16.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec16.md
@@ -40,10 +40,10 @@ DS16_CDS_INVALID_RRSIG               | ERROR   | CDS RRset is signed with an inv
 DS16_CDS_MATCHES_NON_SEP_DNSKEY      | NOTICE  | CDS record matches a DNSKEY with SEP bit (bit 15) unset.
 DS16_CDS_MATCHES_NON_ZONE_DNSKEY     | ERROR   | CDS record matches a DNSKEY with zone bit (bit 7) unset.
 DS16_CDS_MATCHES_NO_DNSKEY           | WARNING | CDS record does not match any DNSKEY in DNSKEY RRset.
-DS16_CDS_NOT_SIGNED_BY_CDS           | NOTICE  | CDS RRset is signed but not by the key that the CDS record points to.
-DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY    | ERROR   | CDS RRset is signed but not by a key in DNSKEY RRset.
-DS16_CDS_UNSIGNED                    | ERROR   | CDS RRset is not signed.
-DS16_CDS_WITHOUT_DNSKEY              | ERROR   | CDS RRset exists, but no DNSKEY RRset.
+DS16_CDS_NOT_SIGNED_BY_CDS           | NOTICE  | CDS RRset is not signed by the key that the CDS record points to.
+DS16_CDS_SIGNED_BY_UNKNOWN_DNSKEY    | ERROR   | CDS RRset is signed by a key not in DNSKEY RRset.
+DS16_CDS_UNSIGNED                    | ERROR   | CDS RRset is unsigned.
+DS16_CDS_WITHOUT_DNSKEY              | ERROR   | CDS RRset exists, but there is no DNSKEY RRset.
 DS16_DELETE_CDS                      | INFO    | CDS RRset has a "delete" CDS record as a single record.
 DS16_DNSKEY_NOT_SIGNED_BY_CDS        | WARNING | DNSKEY RRset is not signed by the key or keys that the CDS records point to.
 DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed with normal CDS record.
@@ -144,8 +144,8 @@ DS16_MIXED_DELETE_CDS                | ERROR   | "Delete" CDS record is mixed wi
              key tag of CDS record to the *DNSKEY Not Signed By CDS* set.
           2. If the CDS RRset has not been signed by the DNSKEY record that
              the CDS record points at then add the name server IP address and
-             key tag of CDS record to the *DNSKEY Not Signed By CDS* set.
-          3. If bit 15 of the flags field of the DNSKEY that the DS record
+             key tag of CDS record to the *CDS Not Signed By CDS* set.
+          3. If bit 15 of the flags field of the DNSKEY that the CDS record
              points at is unset (value 0) then add the name server IP address
              and the key tag of the CDS record to the
              *CDS points to non-SEP DNSKEY* set.

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec17.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec17.md
@@ -40,9 +40,9 @@ DS17_CDNSKEY_INVALID_RRSIG           | ERROR   | CDNSKEY RRset signed with an in
 DS17_CDNSKEY_IS_NON_SEP              | NOTICE  | CDNSKEY record has the SEP bit (bit 15) unset.
 DS17_CDNSKEY_IS_NON_ZONE             | ERROR   | CDNSKEY record has the zone bit (bit 7) unset.
 DS17_CDNSKEY_MATCHES_NO_DNSKEY       | WARNING | CDNSKEY record does not match any DNSKEY in DNSKEY RRset.
-DS17_CDNSKEY_NOT_SIGNED_BY_CDNSKEY   | NOTICE  | CDNSKEY RRset is signed but not by the key that the CDNSKEY record points to.
-DS17_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY| ERROR   | CDNSKEY RRset is signed but not by a key in DNSKEY RRset.
-DS17_CDNSKEY_UNSIGNED                | ERROR   | CDNSKEY RRset is not signed.
+DS17_CDNSKEY_NOT_SIGNED_BY_CDNSKEY   | NOTICE  | CDNSKEY RRset is not signed by the key that the CDNSKEY record points to.
+DS17_CDNSKEY_SIGNED_BY_UNKNOWN_DNSKEY| ERROR   | CDNSKEY RRset is signed by a key not in DNSKEY RRset.
+DS17_CDNSKEY_UNSIGNED                | ERROR   | CDNSKEY RRset is unsigned.
 DS17_CDNSKEY_WITHOUT_DNSKEY          | ERROR   | CDNSKEY RRset exists, but there is no DNSKEY RRset.
 DS17_DELETE_CDNSKEY                  | INFO    | CDNSKEY RRset has a "delete" CDNSKEY record as a single record.
 DS17_DNSKEY_NOT_SIGNED_BY_CDNSKEY    | WARNING | DNSKEY RRset is not signed by the key or keys that the CDNSKEY records point to.


### PR DESCRIPTION
## Purpose

Typos in the text was found in the DNSSEC16 specification. Related inconsistencies between some messages and the logic were found in DNSSEC16 and DNSSEC17 specifications. The messages are updated to match the logic.

No change of logic are needed in the implementation of the two test cases, but the messages must be updated in the implementation when this PR has been merged.

## How to test this PR

Review the messages and the logic of the test cases.
