### PR TITLE
Updates NAMESERVER15

### DIFF
--- a/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
@@ -37,8 +37,8 @@ giving a correct DNS response for an authoritative name server.
 Message Tag                | Level   | Arguments                   | Message ID for message tag
 :--------------------------|:--------|:----------------------------|:----------------------------------------------------------------------------------------------------------------------------
 N15_SOFTWARE_VERSION       | NOTICE  | ns_list, query_name, string | The following name server(s) respond to software version query "{query_name}" with string "{string}". Returned from name servers: "{ns_list}"
-N15_ERROR_ON_VERSION_QUERY | NOTICE  | ns_list, query_name         | The following name server(s) do not respond or responds with SERVFAIL to software version query with query name {query_name}. Returned from name servers: "{ns_list}"
-N15_NO_VERSION_REVEALED    | INFO    | ns_list                     | The following name server(s) do not revealed the software version. Name servers: "{ns_list}"
+N15_ERROR_ON_VERSION_QUERY | NOTICE  | ns_list, query_name         | The following name server(s) do not respond or respond with SERVFAIL to software version query "{query_name}". Returned from name servers: "{ns_list}"
+N15_NO_VERSION_REVEALED    | INFO    | ns_list                     | The following name server(s) do not reveal the software version. Returned from name servers: "{ns_list}"
 
 The value in the Level column is the default severity level of the message. The
 severity level can be changed in the [Zonemaster-Engine Profile]. Also see the
@@ -57,7 +57,7 @@ servers.
 1.  Create the following empty sets:
     1. Name server IP, query name and string ("TXT Data")
     2. Name server IP and query name ("Error On Version Query")
-    2. Name server IP ("Sending Version Query")
+    3. Name server IP ("Sending Version Query")
 
 2.  Create a [DNS Query] with query type SOA and query name *Child Zone*
     ("SOA Query").
@@ -71,7 +71,6 @@ servers.
     [Method5] ("Name Server IP").
 
 6.  For each name server in *Name Server IP* do:
-
     1. Send *SOA Query* to the name server IP.
     2. If there is no DNS response, then go to next name server IP.
     3. Add the name server IP to the *Sending Version Query* set.
@@ -93,8 +92,8 @@ servers.
     string and query name pair in the set, output *[N15_SOFTWARE_VERSION]*
     with name server IP list, query name and string.
 
-8.  If the *Error On Version Query* set is non-empty, then output for each query
-    name in the set out put *[N15_ERROR_ON_VERSION_QUERY]* with the query name
+8.  If the *Error On Version Query* set is non-empty, then for each query name
+    in the set output *[N15_ERROR_ON_VERSION_QUERY]* with the query name
     and the list of name server IP addresses.
 
 9.  For each name server IP in the *Sending Version Query* set, remove that name

--- a/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
@@ -153,9 +153,9 @@ None
 [Method4]:                                                      ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]:                                                      ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 [Methods]:                                                      ../Methods.md
-[N15_SOFTWARE_VERSION]:                                         #summary
-[N15_NO_VERSION_REVEALED]:                                      #summary
 [N15_ERROR_ON_VERSION_QUERY]:                                   #summary
+[N15_NO_VERSION_REVEALED]:                                      #summary
+[N15_SOFTWARE_VERSION]:                                         #summary
 [NOTICE]:                                                       ../SeverityLevelDefinitions.md#notice
 [RCODE Name]:                                                   https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 [Requirements and normalization of domain names in input]:      ../RequirementsAndNormalizationOfDomainNames.md

--- a/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
@@ -43,7 +43,7 @@ Message Tag                | Level   | Arguments                   | Message ID 
 N15_ERROR_ON_VERSION_QUERY | NOTICE  | ns_list, query_name         | The following name server(s) do not respond or respond with SERVFAIL to software version query "{query_name}". Returned from name servers: "{ns_list}"
 N15_NO_VERSION_REVEALED    | INFO    | ns_list                     | The following name server(s) do not reveal the software version. Returned from name servers: "{ns_list}"
 N15_SOFTWARE_VERSION       | NOTICE  | ns_list, query_name, string | The following name server(s) respond to software version query "{query_name}" with string "{string}". Returned from name servers: "{ns_list}"
-N15_WRONG_CLASS            | WARNING | ns_list                     | The following name server(s) does not return CH class record(s) on CH class query:  "{ns_list}"
+N15_WRONG_CLASS            | WARNING | ns_list                     | The following name server(s) do not return CH class record(s) on CH class query. Returned from name servers: "{ns_list}"
 
 
 The value in the Level column is the default severity level of the message. The

--- a/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
@@ -95,7 +95,10 @@ servers.
              to the *Wrong Record Class* set.
           2. Extract and [concatenate] the string(s) from the RDATA of the
              record.
