### PR TITLE
Move and update Arguments document

### DIFF
--- a/docs/internal/maintenance/Instructions-for-translators.md
+++ b/docs/internal/maintenance/Instructions-for-translators.md
@@ -385,7 +385,7 @@ make update-po MSGMERGE_OPTS=--no-fuzzy-matching
 <!-- Zonemaster links point on purpose on the develop branch. -->
 [Adding a new SSH key to your GitHub account]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
 [Adding a new language]:                       #adding-a-new-language
-[Arguments for test case messages]:            https://github.com/zonemaster/zonemaster-engine/blob/develop/docs/logentry_args.md
+[Arguments for test case messages]:            ../../public/specifications/tests/ArgumentsForTestCaseMessages.md
 [Clone preparation]:                           #clone-preparation
 [Cloning a repository]:                        https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository#cloning-a-repository
 [Emacs PO-mode]:                               https://www.gnu.org/software/gettext/manual/html_node/PO-Mode.html#PO-Mode

--- a/docs/internal/templates/specifications/tests/Template01.md
+++ b/docs/internal/templates/specifications/tests/Template01.md
@@ -297,6 +297,7 @@ No special terminology for this test case.
 
 [Connectivity01]:                                                 ../../../../public/specifications/tests/Connectivity-TP/connectivity01.md
 
+[Argument list]:                                                  ../../../../public/specifications/tests/ArgumentsForTestCaseMessages.md
 [DNS Query and Response Defaults]:                                ../../../../public/specifications/tests/DNSQueryAndResponseDefaults.md
 [DNS Query]:                                                      ../../../../public/specifications/tests/DNSQueryAndResponseDefaults.md#default-setting-in-dns-query
 [DNS Response]:                                                   ../../../../public/specifications/tests/DNSQueryAndResponseDefaults.md#default-handling-of-a-dns-response
@@ -311,9 +312,6 @@ No special terminology for this test case.
 
 [Requirements and normalization of domain names in input]:        ../../../../public/specifications/tests/RequirementsAndNormalizationOfDomainNames.md
 
