### PR TITLE
Removes limitation on multiple batches

### DIFF
--- a/docs/public/using/backend/rpcapi-reference.md
+++ b/docs/public/using/backend/rpcapi-reference.md
@@ -1316,8 +1316,8 @@ A [*batch id*][Batch id].
 
 #### `"error"`
 
-* If the given `profile` is not among the [available profiles][Profile sections],
-  a user error is returned, see the [profile name section][profile name].
+If the given `profile` is not among the [available profiles][Profile sections], a
+user error is returned, see the [profile name section][profile name].
 
 Trying to add a batch when wrong [*username*][Username] or [*api key*][Api key] is used:
 ```json

--- a/docs/public/using/backend/rpcapi-reference.md
+++ b/docs/public/using/backend/rpcapi-reference.md
@@ -1252,6 +1252,10 @@ A [*username*][Username] and its [*api key*][Api key] can be added with the
 
 *Tests* enqueud using this method are assigned a [*priority*][Priority] of 5.
 
+> In previous versions of Zonemaster-Backend a new batch could not be created by
+> the same [*username*][Username] if that *username* had created a batch that was
+> not yet finished. That restriction has been removed.
+
 
 Example request:
 ```json
@@ -1312,28 +1316,8 @@ A [*batch id*][Batch id].
 
 #### `"error"`
 
-* You cannot create a new batch job if a *batch* with unfinished *tests* already
-  exists for this [*username*][Username].
 * If the given `profile` is not among the [available profiles][Profile sections],
   a user error is returned, see the [profile name section][profile name].
-
-Trying to add a batch when a batch is still running for the [*username*][Username] in the
-request:
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "error": {
-    "data": {
-      "created_at": "2021-09-27T07:33:40Z",
-      "batch_id": 1
-    },
-    "code": -32603,
-    "message": "Batch job still running"
-  }
-}
-
-```
 
 Trying to add a batch when wrong [*username*][Username] or [*api key*][Api key] is used:
 ```json

--- a/docs/public/using/backend/rpcapi-reference.md
+++ b/docs/public/using/backend/rpcapi-reference.md
@@ -1248,8 +1248,7 @@ This method is not available if [`RPCAPI.enable_add_batch_job`][RPCAPI.enable_ad
 is disabled (enabled by default).
 
 A [*username*][Username] and its [*api key*][Api key] can be added with the
-[`add_api_user`][API add_api_user] method. A [*username*][Username] can only have
-one un-finished *batch* at a time.
+[`add_api_user`][API add_api_user] method.
 
 *Tests* enqueud using this method are assigned a [*priority*][Priority] of 5.
 

--- a/docs/public/using/backend/rpcapi-reference.md
+++ b/docs/public/using/backend/rpcapi-reference.md
@@ -1254,7 +1254,7 @@ A [*username*][Username] and its [*api key*][Api key] can be added with the
 
 > In previous versions of Zonemaster-Backend a new batch could not be created by
 > the same [*username*][Username] if that *username* had created a batch that was
-> not yet finished. That restriction has been removed.
+> not yet finished. That restriction has been removed in version 2023.2.
 
 
 Example request:


### PR DESCRIPTION
## Purpose

The purpose is described in https://github.com/zonemaster/zonemaster-backend/pull/1118 where the change is implemented. The statement that a user only can have one active batch running is removed.

## Changes

The specification of the RPC-API.

## How to test this PR

Review the document and compare with https://github.com/zonemaster/zonemaster-backend/pull/1118