-          3. If the extracted string is non-empty, add name server, query name
+          3. Remove any leading or trailing [SPACE] (U+0020) or
+             [CHARACTER TABULATION] (horizontal tab, U+0009) characters from the
+             concatenated string.
+          4. If the extracted string is non-empty, add name server, query name
              and the string to the *TXT Data* set.
 
 7.  If the *TXT Data* set is non-empty, then, for each unique string and query
@@ -155,6 +158,7 @@ None
 
 [Argument List]:                                                https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
 [CRITICAL]:                                                     ../SeverityLevelDefinitions.md#critical
+[CHARACTER TABULATION]:                                         https://codepoints.net/U+0009
 [Concatenate]:                                                  #terminology
 [Connectivity01]:                                               ../Connectivity-TP/connectivity01.md
 [DEBUG]:                                                        ../SeverityLevelDefinitions.md#notice
@@ -176,6 +180,7 @@ None
 [RFC2929]:                                                      https://datatracker.ietf.org/doc/html/rfc2929#section-3.2
 [RFC7208#3.3]:                                                  https://datatracker.ietf.org/doc/html/rfc7208#section-3.3
 [Requirements and normalization of domain names in input]:      ../RequirementsAndNormalizationOfDomainNames.md
+[SPACE]:                                                        https://codepoints.net/U+0020
 [Send]:                                                         #terminology
 [Severity Level Definitions]:                                   ../SeverityLevelDefinitions.md
 [Test Case Identifier Specification]:                           ../../../../internal/templates/specifications/tests/TestCaseIdentifierSpecification.md

--- a/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
@@ -34,10 +34,11 @@ giving a correct DNS response for an authoritative name server.
 
 ## Summary
 
-Message Tag                 | Level   | Arguments                      | Message ID for message tag
-:---------------------------|:--------|:-------------------------------|:----------------------------------------------------------------------------------------------------------------------------
-N15_SOFTWARE_VERSION        | INFO    | ns_ip_list, query_name, string | The following name server(s) respond to software version query "{query_name}" with string "{string}". Returned from name servers: "{ns_ip_list}"
-N15_NO_VERSION              | INFO    | ns_ip_list                     | The following name server(s) do not respond to software version queries. Returned from name servers: "{ns_ip_list}"
+Message Tag                | Level   | Arguments                   | Message ID for message tag
+:--------------------------|:--------|:----------------------------|:----------------------------------------------------------------------------------------------------------------------------
+N15_SOFTWARE_VERSION       | NOTICE  | ns_list, query_name, string | The following name server(s) respond to software version query "{query_name}" with string "{string}". Returned from name servers: "{ns_list}"
+N15_ERROR_ON_VERSION_QUERY | NOTICE  | ns_list                     | The following name server(s) do not respond or responds with SERVFAIL to software version query. Returned from name servers: "{ns_list}"
+N15_NO_VERSION_REVEALED    | INFO    | ns_list                     | No name server revealed the software version. Returned from name servers: "{ns_list}"
 
 The value in the Level column is the default severity level of the message. The
 severity level can be changed in the [Zonemaster-Engine Profile]. Also see the
@@ -46,43 +47,59 @@ severity level can be changed in the [Zonemaster-Engine Profile]. Also see the
 The argument names in the Arguments column lists the arguments used in the
 message. The argument names are defined in the [Argument List].
 
+The name server names are assumed to be available at the time when the msgid
+is created, if the argument name is "ns" or "ns_list" even when in the
+"[Test procedure]" below it is only referred to the IP address of the name
+servers.
+
 ## Test procedure
 
-1. Create the following empty sets:
+1. Create a [DNS Query] with query type SOA and query name *Child Zone*
+   ("SOA Query").
+
+2. Create the following empty sets:
    1. Name server IP, query name and string ("TXT Data")
-   2. Name server IP ("No Version")
+   2. Name server IP ("Error On Version Query")
+   2. Name server IP ("Sending Version Query")
 
-2. Create [DNS Query] with query type TXT and query class CHAOS ("TXT Query").
+3. Create a [DNS Query] with query type TXT and query class CHAOS ("TXT Query").
 
-3. Create the set of query names with values "version.bind"
+4. Create the set of query names with values "version.bind"
    and "version.server" ("Query Names").
 
-4. Obtain the set of name server IP addresses using [Method4] and
+5. Obtain the set of name server IP addresses using [Method4] and
    [Method5] ("Name Server IP").
 
-5. For each name server in *Name Server IP* do:
-   1. For each query name in *Query Names* do:
+6. For each name server in *Name Server IP* do:
+
+   1. Send *SOA Query* to the name server IP.
+   2. If there is no DNS response, then go to next name server IP.
+   3. Add the name server IP to the *Sending Version Query* set.
+   4. For each query name in *Query Names* do:
       1. [Send] *TXT Query* with query name to
          the name server and collect the response.
-      2. If at least one of the following criteria is met, go to next query name:
-         1. There is no DNS response.
-         2. The [DNS Response] does not have the [RCODE Name] NoError.
-         3. The [DNS Response] does not have any TXT record in the
-            answer section with query name as owner name.
-      3. For each TXT record in the answer section of the [DNS Response]
+      2. If there is no DNS response or the response has the [RCODE Name]
+         ServFail, add name server to the *Error On Version Query* set and go to
+         next query name.
+      3. If the [DNS Response] does not have any TXT record in the answer section
+          with query name as owner name, go to next query name.
+      4. For each TXT record in the answer section of the [DNS Response]
          with owner name query name, extract and [concatenate] the string(s)
          from the RDATA of the record.
-      4. If the extracted string is non-empty, add *Name Server IP*, query name
+      5. If the extracted string is non-empty, add *Name Server IP*, query name
          and the string to the *TXT Data* set.
-   2. If nothing was added to the *TXT Data* set in the previous steps,
-      add name server to the *No Version* set.
 
-6. If the *TXT Data* set is non-empty, then, for each unique
+7. If the *TXT Data* set is non-empty, then, for each unique
    string and query name pair in the set, output *[N15_SOFTWARE_VERSION]*
    with name server IP list, query name and string.
 
-7. If the *No Version* set is non-empty, then output
-   *[N15_NO_VERSION]* with name server IP list.
+8. If the *Error On Version Query* set is non-empty, then output
+   *[N15_ERROR_ON_VERSION_QUERY]* with name server IP list.
+
+9. If neither *[N15_SOFTWARE_VERSION]* nor *[N15_ERROR_ON_VERSION_QUERY]* was
+   outputted, then output *[N15_NO_VERSION_REVEALED]* with the list of the name
+   servers in the *Sending Version Query* set.
+
 
 ## Outcome(s)
 
@@ -96,14 +113,17 @@ with the severity level *[WARNING]*, but no message with severity level
 In other cases, no message or only messages with severity level
 *[INFO]* or *[NOTICE]*, the outcome of this Test Case is "pass".
 
+
 ## Special procedural requirements
 
 The *Child Zone* must be a valid name meeting
 "[Requirements and normalization of domain names in input]".
 
+
 ## Intercase dependencies
 
 None
+
 
 ## Terminology
 
@@ -113,6 +133,7 @@ None
 
 * "Send" - The term is used when a DNS query is sent to
   a specific name server (name server IP address).
+
 
 [Argument List]:                                                https://github.com/zonemaster/zonemaster-engine/blob/master/docs/logentry_args.md
 [Concatenate]:                                                  #terminology
@@ -128,8 +149,9 @@ None
 [Method4]:                                                      ../Methods.md#method-4-obtain-glue-address-records-from-parent
 [Method5]:                                                      ../Methods.md#method-5-obtain-the-name-server-address-records-from-child
 [Methods]:                                                      ../Methods.md
-[N15_NO_VERSION]:                                               #summary
 [N15_SOFTWARE_VERSION]:                                         #summary
+[N15_NO_VERSION_REVEALED]:                                      #summary
+[N15_ERROR_ON_VERSION_QUERY]:                                   #summary
 [NOTICE]:                                                       ../SeverityLevelDefinitions.md#notice
 [RCODE Name]:                                                   https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 [Requirements and normalization of domain names in input]:      ../RequirementsAndNormalizationOfDomainNames.md
@@ -138,5 +160,6 @@ None
 [Send]:                                                         #terminology
 [Severity Level Definitions]:                                   ../SeverityLevelDefinitions.md
 [Test Case Identifier Specification]:                           ../../../../internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
+[Test procedure]:                                               #test-procedure
 [WARNING]:                                                      ../SeverityLevelDefinitions.md#warning
 [Zonemaster-Engine Profile]:                                    ../../../configuration/profiles.md

--- a/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
@@ -37,7 +37,7 @@ giving a correct DNS response for an authoritative name server.
 Message Tag                | Level   | Arguments                   | Message ID for message tag
 :--------------------------|:--------|:----------------------------|:----------------------------------------------------------------------------------------------------------------------------
 N15_SOFTWARE_VERSION       | NOTICE  | ns_list, query_name, string | The following name server(s) respond to software version query "{query_name}" with string "{string}". Returned from name servers: "{ns_list}"
-N15_ERROR_ON_VERSION_QUERY | NOTICE  | ns_list                     | The following name server(s) do not respond or responds with SERVFAIL to software version query. Returned from name servers: "{ns_list}"
+N15_ERROR_ON_VERSION_QUERY | NOTICE  | ns_list, query_name         | The following name server(s) do not respond or responds with SERVFAIL to software version query with query name {query_name}. Returned from name servers: "{ns_list}"
 N15_NO_VERSION_REVEALED    | INFO    | ns_list                     | The following name server(s) do not revealed the software version. Name servers: "{ns_list}"
 
 The value in the Level column is the default severity level of the message. The
@@ -56,7 +56,7 @@ servers.
 
 1.  Create the following empty sets:
     1. Name server IP, query name and string ("TXT Data")
-    2. Name server IP ("Error On Version Query")
+    2. Name server IP and query name ("Error On Version Query")
     2. Name server IP ("Sending Version Query")
 
 2.  Create a [DNS Query] with query type SOA and query name *Child Zone*
@@ -79,8 +79,8 @@ servers.
        1. [Send] *TXT Query* with query name to
           the name server and collect the response.
        2. If there is no DNS response or the response has the [RCODE Name]
-          ServFail, add name server to the *Error On Version Query* set and go to
-          next query name.
+          ServFail, add name server and query name to the
+          *Error On Version Query* set and go to next query name.
        3. If the [DNS Response] does not have any TXT record in the answer
           section with query name as owner name, go to next query name.
        4. For each TXT record in the answer section of the [DNS Response]
@@ -93,8 +93,9 @@ servers.
     string and query name pair in the set, output *[N15_SOFTWARE_VERSION]*
     with name server IP list, query name and string.
 
-8.  If the *Error On Version Query* set is non-empty, then output
-    *[N15_ERROR_ON_VERSION_QUERY]* with name server IP list.
+8.  If the *Error On Version Query* set is non-empty, then output for each query
+    name in the set out put *[N15_ERROR_ON_VERSION_QUERY]* with the query name
+    and the list of name server IP addresses.
 
 9.  For each name server IP in the *Sending Version Query* set, remove that name
     server IP from the set if the name server IP is also a member of the


### PR DESCRIPTION
## Purpose

The objective of the test case states about name servers that "it may sometimes be desirable not to reveal that information" but then if it does, this test case only sends an INFO message. An INFO message does not signal that there is any reason to look at it. This PR raises the level to NOTICE.

```
$ zonemaster-cli --test nameserver/nameserver15 telia.com --raw
   0.00 INFO     UNSPECIFIED    GLOBAL_VERSION   version=v4.7.2
   1.57 INFO     NAMESERVER15   N15_SOFTWARE_VERSION   ns_ip_list=dns358.fi.telia.net/88.194.40.67;dns49.de.telia.net/2001:2030:c000:5::4;dns49.de.telia.net/213.248.77.82; query_name=version.bind; string=9.18.9
   1.58 INFO     NAMESERVER15   N15_SOFTWARE_VERSION   ns_ip_list=dns1.telia.com/2001:2040:c001:101::5;dns1.telia.com/81.228.11.67;dns2.telia.com/2001:2040:c001:401::6;dns2.telia.com/81.228.10.67; query_name=version.bind; string=9.18.11
```

The specification does not distinguish between a server that does not respond at all on a "version query" and a server that responds, but with no version information. In the following example some of the servers do not respond at all and some of them responds with no information. This PR splits the message and make the test case make a distinction.
```
$ zonemaster-cli --test nameserver/nameserver15 festo.press --raw
   0.00 INFO     UNSPECIFIED    GLOBAL_VERSION   version=v4.7.2
  41.67 INFO     NAMESERVER15   N15_NO_VERSION   ns_ip_list=ns2.atvirtual.com/185.136.96.210;ns2.atvirtual.com/2a06:fb00:1::1:210;ns6.atvirtual.com/185.136.97.210;ns6.atvirtual.com/2a06:fb00:1::2:210;ns7.atvirtual.com/185.136.98.210;ns7.atvirtual.com/2a06:fb00:1::3:210;ns8.atvirtual.com/185.136.99.210;ns8.atvirtual.com/2a06:fb00:1::4:210
```

This PR also make the test case skip servers that do not even answer SOA queries to make it lift up any servers that do not answer because it is a "version query".

This PR also changes the argument from `ns_ip_list` to `ns_list` to give more information. It uses the same technique introduced by #1179.

This PR also updates the test case to check the class in the response.

## Context

Also see https://github.com/zonemaster/zonemaster-engine/issues/1281

Also see #1208

Also see test zones that match this update in #1217.

## Changes

The specification of NAMESERVER15.

## How to test this PR

Review the proposed changes.