### PR TITLE
change letter case for test case identifier

### DIFF
--- a/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -15,7 +15,7 @@ that test level’s name. The following test levels are defined and available:
 
 The test level name is not case sensitive, but the forms defined above
 must be used when referring to the test levels, i.e. only the first letter
-uppercase, expect for acronyms, in the case all uppercase is used.
+uppercase, expect for acronyms for wich all uppercase is used.
 For exemple "Address" and neither "ADDRESS" nor "address".
 
 The test case identifier in the test case specification (both in the main

--- a/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -1,6 +1,6 @@
 # Test Case Identifier Specification
 
-All test cases belong to one module, and it gets its name from that module's
+All test cases belong to one module and their names are based on that module’s
 name. The following modules are defined and available:
 
 * Address

--- a/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -1,7 +1,7 @@
 # Test Case Identifier Specification
 
-All test cases belong to one specific test level, and it gets its name from that
-test level's name. The following test levels are defined and available:
+All test cases belong to one module, and it gets its name from that module's
+name. The following modules are defined and available:
 
 * Address
 * Basic
@@ -13,25 +13,26 @@ test level's name. The following test levels are defined and available:
 * Syntax
 * Zone
 
-The test level name is not case sensitive.
+The module name is not case sensitive, but camel case, as defined above,
+should be prefered.
 
 The test case identifier in the test case specification (both in the main
-headline and in the "Test case identifier" section) uses the test level name
-in all uppercase and has the format: `{Test Level name} + {Index}`
+headline and in the "Test case identifier" section) uses the module name,
+as defined above, and has the format: `{Module name} + {Index}`
 
-When referencing to a test case the test level name may be used in other letter
-case than all uppercase.
+When referencing to a test case the module name may be used in other letter
+case, but for readability, camel case sould be prefered.
 
 The `{Index}` is a two-digit suffix 01-99, and should be selected so that the test
 case identifier is unique. Normally the first free index is selected.
 
 Example of test case identifiers:
 
-* ADDRESS03
-* BASIC04
+* Address03
+* Basic04
 * DNSSEC15
-* ZONE06
+* Zone06
 
-One exceptional test case identifier is `BASIC00`, in which the index
+One exceptional test case identifier is `Basic00`, in which the index
 suffix is out of range of the stated range above. That test case is planned to
 be removed.

--- a/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -13,15 +13,16 @@ name. The following modules are defined and available:
 * Syntax
 * Zone
 
-The module name is not case sensitive, but camel case, as defined above,
-should be prefered.
+The module name is not case sensitive, but the forms defined above,
+should be used when referring to the modules, i.e. "Address" and neither
+"ADDRESS" nor "address".
 
 The test case identifier in the test case specification (both in the main
 headline and in the "Test case identifier" section) uses the module name,
 as defined above, and has the format: `{Module name} + {Index}`
 
 When referencing to a test case the module name may be used in other letter
-case, but for readability, camel case sould be prefered.
+case, but for readability, PascalCase should be prefered.
 
 The `{Index}` is a two-digit suffix 01-99, and should be selected so that the test
 case identifier is unique. Normally the first free index is selected.

--- a/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -1,7 +1,7 @@
 # Test Case Identifier Specification
 
-All test cases belong to one module and their names are based on that module’s
-name. The following modules are defined and available:
+All test cases belong to one specific test level and their names are based on
+that test level’s name. The following test levels are defined and available:
 
 * Address
 * Basic
@@ -13,19 +13,20 @@ name. The following modules are defined and available:
 * Syntax
 * Zone
 
-The module name is not case sensitive, but the forms defined above,
-should be used when referring to the modules, i.e. "Address" and neither
-"ADDRESS" nor "address".
+The test level name is not case sensitive, but the forms defined above
+must be used when referring to the test levels, i.e. only the first letter
+uppercase, expect for acronyms, in the case all uppercase is used.
+For exemple "Address" and neither "ADDRESS" nor "address".
 
 The test case identifier in the test case specification (both in the main
-headline and in the "Test case identifier" section) uses the module name,
-as defined above, and has the format: `{Module name} + {Index}`
+headline and in the "Test case identifier" section) uses the test level name,
+as defined above, and has the format: `{Test level name} + {Index}`
 
-When referencing to a test case the module name may be used in other letter
-case, but for readability, PascalCase should be prefered.
+When referencing to a test case, for readability, the letter case defined
+above must be used for the test level name.
 
-The `{Index}` is a two-digit suffix 01-99, and should be selected so that the test
-case identifier is unique. Normally the first free index is selected.
+The `{Index}` is a two-digit suffix 01-99, and should be selected so that the
+test case identifier is unique. Normally the first free index is selected.
 
 Example of test case identifiers:
 

--- a/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
+++ b/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
@@ -15,7 +15,7 @@ that test level’s name. The following test levels are defined and available:
 
 The test level name is not case sensitive, but the forms defined above
 must be used when referring to the test levels, i.e. only the first letter
-uppercase, expect for acronyms for wich all uppercase is used.
+uppercase, expect for acronyms for which all uppercase is used.
 For exemple "Address" and neither "ADDRESS" nor "address".
 
 The test case identifier in the test case specification (both in the main


### PR DESCRIPTION
## Purpose

Improve test case identifier and module readability by preferring capitalized words to upper case.

## Context

https://github.com/zonemaster/zonemaster-gui/issues/437

## Changes

* prefer capitalized words to full uppercase

## How to test this PR

\-
