### PR TITLE
Give correct information on where the ASN data comes from

### DIFF
--- a/docs/public/specifications/tests/Connectivity-TP/connectivity03.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity03.md
@@ -92,7 +92,7 @@ ASN lookup, RIPE or Cymru. The service must be available over the network.
 
 The Cymru lookup method is described on the Team Cymru [IP to ASN Mapping]
 using DNS lookup, but the default data comes from [bgp.tools] (Port 179 Ltd
-in England and Wales) and is continuesly being mapped into
+in England and Wales) and is continuously being mapped into
 `asnlookup.zonemaster.net` by the Zonemaster project. Data is fetched from
 <https://bgp.tools/table.txt>. The Cymru source can also be used, if
 requested.

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity03.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity03.md
@@ -91,7 +91,11 @@ ASN lookup, RIPE or Cymru. The service must be available over the network.
 ### Cymru ASN lookup
 
 The Cymru lookup method is described on the Team Cymru [IP to ASN Mapping]
-using DNS lookup.
+using DNS lookup, but the default data comes from [bgp.tools] (Port 179 Ltd
+in England and Wales) and is continuesly being mapped into
+`asnlookup.zonemaster.net` by the Zonemaster project. Data is fetched from
+<https://bgp.tools/table.txt>. The Cymru source can also be used, if
+requested.
 
 1. Prepend the *Cymru Base Name* with the label "origin" (IPv4) or 
    "origin6" (IPv6). Example of expanded basenames 
@@ -180,6 +184,7 @@ whois -h riswhois.ripe.net " -F -M 192.0.2.10"
 None
 
 
+[Bgp.tools]:            https://bgp.tools/
 [Cymru database]:       #cymru-asn-lookup
 [EMPTY_ASN_SET]:        #outcomes 
 [ERROR_ASN_DATABASE]:   #outcomes 

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
@@ -131,7 +131,7 @@ the appropriate section below.
 
 The Cymru prefix lookup is described on the Team Cymru [IP to ASN Mapping]
 using DNS lookup, but the default data comes from [bgp.tools] (Port 179 Ltd
-in England and Wales) and is continuesly being mapped into
+in England and Wales) and is continuously being mapped into
 `asnlookup.zonemaster.net` by the Zonemaster project. Data is fetched from
 <https://bgp.tools/table.txt>. The Cymru source can also be used, if
 requested.

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
@@ -130,7 +130,12 @@ the appropriate section below.
 ### Cymru prefix lookup
 
 The Cymru prefix lookup is described on the Team Cymru [IP to ASN Mapping]
-using DNS lookup.
+using DNS lookup, but the default data comes from [bgp.tools] (Port 179 Ltd
+in England and Wales) and is continuesly being mapped into
+`asnlookup.zonemaster.net` by the Zonemaster project. Data is fetched from
+<https://bgp.tools/table.txt>. The Cymru source can also be used, if
+requested.
+
 
 1. Prepend the *Cymru Base Name* with the label "origin" (IPv4) or 
    "origin6" (IPv6) ("Expanded Base Name"). Example of expanded basenames :
@@ -216,6 +221,7 @@ None
   a specific server (server IP address).
 
 [Argument List]:                                                ../ArgumentsForTestCaseMessages.md
+[Bgp.tools]:                                                    https://bgp.tools/
 [CN04_EMPTY_PREFIX_SET]:                                        #outcomes
 [CN04_ERROR_PREFIX_DATABASE]:                                   #outcomes
 [CN04_IPV4_DIFFERENT_PREFIX]:                                   #outcomes


### PR DESCRIPTION
## Purpose

The Cymru ASN data method no longer uses Cymru source of the data. This PR updates the information. No change in any logic. No change in implementation needed.

## How to test this PR

Review only.