-> > Links to other repositories:
-
-[Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
 [Zonemaster-Engine profile]:                                      ../../../../public/configuration/profiles.md
 
 > > External links:

--- a/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
+++ b/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
@@ -147,11 +147,11 @@ defined *arguments*.
 Message names maked with a question mark should not be considered stable.
 
 
-[Basic.pm]:                                  ../lib/Zonemaster/Engine/Test/Basic.pm
+[Basic.pm]:                                  https://github.com/zonemaster/zonemaster-engine/blob/master/lib/Zonemaster/Engine/Test/Basic.pm
 [DNS RR TYPEs]:                              https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
 [DNS RCODEs]:                                https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 [DNSSEC05#objective]:                        DNSSEC-TP/dnssec05.md#objective
 [DS Digest algorithm]:                       https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml
-[fr.po]:                                     ../share/fr.po
+[fr.po]:                                     https://github.com/zonemaster/zonemaster-engine/blob/master/share/fr.po
 [RFC1035, section 4.1.2]:                    https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.2
-[sv.po]:                                     ../share/sv.po
+[sv.po]:                                     https://github.com/zonemaster/zonemaster-engine/blob/master/share/sv.po

--- a/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
+++ b/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
@@ -56,6 +56,7 @@ and updated messages (*msgids* and *msgstr*).
 | ds_algo_descr  | Text                                     | The human readable description of a [DS Digest algorithm].              |
 | ds_algo_mnemo  | Text                                     | The mnemonic of a [DS Digest algorithm].                                |
 | ds_algo_num    | Non-negative integer                     | The numeric value for a [DS Digest algorithm].                          |
+| int            | integer                                  | An integer. If "algo_num", "ds_also_num", "keytag", "soaserial" or some other specific name is applicale, utse that instead. |
 | ip_prefix      | IP prefix                                | An IP prefix (i.e., an IP address with a network mask in CIDR notation).|
 | keytag         | Non-negative integer                     | A keytag for a DNSKEY record or a keytag used in a DS or RRSIG record.  |
 | label          | Domain name label                        | A single label, i.e. the string between the dots, from a domain name.   |

--- a/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
+++ b/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
@@ -56,7 +56,7 @@ and updated messages (*msgids* and *msgstr*).
 | ds_algo_descr  | Text                                     | The human readable description of a [DS Digest algorithm].              |
 | ds_algo_mnemo  | Text                                     | The mnemonic of a [DS Digest algorithm].                                |
 | ds_algo_num    | Non-negative integer                     | The numeric value for a [DS Digest algorithm].                          |
-| int            | integer                                  | An integer. If "algo_num", "ds_also_num", "keytag", "soaserial" or some other specific name is applicale, utse that instead. |
+| int            | integer                                  | An integer. If "algo_num", "ds_also_num", "keytag", "soaserial" or some other specific name is applicable, use that instead. |
 | ip_prefix      | IP prefix                                | An IP prefix (i.e., an IP address with a network mask in CIDR notation).|
 | keytag         | Non-negative integer                     | A keytag for a DNSKEY record or a keytag used in a DS or RRSIG record.  |
 | label          | Domain name label                        | A single label, i.e. the string between the dots, from a domain name.   |
@@ -144,7 +144,7 @@ defined *arguments*.
 || TLD| The name of a top-level domain.|
 || `time_t` value when RRSIG validation was attempted| The time when an RRSIG validation was attempted, in Unix `time_t` format.|
 
-Message names maked with a question mark should not be considered stable.
+Message names marked with a question mark should not be considered stable.
 
 
 [Basic.pm]:                                  https://github.com/zonemaster/zonemaster-engine/blob/master/lib/Zonemaster/Engine/Test/Basic.pm

--- a/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
+++ b/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
@@ -49,9 +49,9 @@ and updated messages (*msgids* and *msgstr*).
 
 | Argument name  | Type of value                            | Description and formatting                                              |
 |--------------- |------------------------------------------|-------------------------------------------------------------------------|
-| algo_descr     | Text                                     | The human readable description of a [DNSSEC algorithm].                 |
-| algo_mnemo     | Text                                     | The mnemonic of a [DNSSEC algorithm].                                   |
-| algo_num       | Non-negative integer                     | The numeric value for a [DNSSEC algorithm].                             |
+| algo_descr     | Text                                     | The human readable description of a DNSSEC algorithm as in table in [DNSSEC05][DNSSEC05#objective].|
+| algo_mnemo     | Text                                     | The mnemonic of a DNSSEC algorithm as in table in [DNSSEC05][DNSSEC05#objective].|
+| algo_num       | Non-negative integer                     | The numeric value for a DNSSEC algorithm as in table in [DNSSEC05][DNSSEC05#objective].|
 | domain         | Domain name                              | A domain name. If "nsname", "mailtarget" or "query_name" is also applicable, use that one instead.      |
 | ds_algo_descr  | Text                                     | The human readable description of a [DS Digest algorithm].              |
 | ds_algo_mnemo  | Text                                     | The mnemonic of a [DS Digest algorithm].                                |
@@ -150,9 +150,8 @@ Message names maked with a question mark should not be considered stable.
 [Basic.pm]:                                  ../lib/Zonemaster/Engine/Test/Basic.pm
 [DNS RR TYPEs]:                              https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
 [DNS RCODEs]:                                https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
-[DNSSEC algorithm]:                          https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
+[DNSSEC05#objective]:                        DNSSEC-TP/dnssec05.md#objective
 [DS Digest algorithm]:                       https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml
 [fr.po]:                                     ../share/fr.po
 [RFC1035, section 4.1.2]:                    https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.2
 [sv.po]:                                     ../share/sv.po
-

--- a/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
+++ b/docs/public/specifications/tests/ArgumentsForTestCaseMessages.md
@@ -1,0 +1,157 @@
+# Arguments for test case messages
+
+
+## Introduction
+
+This document defines *arguments*. An *argument* is defined with its name, its
+type of value and its usage and formatting. The *arguments* are used in a
+Zonemaster-Engine message. The messages, in the form of *msgid* strings, are
+primarily defined in the Perl modules for the test cases, e.g. [Basic.pm]. The
+*arguments* are also used in the translated messages, in the form of *msgstr*
+strings, in the PO files, e.g. [fr.po] and [sv.po]. When an *arguments* is used
+in a message (*msgid* or *msgstr*) it is represented by its name which is put
+within curly brackets, e.g. as `{ns}`.
+
+When a message is created or updated only *arguments* defined in this document
+should be used. If there is not a defined *argument* that can be used for the
+message then a new *argument* must be defined and this document is to be updated.
+
+
+## Multiple instances of the same argument
+
+In a message the same *argument* can only be used once. In case a message needs
+more than one instance of an *argument*, the instances need to be disambiguated.
+This is done by adding different suffixes to the argument's name. The suffix is
+an underscore ("_") followed by a descriptive string of lower case "a-z0-9". The
+suffixed *argument name* is not to be listed in this document, it is just an
+instance of the *argument name* without the specific suffix.
+
+### Example of multiple instances
+
+If two arguments of type "List of IP addresses" are to be used in a message, then
+both *argument names* should be `ns_ip_list` following the list of defined
+arguments below. If the relevant suffixes for those are "nsec" (connected to an
+NSEC record type) and "nsec3" (connected to an NSEC3 record type) then two
+resulting argument names should be `ns_ip_list_nsec` and `ns_ip_list_nsec3`,
+respectively.
+
+The following is a message (*msgid* in this case) where this is in use:
+
+> The zone is inconsistent on NSEC and NSEC3. NSEC is fetched from nameservers
+> with IP addresses "{ns_ip_list_nsec}". NSEC3 is fetched from nameservers with
+> IP addresses "{ns_ip_list_nsec3}".
+
+
+## Defined arguments
+
+When a suitable *argument* is found in this list, it should also be used in new
+and updated messages (*msgids* and *msgstr*).
+
+| Argument name  | Type of value                            | Description and formatting                                              |
+|--------------- |------------------------------------------|-------------------------------------------------------------------------|
+| algo_descr     | Text                                     | The human readable description of a [DNSSEC algorithm].                 |
+| algo_mnemo     | Text                                     | The mnemonic of a [DNSSEC algorithm].                                   |
+| algo_num       | Non-negative integer                     | The numeric value for a [DNSSEC algorithm].                             |
+| domain         | Domain name                              | A domain name. If "nsname", "mailtarget" or "query_name" is also applicable, use that one instead.      |
+| ds_algo_descr  | Text                                     | The human readable description of a [DS Digest algorithm].              |
+| ds_algo_mnemo  | Text                                     | The mnemonic of a [DS Digest algorithm].                                |
+| ds_algo_num    | Non-negative integer                     | The numeric value for a [DS Digest algorithm].                          |
+| ip_prefix      | IP prefix                                | An IP prefix (i.e., an IP address with a network mask in CIDR notation).|
+| keytag         | Non-negative integer                     | A keytag for a DNSKEY record or a keytag used in a DS or RRSIG record.  |
+| label          | Domain name label                        | A single label, i.e. the string between the dots, from a domain name.   |
+| mailtarget     | Domain name                              | The domain name of the mailserver in an MX RDATA.                       |
+| mailtarget_list| List of domain names                     | A list of name servers, as specified by "mailtarget", separated by ";". |
+| module         | A Zonemaster test module, or `all`       | The name of a Zonemaster test module.                                   |
+| module_list    | List of Zonemaster test modules          | A list of Zonemaster test modules, separated by ":".                    |
+| ns             | Domain name and IP address pair          | The name and IP address of a name server, separated by "/".             |
+| ns_ip          | IP address                               | The IP address of a name server.                                        |
+| ns_ip_list     | List of IP addresses                     | A list of name servers, as specified by "ns_ip", separated by ";".      |
+| ns_list        | List of domain name and IP address pairs | A list of name servers, as specified by "ns", separated by ";".         |
+| nsname         | Domain name                              | The domain name of a name server.                                       |
+| nsname_list    | List of domain names                     | A list of name servers, as specified by "nsname", separated by ";".     |
+| query_name     | Domain name                              | A query domain name (QNAME), as defined in [RFC1035, section 4.1.2].    |
+| rcode          | An RCODE Name                            | An RCODE Name (not numeric code) from [DNS RCODEs].                     |
+| rrtype         | A Resource Record TYPE Name              | A Resource Record TYPE Name (not numeric code) from [DNS RR TYPEs].     |
+| soaserial      | Non-negative integer                     | The numeric value for the SERIAL field in an SOA record. Integer in range 0-4,294,967,295 |
+| soaserial_list | List of non-negative integers            | A list of non-negative integers, as specified by "soaserial", separated by ";". |
+| string         | Text                                     | The content of the RDATA of a TXT resource record.                      |
+| testcase       | A Zonemaster test case, or `all`         | A test case identifier.                                                 |
+| unicode_name   | Unicode name of a code point             | The name is a string in ASCII only and in upper case, e.g. "LATIN SMALL LETTER A"|
+
+## Preliminary or proposed arguments
+
+The *arguments* in in this table are not fully defined. If used it should follow
+the pattern of defined *arguments*, be fully defined and moved to the list of
+defined *arguments*.
+
+| Argument name  | Type of value                      | Description and formatting                                  |
+|--------------- |------------------------------------|-------------------------------------------------------------|
+|| AS number| An Autonomous Space number for an IP address.|
+|| Address record type (A or AAAA)| Used to tell the difference between IPv4 and IPv6.|
+|| Count of different SOA RNAMEs.| Total number of different SOA RNAME fields seen.|
+|| Count of different SOA serial numbers| Total number of different SOA serial numbers seen.|
+|| Count of different sets of NS name/IP seen.| Total number of different sets of nameserver information seen.|
+|| Count of different time parameter sets seen| Total number of different sets of SOA time parameters seen.|
+|| Count of domain names| A count of domain names.|
+|| Count of nameservers| A count of nameservers.|
+|| DNS packet size| The size in octets of a DNS packets.|
+|| DNSKEY key length| The key length for a DNSKEY. The interpretation of this value various quite a bit with the algorithm. Be careful when using it for algorithms that aren't RSA-based.|
+|| DNSSEC delegation verification failure reason| A somewhat human-readable reason why the delegation step between the tested zone and its parent is not secure.|
+| dlength (?) | Domain name label length| The length of a domain name label.|
+|| Duration in seconds| An integer number of seconds.|
+| fqdn (?) | FQDN| A fully qualified domain name (with terminating dot).|
+| fqdnlength (?) | FQDN length| The length of an FQDN.|
+|| IP address| An IPv4 or IPv6 address.|
+|| IP address or nothing| An IPv4 or IPv6 address, or no value.|
+|| IP range| An IP range.|
+|| IP reserved range description| A brief description what an IP range is reserved for.|
+|| Largest SOA serial number seen| The numerically largest SOA serial value seen.|
+|| List of AS numbers| A list of Autonomous Space numbers.|
+|| List of DNSKEY keytags| A list of keytags from DNSKEY records.|
+|| List of DS keytags| A list of keytags from DS records.|
+|| List of DS/DNSKEY/RRSIG keytags| A list of keytags from DS, DNSKEY or RRSIG records.|
+|| List of IP addresses| A list of IP addresses.|
+|| List of MX domain names| A list of domain names from MX records.|
+|| List of RR types| A list of RR types, typically from an NSEC or NSEC3 record.|
+|| List of SOA RNAMEs| A list of RNAME values from SOA records.|
+|| List of SOA serial numbers| A list of serial number values from SOA records.|
+|| List of domain names| A list of domain names.|
+|| NS names from child| A list of nameserver names taken from a zone's child servers.|
+|| NS names from parent| A list of nameserver names taken from a zone's parent servers.|
+|| NSEC3 iteration count| An iteration count from an NSEC3PARAM record.|
+|| Number of DNSKEY RRs in packet| The number of DNSKEY records found in a packet.|
+|| Number of RRSIG RRs in packet| The number of RRSIG records found in a packet.|
+|| Number of SOA RRs in packet| The number of SOA records found in a packet.|
+|| Protocol (UDP or TCP)| The protocol used for a query.|
+|| RFC reference| A reference to an RFC.|
+| rrtype (?) | RR type| The type of RR the message pertains to.|
+|| RRSIG Expiration date| The time when a signature expires.|
+|| RRSIG validation error message| The human-readable reason why the cryptographic validation of a signature failed.|
+|| SOA MNAME| The MNAME value from a SOA record.|
+|| SOA RNAME| The RNAME value from a SOA record.|
+|| SOA expire| The expire value from a SOA record.|
+|| SOA expire minimum value| The lowest value considered OK for the SOA expire field.|
+|| SOA minimum| The minimum value from a SOA record.|
+|| SOA minimum maximum value| The highest value considered OK for the SOA minimum field.|
+|| SOA minimum minimum value| The lowest value considered OK for the SOA minimum field.|
+|| SOA refresh| The refresh value from a SOA record.|
+|| SOA refresh minimum value| The lowest value considered OK for the SOA refresh field.|
+|| SOA retry| The retry value from a SOA record.|
+|| SOA retry minimum value| The lowest value considered OK for the SOA retry field.|
+|| SOA serial number| The serial number value from a SOA record.|
+|| Smallest SOA serial number seen| The smallest value seen in a SOA serial field in the tested zone.|
+|| TLD| The name of a top-level domain.|
+|| `time_t` value when RRSIG validation was attempted| The time when an RRSIG validation was attempted, in Unix `time_t` format.|
+
+Message names maked with a question mark should not be considered stable.
+
+
+[Basic.pm]:                                  ../lib/Zonemaster/Engine/Test/Basic.pm
+[DNS RR TYPEs]:                              https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-4
+[DNS RCODEs]:                                https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
+[DNSSEC algorithm]:                          https://www.iana.org/assignments/dns-sec-alg-numbers/dns-sec-alg-numbers.xhtml
+[DS Digest algorithm]:                       https://www.iana.org/assignments/ds-rr-types/ds-rr-types.xhtml
+[fr.po]:                                     ../share/fr.po
+[RFC1035, section 4.1.2]:                    https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.2
+[sv.po]:                                     ../share/sv.po
+

--- a/docs/public/specifications/tests/Basic-TP/basic01.md
+++ b/docs/public/specifications/tests/Basic-TP/basic01.md
@@ -342,7 +342,7 @@ records).
 a specific name server. Compare with "[DNS Lookup]".
 
 
-[Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                                                  ../ArgumentsForTestCaseMessages.md
 [B01_CHILD_FOUND]:                                                #Summary
 [B01_CHILD_IS_ALIAS]:                                             #Summary
 [B01_CHILD_NOT_EXIST]:                                            #Summary

--- a/docs/public/specifications/tests/Basic-TP/basic02.md
+++ b/docs/public/specifications/tests/Basic-TP/basic02.md
@@ -177,7 +177,7 @@ means what is not "in-bailiwick, in domain", in this document.
 None.
 
 
-[Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                                                  ../ArgumentsForTestCaseMessages.md
 [B02_AUTH_RESPONSE_SOA]:                                          #outcomes
 [B02_NO_DELEGATION]:                                              #outcomes
 [B02_NO_WORKING_NS]:                                              #outcomes

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity01.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity01.md
@@ -183,7 +183,7 @@ None.
 No special terminology for this test case.
 
 
-[Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                                                  ../ArgumentsForTestCaseMessages.md
 [Basic02]:                                                        basic02.md
 [CN01_IPV4_DISABLED]:                                             #summary
 [CN01_IPV6_DISABLED]:                                             #summary

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity02.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity02.md
@@ -163,7 +163,7 @@ None.
 No special terminology for this Test Case.
 
 
-[Argument list]:                                                  https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                                                  ../ArgumentsForTestCaseMessages.md
 [CN02_MISSING_NS_RECORD_TCP]:                                     #summary
 [CN02_MISSING_SOA_RECORD_TCP]:                                    #summary
 [CN02_NO_RESPONSE_NS_QUERY_TCP]:                                  #summary

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
@@ -215,7 +215,7 @@ None
 * "Send" - The term is used when a query is sent to
   a specific server (server IP address).
 
-[Argument List]:                                                https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument List]:                                                ../ArgumentsForTestCaseMessages.md
 [CN04_EMPTY_PREFIX_SET]:                                        #outcomes
 [CN04_ERROR_PREFIX_DATABASE]:                                   #outcomes
 [CN04_IPV4_DIFFERENT_PREFIX]:                                   #outcomes

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec01.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec01.md
@@ -217,7 +217,7 @@ None.
 No special terminology for this test case.
 
 
-[Argument list]:                                      https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                                      ../ArgumentsForTestCaseMessages.md
 [CRITICAL]:                                           ../SeverityLevelDefinitions.md#critical
 [DNS Query and Response Defaults]:                    ../DNSQueryAndResponseDefaults.md
 [DNSSEC Query]:                                       ../DNSQueryAndResponseDefaults.md#default-setting-in-dnssec-query

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec02.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec02.md
@@ -276,7 +276,7 @@ None.
 No special terminology for this test case.
 
 
-[Argument list]:                              https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                              ../ArgumentsForTestCaseMessages.md
 [Connectivity01]:                             ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                                   ../SeverityLevelDefinitions.md#critical
 [DNS Query and Response Defaults]:            ../DNSQueryAndResponseDefaults.md

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec08.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec08.md
@@ -168,7 +168,7 @@ None.
 No special terminology for this test case.
 
 
-[Argument list]:                              https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                              ../ArgumentsForTestCaseMessages.md
 [Connectivity01]:                             ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                                   ../SeverityLevelDefinitions.md#critical
 [DNSSEC README]:                              ./README.md

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec09.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec09.md
@@ -185,7 +185,7 @@ None.
 No special terminology for this test case.
 
 
-[Argument list]:                              https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                              ../ArgumentsForTestCaseMessages.md
 [Connectivity01]:                             ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                                   ../SeverityLevelDefinitions.md#critical
 [Consistency01]:                              ../Consistency-TP/consistency01.md

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec10.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec10.md
@@ -311,7 +311,7 @@ exist, as a directly defined name. The first label starts with "xx--" which
 should not be used as of [RFC 5890][RFC 5890#section-2.3.1], section 2.3.1.
 
 
-[Argument list]:                              https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                              ../ArgumentsForTestCaseMessages.md
 [Connectivity01]:                             ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                                   ../SeverityLevelDefinitions.md#critical
 [DNSSEC README]:                              README.md

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec11.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec11.md
@@ -210,7 +210,7 @@ None.
 No special terminology for this test case.
 
 
-[Argument list]:                              https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                              ../ArgumentsForTestCaseMessages.md
 [Connectivity01]:                             ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                                   ../SeverityLevelDefinitions.md#critical
 [DNSSEC README]:                              README.md

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec13.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec13.md
@@ -189,7 +189,7 @@ None.
 No special terminology for this test case.
 
 
-[Argument list]:                              https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                              ../ArgumentsForTestCaseMessages.md
 [Connectivity01]:                             ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                                   ../SeverityLevelDefinitions.md#critical
 [DNSSEC README]:                              README.md

--- a/docs/public/specifications/tests/Nameserver-TP/nameserver10.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver10.md
@@ -142,7 +142,7 @@ None
 No special terminology for this test case.
 
 
-[Argument list]:                           https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                           ../ArgumentsForTestCaseMessages.md
 [Connectivity01]:                          ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                                ../SeverityLevelDefinitions.md#critical
 [ERROR]:                                   ../SeverityLevelDefinitions.md#error

--- a/docs/public/specifications/tests/Nameserver-TP/nameserver11.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver11.md
@@ -165,7 +165,7 @@ None.
 No special terminology for this test case.
 
 
-[Argument list]:                        https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                        ../ArgumentsForTestCaseMessages.md
 [Connectivity01]:                       ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                             ../SeverityLevelDefinitions.md#critical
 [DNS Query and Response Defaults]:      ../DNSQueryAndResponseDefaults.md

--- a/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
@@ -114,7 +114,7 @@ None
 * "Send" - The term is used when a DNS query is sent to
   a specific name server (name server IP address).
 
-[Argument List]:                                                https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument List]:                                                ../ArgumentsForTestCaseMessages.md
 [Concatenate]:                                                  #terminology
 [Connectivity01]:                                               ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                                                     ../SeverityLevelDefinitions.md#critical

--- a/docs/public/specifications/tests/RequirementsAndNormalizationOfDomainNames.md
+++ b/docs/public/specifications/tests/RequirementsAndNormalizationOfDomainNames.md
@@ -451,7 +451,7 @@ No special terminology for this specification.
 
 
 [AMBIGUOUS_DOWNCASING]:                  #summary
-[Argument list]:                         https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                         ../ArgumentsForTestCaseMessages.md
 [CHARACTER TABULATION]:                  https://codepoints.net/U+0009
 [DOMAIN_NAME_TOO_LONG]:                  #summary
 [Detailed requirements]:                 #detailed-requirements

--- a/docs/public/specifications/tests/Zone-TP/zone01.md
+++ b/docs/public/specifications/tests/Zone-TP/zone01.md
@@ -222,7 +222,7 @@ None.
 any changes to the DNS tree introduced by an [undelegated test] must be
 respected.
 
-[Argument list]:                        https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                        ../ArgumentsForTestCaseMessages.md
 [CONNECTIVITY01]:                       ../Connectivity-TP/connectivity01.md
 [CONSISTENCY06]:                        ../Consistency-TP/consistency06.md
 [CRITICAL]:                             ../SeverityLevelDefinitions.md#critical

--- a/docs/public/specifications/tests/Zone-TP/zone09.md
+++ b/docs/public/specifications/tests/Zone-TP/zone09.md
@@ -260,7 +260,7 @@ of a single label (ignoring the empty label after the final dot).
 The term "Email Domain" is used for the domain name at right of the at-sign ("@")
 in an email address.
 
-[Argument list]:                              https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                              ../ArgumentsForTestCaseMessages.md
 [Connectivity01]:                             ../Connectivity-TP/connectivity01.md
 [CRITICAL]:                                   ../SeverityLevelDefinitions.md#critical
 [DNS Query and Response Defaults]:            ../DNSQueryAndResponseDefaults.md

--- a/docs/public/specifications/tests/Zone-TP/zone11.md
+++ b/docs/public/specifications/tests/Zone-TP/zone11.md
@@ -174,7 +174,7 @@ None.
 * "using Method" - The term is used when data is fetched using the defined
   [Method][Methods].
 
-[Argument list]:                        https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
+[Argument list]:                        ../ArgumentsForTestCaseMessages.md
 [argument]:                             #terminology
 [concatenate]:                          #terminology
 [Connectivity01]:                       ../Connectivity-TP/connectivity01.md


### PR DESCRIPTION
## Purpose

The Arguments document resided in the Zonemaster-Engine repository, but is usually updated when updating test case specifications. All references are from this repository.

This PR also adds a new name used in #1189.

This PR also updates the reference to the DNSSEC algorithms as specified in #1183 and expected by #1179.

When this PR is merged, the document should be removed in the Zonemaster-Engine repository. See https://github.com/zonemaster/zonemaster-engine/pull/1268.

## Changes

The changes are found the following commits:

1. Copies the document verbatim from Zonemaster-Engine.
2. Adds the new argument name ("int").
3. Changes the DNSSEC algorithm reference.
4. Updates all documents that has a reference to the Arguments document to point at the new location.
5. Updates links that assumed that the document was still in the Zonemaster-Engine repository.

## How to test this PR

Review and check links. Note there is a link to DNSSEC05 that assumes that is has been updated by #1183.