### PR TITLE
Store release information in public

### DIFF
--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -5,6 +5,7 @@ documentation.*
 
 The public documentation is divided into the following main categories:
 
+* [Release information](RELEASE.md) give the release information of latest release.
 * [Installation](installation/README.md) contains documents that explain how to
   install the different components of Zonemaster.
 * [Upgrading](upgrading/README.md) contains documents that explain how to upgrade

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -5,7 +5,7 @@ documentation.*
 
 The public documentation is divided into the following main categories:
 
-* [Release information](RELEASE.md) give the release information of latest release.
+* [Release information](RELEASE.md) gives release information of latest release.
 * [Installation](installation/README.md) contains documents that explain how to
   install the different components of Zonemaster.
 * [Upgrading](upgrading/README.md) contains documents that explain how to upgrade

--- a/docs/public/RELEASE.md
+++ b/docs/public/RELEASE.md
@@ -1,0 +1,41 @@
+# Release v2023.2.1
+
+### [Fixes]
+ - Corrects the database migration script introduced in release v2023.2 in [Zonemaster-Backend].
+ - Corrects database upgrade instructions (#1244)
+
+### [Zonemaster product]
+This version of Zonemaster also consists of the following components. For each component, see its Changes file or Github release notes. This fix version does not change anything in other components. See previous releases for recent changes.
+
+Component | Github release notes | Changes file | Updated in this release
+------------------------|:-----------------------:|---------------------------------|:----:
+[Zonemaster-LDNS]      | [v4.0.1][ldns-tag]        | [Changes][ldns-Changes]          | Yes
+[Zonemaster-Engine]    | [v5.0.0][engine-tag]    | [Changes][engine-Changes]       | No
+[Zonemaster-CLI]          | [v6.1.0][cli-tag]           | [Changes][cli-Changes]              | No
+[Zonemaster-Backend] | [v11.1.1][backend-tag] | [Changes][backend-Changes]   | Yes
+[Zonemaster-GUI]         | [v4.2.0][gui-tag]          | [Changes][gui-Changes]            | No
+
+For more information on previous versions of the Zonemaster product see the [Changes][zonemaster-Changes] file or the [releases] page. For general information ses the [README] file.
+
+[README]: https://github.com/zonemaster/zonemaster/blob/master/README.md
+[releases]: https://github.com/zonemaster/zonemaster/releases
+
+[ldns-tag]: https://github.com/zonemaster/zonemaster-ldns/releases/tag/v4.0.1
+[engine-tag]: https://github.com/zonemaster/zonemaster-engine/releases/tag/v5.0.0
+[cli-tag]: https://github.com/zonemaster/zonemaster-cli/releases/tag/v6.1.0
+[backend-tag]: https://github.com/zonemaster/zonemaster-backend/releases/tag/v11.1.1
+[gui-tag]: https://github.com/zonemaster/zonemaster-gui/releases/tag/v4.2.0
+
+[zonemaster-Changes]: https://github.com/dotse/zonemaster/blob/master/Changes
+[ldns-Changes]: https://github.com/zonemaster/zonemaster-ldns/blob/master/Changes
+[engine-Changes]: https://github.com/zonemaster/zonemaster-engine/blob/master/Changes
+[cli-Changes]: https://github.com/zonemaster/zonemaster-cli/blob/master/Changes
+[backend-Changes]: https://github.com/zonemaster/zonemaster-backend/blob/master/Changes
+[gui-Changes]: https://github.com/zonemaster/zonemaster-gui/blob/master/Changes
+
+[Zonemaster-LDNS]: https://github.com/zonemaster/zonemaster-ldns
+[Zonemaster-Engine]: https://github.com/zonemaster/zonemaster-engine
+[Zonemaster-CLI]: https://github.com/zonemaster/zonemaster-cli
+[Zonemaster-Backend]: https://github.com/zonemaster/zonemaster-backend
+[Zonemaster-GUI]: https://github.com/zonemaster/zonemaster-gui
+

--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -2,6 +2,7 @@
  https://rust-lang.github.io/mdBook/format/summary.html -->
 # Documents in public document tree
 
+- [Release information](RELEASE.md)
 - [Installation](installation/README.md)
     - [Prerequisites](installation/prerequisites.md)
     - [Zonemaster-LDNS](installation/zonemaster-ldns.md)


### PR DESCRIPTION
## Purpose

Add release information to the public document path. **This PR is not to be merged.** It is to show a proposal that would be executed at an upcoming release for that release.

File "public/RELEASE.md" is added. The file should be updated at release time with the release information of the latest release (and not including previous releases). The content is to be directly copied to the Github release page, e.g. https://github.com/zonemaster/zonemaster/releases/tag/v2023.2.1. No edits should be needed.

SUMMARY.md has also been updated with a link to the RELEASE.md file.

I built a "book" and the file works well into the book.

## How to test this PR

Review. Build a "book" following the instruction in https://github.com/zonemaster/zonemaster?tab=readme-ov-file#documentation.