### PR TITLE
Document Clickhouse installation and configuration (experimental)

### DIFF
--- a/docs/public/configuration/backend.md
+++ b/docs/public/configuration/backend.md
@@ -23,6 +23,12 @@
   * [user](#user-1)
   * [password](#password-1)
   * [database](#database-1)
+* [CLICKHOUSE section (experimental)](#clickhouse-section-experimental)
+  * [host](#host-2)
+  * [port](#port-2)
+  * [user](#user-2)
+  * [password](#password-2)
+  * [database](#database-2)
 * [SQLITE section](#sqlite-section)
   * [database_file](#database_file)
 * [LANGUAGE section](#language-section)
@@ -104,7 +110,10 @@ Database Engine   | Value
 MariaDB           | `MySQL`
 MySQL             | `MySQL`
 PostgreSQL        | `PostgreSQL`
+Clickhouse†       | `Clickhouse`
 SQLite            | `SQLite`
+
+† _experimental feature_
 
 ### polling_interval
 
@@ -189,6 +198,43 @@ The password of the configured user.
 ### database
 
 A US ASCII-only [PostgreSQL identifier]. Max length 63 characters.
+
+The name of the database to use.
+
+
+## CLICKHOUSE section (experimental)
+
+Available keys : `host`, `port`, `user`, `password`, `database`.
+
+### host
+
+An [LDH domain name] or IP address.
+
+The host name of the machine on which the Clickhouse server is running.
+
+### port
+
+The [MySQL interface][Clickhouse MySQL interface]'s port the Clickhouse server
+is listening on.
+Default value: `9004`.
+
+### user
+
+A US ASCII-only identifier. Max length 63 characters.
+
+The name of the user with sufficient permission to access the database.
+
+### password
+
+A string of [US ASCII printable characters].
+The first character must be neither space nor `<`.
+Max length 100 characters.
+
+The password of the configured user.
+
+### database
+
+A US ASCII-only identifier. Max length 63 characters.
 
 The name of the database to use.
 
@@ -381,6 +427,7 @@ Otherwise a new test request is enqueued.
 
 
 [API documentation]:                  ../using/backend/api.md
+[Clickhouse MySQL interface]:         https://clickhouse.com/docs/en/interfaces/mysql
 [DBD::mysql documentation]:           https://metacpan.org/pod/DBD::mysql#host
 [Default JSON profile file]:          https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
 [Environement Variables]:             backend-environment-variables.md

--- a/docs/public/configuration/backend.md
+++ b/docs/public/configuration/backend.md
@@ -214,8 +214,8 @@ The host name of the machine on which the Clickhouse server is running.
 
 ### port
 
-The [MySQL interface][Clickhouse MySQL interface]'s port the Clickhouse server
-is listening on.
+The port the Clickhouse server is listening on, for connections using the
+[MySQL-compatible protocol][Clickhouse MySQL interface].
 Default value: `9004`.
 
 ### user

--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -34,13 +34,18 @@
   * [8.1. PostgreSQL (Rocky Linux)][PostgreSQL instructions Rocky Linux]
   * [8.2. PostgreSQL (Debian/Ubuntu)][PostgreSQL instructions Debian]
   * [8.3. PostgreSQL (FreeBSD)][PostgreSQL instructions FreeBSD]
-* [9. Cleaning up the database][Removing database]
-  * [9.1. MariaDB and MySQL](#91-mariadb-and-mysql)
-  * [9.2. PostgreSQL](#92-postgresql)
-  * [9.3. SQLite](#93-sqlite)
-* [10. Optional features](#10-optional-features)
-  * [10.1. Metrics](#101-metrics)
-  * [10.2 Installation with Clickhouse](#102-installation-with-clickhouse)
+* [9. Installation with Clickhouse (experimental)](#9-Installation-with-clickhouse-experimental)
+  * [9.1. Clickhouse (Rocky Linux)](#91-clickhouse-rocky-linux)
+  * [9.2. Clickhouse (Debian/Ubuntu)][Clickhouse instructions Debian]
+  * [9.3. Clickhouse (FreeBSD)](#93-clickhouse-freebsd)
+* [10. Cleaning up the database][Cleaning up the database]
+  * [10.1. MariaDB and MySQL](#101-mariadb-and-mysql)
+  * [10.2. PostgreSQL](#102-postgresql)
+  * [10.3. SQLite](#103-sqlite)
+  * [10.4 Clickhouse](#104-clickhouse)
+* [11. Optional features](#11-optional-features)
+  * [11.1. Metrics](#111-metrics)
+
 
 ## 1. Overview
 
@@ -49,7 +54,7 @@ Zonemaster product, please see the [main Zonemaster Repository].
 
 If you upgrade your Zonemaster installation with a newer version of
 Zonemaster::Backend instead, and want to keep the database, then see the
-[Upgrade document]. Otherwise [remove the database][Removing database] and
+[Upgrade document]. Otherwise [remove the database][Cleaning up the database] and
 continue with this installation document.
 
 
@@ -273,8 +278,9 @@ sudo install -v -m 755 -o zonemaster -g zonemaster -d /var/lib/zonemaster
 
 #### 4.2.2 Instructions for other engines (Debian/Ubuntu)
 
-See sections for [MariaDB][MariaDB instructions Debian] and
-[PostgreSQL][PostgreSQL instructions Debian].
+See sections for [MariaDB][MariaDB instructions Debian],
+[PostgreSQL][PostgreSQL instructions Debian] and
+[Clickhouse][Clickhouse instructions Debian].
 
 
 ### 4.3 Database configuration (Debian/Ubuntu)
@@ -712,78 +718,19 @@ Now go back to "[Database configuration](#53-database-configuration-freebsd)"
 to create the database tables and then continue with the steps after that.
 
 
-## 9. Cleaning up the database
+## 9. Installation with Clickhouse (experimental)
 
-If, at some point, you want to delete all traces of Zonemaster in the database,
-you can run the file `cleanup-mysql.sql` or file `cleanup-postgres.sql`
-as a database administrator. Commands
-for locating and running the file are below. It removes the user and drops the
-database (obviously taking all data with it).
-
-> Each script uses default values, you may need to adapt them to your setup.
-
-### 9.1. MariaDB and MySQL
-
-Rocky Linux, Debian and Ubuntu:
-
-```sh
-sudo mysql --user=root < `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`/cleanup-mysql.sql
-```
-
-FreeBSD (you will get prompted for MySQL password):
-
-```sh
-mysql --user=root -p < `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`/cleanup-mysql.sql
-```
-
-### 9.2. PostgreSQL
-
-Rocky Linux, Debian and Ubuntu:
-
-```sh
-sudo -u postgres psql -f $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/cleanup-postgres.sql
-```
-
-FreeBSD (as root):
-
-```sh
-psql -U postgres -f `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`/cleanup-postgres.sql
-```
-
-### 9.3. SQLite
-
-Remove the database file and recreate it following the installation instructions above.
-
-## 10. Optional features
-
-### 10.1 Metrics
-
-Statsd metrics are available, to enable the feature install the additional
-`Net::Statsd` module. See the [configuration][Backend configuration] to
-configure the receiver.
-
-The list of metrics is available in the [Telemetry document][metrics].
-
-### 10.1.1 Installation on Rocky Linux
-
-```sh
-sudo cpanm --notest Net::Statsd
-```
-
-### 10.1.2 Installation on Debian / Ubuntu
+First follow the installation instructions for the OS in question, and then go
+to this section to install Clickhouse.
 
 
-```sh
-sudo apt install libnet-statsd-perl
-```
+### 9.1. Clickhouse (Rocky Linux)
 
-### 10.1.3 Installation on Freebsd
+There is not yet any specific installation instructions for Rocky Linux. In most
+parts the instructions for Debian/Ubuntu can be followed. 
 
-```sh
-cpanm --notest Net::Statsd
-```
 
-## 10.2 Installation with Clickhouse
+### 9.2. Clickhouse (Debian/Ubuntu)
 
 > This is an experimental feature.
 
@@ -830,9 +777,94 @@ Now go back to "[Database configuration](#43-database-configuration-debianubuntu
 to create the database tables and then continue with the steps after that.
 
 
+### 9.3. Clickhouse (FreeBSD)
+
+There is not yet any specific installation instructions for FreeBSD. In most
+parts the instructions for Debian/Ubuntu can be followed. 
+
+
+## 10. Cleaning up the database
+
+If, at some point, you want to delete all traces of Zonemaster in the database,
+you can run the file `cleanup-mysql.sql` or file `cleanup-postgres.sql`
+as a database administrator. Commands
+for locating and running the file are below. It removes the user and drops the
+database (obviously taking all data with it).
+
+> Each script uses default values, you may need to adapt them to your setup.
+
+### 10.1. MariaDB and MySQL
+
+Rocky Linux, Debian and Ubuntu:
+
+```sh
+sudo mysql --user=root < `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`/cleanup-mysql.sql
+```
+
+FreeBSD (you will get prompted for MySQL password):
+
+```sh
+mysql --user=root -p < `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`/cleanup-mysql.sql
+```
+
+### 10.2. PostgreSQL
+
+Rocky Linux, Debian and Ubuntu:
+
+```sh
+sudo -u postgres psql -f $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/cleanup-postgres.sql
+```
+
+FreeBSD (as root):
+
+```sh
+psql -U postgres -f `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`/cleanup-postgres.sql
+```
+
+### 10.3. SQLite
+
+Remove the database file and recreate it following the installation instructions above.
+
+
+### 10.4 Clickhouse
+
+Currently there are no instructions for cleaning up a Clickhose database.
+
+
+## 11. Optional features
+
+### 11.1 Metrics
+
+Statsd metrics are available, to enable the feature install the additional
+`Net::Statsd` module. See the [configuration][Backend configuration] to
+configure the receiver.
+
+The list of metrics is available in the [Telemetry document][metrics].
+
+### 11.1.1 Installation on Rocky Linux
+
+```sh
+sudo cpanm --notest Net::Statsd
+```
+
+### 11.1.2 Installation on Debian / Ubuntu
+
+
+```sh
+sudo apt install libnet-statsd-perl
+```
+
+### 11.1.3 Installation on Freebsd
+
+```sh
+cpanm --notest Net::Statsd
+```
+
+
 -------
 
 [Backend configuration]:              ../configuration/backend.md
+[Clickhouse instructions Debian]:     #92-clickhouse-debianubuntu
 [Declaration of prerequisites]:       prerequisites.md
 [JSON-RPC API]:                       ../using/backend/rpcapi-reference.md
 [Main Zonemaster repository]:         https://github.com/zonemaster/zonemaster/blob/master/README.md
@@ -845,10 +877,13 @@ to create the database tables and then continue with the steps after that.
 [PostgreSQL instructions Debian]:     #82-postgresql-debianubuntu
 [PostgreSQL instructions FreeBSD]:    #83-postgresql-freebsd
 [Prerequisites section]:              #2-prerequisites
-[Removing database]:                  #9-cleaning-up-the-database
+[Cleaning up the database]:           #10-cleaning-up-the-database
 [Upgrade document]:                   ../upgrading/backend.md
 [Zonemaster::CLI installation]:       zonemaster-cli.md
 [Zonemaster::Engine installation]:    zonemaster-engine.md
 [Zonemaster::Engine]:                 https://github.com/zonemaster/zonemaster-engine/blob/master/README.md
 [Zonemaster::GUI installation]:       zonemaster-gui.md
 [Zonemaster::LDNS]:                   https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
+
+
+Cleaning up the database]

--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -734,10 +734,7 @@ parts the instructions for Debian/Ubuntu can be followed.
 
 > This is an experimental feature.
 
-First follow the installation instructions for the OS in question, and then go
-to this section to install Clickhouse.
-
-To install Clickhouse, follow the instruction in the [official
+To install Clickhouse, follow the instructions from the [official
 documentation](https://clickhouse.com/docs/en/install#available-installation-options).
 
 Configure Zonemaster::Backend to use the correct database engine:
@@ -746,26 +743,26 @@ Configure Zonemaster::Backend to use the correct database engine:
 sudo sed -i '/\bengine\b/ s/=.*/= Clickhouse/' /etc/zonemaster/backend_config.ini
 ```
 
+> **Note:** See the [backend configuration] documentation for details.
+
 Install the Perl bindings (Clickhouse relies on the MySQL DBI).
 
 ```sh
 sudo apt install libdbd-mysql-perl
 ```
 
-> **Note:** See the [backend configuration] documentation for details.
-
 To create the database and the database user (unless you keep an old database).
 Edit the command first if you want a non-default database name, user name or
 password.
 
-> The Clickhouse MySQL interface requires a [double SHA1
+> **Note**: The Clickhouse MySQL interface requires a [double SHA1
 > password](https://clickhouse.com/docs/en/operations/settings/settings-users#password_double_sha1_hex)
 > ```
 > PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" | sha1sum | tr -d '-' | xxd -r -p | sha1sum | tr -d '-'
 > ```
 
 ```sh
-clickhouse-client --ask-password -q "CREATE USER zonemaster IDENTIFIED WITH DOUBLE_SHA1 BY '<DOUBLE_SHA1>';"
+clickhouse-client --ask-password -q "CREATE USER zonemaster IDENTIFIED WITH DOUBLE_SHA1_HASH BY '<DOUBLE_SHA1_PASSWORD>';"
 clickhouse-client --ask-password -q "CREATE DATABASE zonemaster;"
 clickhouse-client --ask-password -q "GRANT CREATE TABLE, DROP TABLE, SELECT, INSERT, ALTER UPDATE ON zonemaster.* TO zonemaster;"
 ```

--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -40,6 +40,7 @@
   * [9.3. SQLite](#93-sqlite)
 * [10. Optional features](#10-optional-features)
   * [10.1. Metrics](#101-metrics)
+  * [10.2 Installation with Clickhouse](#102-installation-with-clickhouse)
 
 ## 1. Overview
 
@@ -781,6 +782,53 @@ sudo apt install libnet-statsd-perl
 ```sh
 cpanm --notest Net::Statsd
 ```
+
+## 10.2 Installation with Clickhouse
+
+> This is an experimental feature.
+
+First follow the installation instructions for the OS in question, and then go
+to this section to install Clickhouse.
+
+To install Clickhouse, follow the instruction in the [official
+documentation](https://clickhouse.com/docs/en/install#available-installation-options).
+
+Configure Zonemaster::Backend to use the correct database engine:
+
+```sh
+sudo sed -i '/\bengine\b/ s/=.*/= Clickhouse/' /etc/zonemaster/backend_config.ini
+```
+
+Install the Perl bindings (Clickhouse relies on the MySQL DBI).
+
+```sh
+sudo apt install libdbd-mysql-perl
+```
+
+> **Note:** See the [backend configuration] documentation for details.
+
+To create the database and the database user (unless you keep an old database).
+Edit the command first if you want a non-default database name, user name or
+password.
+
+> The Clickhouse MySQL interface requires a [double SHA1
+> password](https://clickhouse.com/docs/en/operations/settings/settings-users#password_double_sha1_hex)
+> ```
+> PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" | sha1sum | tr -d '-' | xxd -r -p | sha1sum | tr -d '-'
+> ```
+
+```sh
+clickhouse-client --ask-password -q "CREATE USER zonemaster IDENTIFIED WITH DOUBLE_SHA1 BY '<DOUBLE_SHA1>';"
+clickhouse-client --ask-password -q "CREATE DATABASE zonemaster;"
+clickhouse-client --ask-password -q "GRANT CREATE TABLE, DROP TABLE, SELECT, INSERT, ALTER UPDATE ON zonemaster.* TO zonemaster;"
+```
+
+Update the `/etc/zonemaster/backend_config.ini` file with database name, username
+and password if non-default values are used.
+
+Now go back to "[Database configuration](#43-database-configuration-debianubuntu)"
+to create the database tables and then continue with the steps after that.
+
 
 -------
 

--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -34,10 +34,7 @@
   * [8.1. PostgreSQL (Rocky Linux)][PostgreSQL instructions Rocky Linux]
   * [8.2. PostgreSQL (Debian/Ubuntu)][PostgreSQL instructions Debian]
   * [8.3. PostgreSQL (FreeBSD)][PostgreSQL instructions FreeBSD]
-* [9. Installation with Clickhouse (experimental)](#9-Installation-with-clickhouse-experimental)
-  * [9.1. Clickhouse (Rocky Linux)](#91-clickhouse-rocky-linux)
-  * [9.2. Clickhouse (Debian/Ubuntu)][Clickhouse instructions Debian]
-  * [9.3. Clickhouse (FreeBSD)](#93-clickhouse-freebsd)
+* [9. Installation with Clickhouse (experimental)][Clickhouse instructions]
 * [10. Cleaning up the database][Cleaning up the database]
   * [10.1. MariaDB and MySQL](#101-mariadb-and-mysql)
   * [10.2. PostgreSQL](#102-postgresql)
@@ -280,7 +277,7 @@ sudo install -v -m 755 -o zonemaster -g zonemaster -d /var/lib/zonemaster
 
 See sections for [MariaDB][MariaDB instructions Debian],
 [PostgreSQL][PostgreSQL instructions Debian] and
-[Clickhouse][Clickhouse instructions Debian].
+[Clickhouse][Clickhouse instructions].
 
 
 ### 4.3 Database configuration (Debian/Ubuntu)
@@ -720,36 +717,19 @@ to create the database tables and then continue with the steps after that.
 
 ## 9. Installation with Clickhouse (experimental)
 
+> This is an experimental feature.
+
 First follow the installation instructions for the OS in question, and then go
 to this section to install Clickhouse.
-
-
-### 9.1. Clickhouse (Rocky Linux)
-
-There is no specific installation instructions for Rocky Linux yet. In most
-parts the instructions for Debian/Ubuntu can be followed.
-
-
-### 9.2. Clickhouse (Debian/Ubuntu)
-
-> This is an experimental feature.
 
 To install Clickhouse, follow the instructions from the [official
 documentation](https://clickhouse.com/docs/en/install#available-installation-options).
 
-Configure Zonemaster::Backend to use the correct database engine:
+Install the Perl bindings (Clickhouse relies on the MySQL DBI):
 
-```sh
-sudo sed -i '/\bengine\b/ s/=.*/= Clickhouse/' /etc/zonemaster/backend_config.ini
-```
-
-> **Note:** See the [backend configuration] documentation for details.
-
-Install the Perl bindings (Clickhouse relies on the MySQL DBI).
-
-```sh
-sudo apt install libdbd-mysql-perl
-```
+* Rocky Linux: `sudo dnf install -y perl-DBD-MySQL`
+* Debian/Ubuntu: `sudo apt install libdbd-mysql-perl`
+* FreeBSD: `pkg install mysql57-server p5-DBD-mysql`
 
 To create the database and the database user (unless you keep an old database).
 Edit the command first if you want a non-default database name, user name or
@@ -767,17 +747,18 @@ clickhouse-client --ask-password -q "CREATE DATABASE zonemaster;"
 clickhouse-client --ask-password -q "GRANT CREATE TABLE, DROP TABLE, SELECT, INSERT, ALTER UPDATE ON zonemaster.* TO zonemaster;"
 ```
 
-Update the `/etc/zonemaster/backend_config.ini` file with database name, username
-and password if non-default values are used.
+Update the `backend_config.ini` file with the correct databse engine, database
+name, username and password if non-default values are used. The file location
+differs based on the used OS:
+
+* Rocky Linux: `/etc/zonemaster/backend_config.ini`
+* Debian/Ubuntu: `/etc/zonemaster/backend_config.ini`
+* FreeBSD: `/usr/local/etc/zonemaster/backend_config.ini`
+
+> **Note:** See the [backend configuration] documentation for details.
 
 Now go back to "[Database configuration](#43-database-configuration-debianubuntu)"
 to create the database tables and then continue with the steps after that.
-
-
-### 9.3. Clickhouse (FreeBSD)
-
-There is no specific installation instructions for FreeBSD yet. In most parts
-the instructions for Debian/Ubuntu can be followed.
 
 
 ## 10. Cleaning up the database
@@ -863,7 +844,7 @@ cpanm --notest Net::Statsd
 -------
 
 [Backend configuration]:              ../configuration/backend.md
-[Clickhouse instructions Debian]:     #92-clickhouse-debianubuntu
+[Clickhouse instructions]:            #9-Installation-with-clickhouse-experimental
 [Declaration of prerequisites]:       prerequisites.md
 [JSON-RPC API]:                       ../using/backend/rpcapi-reference.md
 [Main Zonemaster repository]:         https://github.com/zonemaster/zonemaster/blob/master/README.md

--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -726,8 +726,8 @@ to this section to install Clickhouse.
 
 ### 9.1. Clickhouse (Rocky Linux)
 
-There is not yet any specific installation instructions for Rocky Linux. In most
-parts the instructions for Debian/Ubuntu can be followed. 
+There is no specific installation instructions for Rocky Linux yet. In most
+parts the instructions for Debian/Ubuntu can be followed.
 
 
 ### 9.2. Clickhouse (Debian/Ubuntu)
@@ -779,8 +779,8 @@ to create the database tables and then continue with the steps after that.
 
 ### 9.3. Clickhouse (FreeBSD)
 
-There is not yet any specific installation instructions for FreeBSD. In most
-parts the instructions for Debian/Ubuntu can be followed. 
+There is no specific installation instructions for FreeBSD yet. In most parts
+the instructions for Debian/Ubuntu can be followed.
 
 
 ## 10. Cleaning up the database
@@ -828,7 +828,9 @@ Remove the database file and recreate it following the installation instructions
 
 ### 10.4 Clickhouse
 
-Currently there are no instructions for cleaning up a Clickhose database.
+Currently there are no instructions for cleaning up a Clickhouse database.
+The scripts used for MariaDB/MySQL and PostgreSQL could be a source of
+inspiration.
 
 
 ## 11. Optional features
@@ -884,6 +886,3 @@ cpanm --notest Net::Statsd
 [Zonemaster::Engine]:                 https://github.com/zonemaster/zonemaster-engine/blob/master/README.md
 [Zonemaster::GUI installation]:       zonemaster-gui.md
 [Zonemaster::LDNS]:                   https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
-
-
-Cleaning up the database]

--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -729,7 +729,7 @@ Install the Perl bindings (Clickhouse relies on the MySQL DBI):
 
 * Rocky Linux: `sudo dnf install -y perl-DBD-MySQL`
 * Debian/Ubuntu: `sudo apt install libdbd-mysql-perl`
-* FreeBSD: `pkg install mysql57-server p5-DBD-mysql`
+* FreeBSD: `pkg install p5-DBD-mysql`
 
 To create the database and the database user (unless you keep an old database).
 Edit the command first if you want a non-default database name, user name or
@@ -757,8 +757,11 @@ differs based on the used OS:
 
 > **Note:** See the [backend configuration] documentation for details.
 
-Now go back to "[Database configuration](#43-database-configuration-debianubuntu)"
-to create the database tables and then continue with the steps after that.
+Now go back to "Database configuration" to create the database tables and then
+continue with the steps after that. Select your OS:
+* [Debian/Ubuntu](#43-database-configuration-debianubuntu)
+* [FreeBSD](#53-database-configuration-freebsd)
+* [Rocky Linux](#33-database-configuration-rocky-linux)
 
 
 ## 10. Cleaning up the database


### PR DESCRIPTION
## Purpose

Document  Clickhouse database engine installation and configuration for Zonemaster-Backend. This is an experimental feature.

## Context

Relates to https://github.com/zonemaster/zonemaster-backend/pull/1094

## Changes

Add a Clickhouse section to `docs/public/installation/zonemaster-backend.md` and `docs/public/configuration/backend.md`.

## How to test this PR

Documentation, review the changes.
