### PR TITLE
Automatic link checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ In the internal tree you can find documentation regarding the
 [design](docs/internal/design) and [requirements](docs/internal/requirements) of
 the Zonemaster implementation.
 
-The [public](docs/public) documentation can be built using
-[`mdbook`](https://rust-lang.github.io/mdBook/) and the following commands:
+The [public](docs/public) documentation can be built using [`mdbook`][mdbook],
+its [`mdbook-linkcheck`][mdbook-linkcheck] plugin and the following commands:
 
 ```
 cd docs/public
@@ -194,6 +194,8 @@ be found in the [LICENSE](LICENSE) file included in this respository.
 [Issues in Zonemaster::GUI]:           https://github.com/zonemaster/zonemaster-gui/issues
 [Issues in Zonemaster::LDNS]:          https://github.com/zonemaster/zonemaster-ldns/issues
 [LDNS]:                                https://www.nlnetlabs.nl/projects/ldns/about/
+[mdbook]:                              https://rust-lang.github.io/mdBook/
+[mdbook-linkcheck]:                    https://github.com/Michael-F-Bryan/mdbook-linkcheck
 [OpenSSL]:                             https://www.openssl.org/
 [Prerequisites]:                       docs/public/installation/prerequisites.md
 [USING]:                               https://github.com/zonemaster/zonemaster-cli/blob/master/USING.md

--- a/docs/public/SUMMARY.md
+++ b/docs/public/SUMMARY.md
@@ -57,6 +57,7 @@
         - [DNS Query and Response](specifications/tests/DNSQueryAndResponseDefaults.md)
         - [Requirements and Normalization](specifications/tests/RequirementsAndNormalizationOfDomainNames.md)
         - [Arguments For Test Case Messages](specifications/tests/ArgumentsForTestCaseMessages.md)
+        - [Implemented Test Cases](specifications/tests/ImplementedTestCases.md)
         - [Address-TP](specifications/tests/Address-TP/README.md)
             - [Address01](specifications/tests/Address-TP/address01.md)
             - [Address02](specifications/tests/Address-TP/address02.md)

--- a/docs/public/book.toml
+++ b/docs/public/book.toml
@@ -12,3 +12,6 @@ enable = true
 level = 1
 
 [preprocessor.index]
+
+[output.linkcheck]
+follow-web-links = true

--- a/docs/public/configuration/backend.md
+++ b/docs/public/configuration/backend.md
@@ -397,7 +397,7 @@ Otherwise a new test request is enqueued.
 [PostgreSQL identifier]:              https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
 [Profile JSON files]:                 profiles.md
 [Profile name section]:               ../using/backend/rpcapi-reference.md#profile-name
-[Profiles]:                           Architecture.md#profile
+[Profiles]:                           https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Architecture.md#profile
 [RPCAPI.enable_add_api_user]:         #enable_add_api_user
 [RPCAPI.enable_add_batch_job]:        #enable_add_batch_job
 [RPCAPI.enable_batch_create]:         #enable_batch_create

--- a/docs/public/installation/README.md
+++ b/docs/public/installation/README.md
@@ -25,7 +25,7 @@ how to run Zonemaster-CLI on Docker.
 To build your own Docker image, see the [Docker Image Creation] documentation.
 
 [Docker Hub]:                          https://hub.docker.com/u/zonemaster
-[Docker Image Creation]:               ../../internal/maintenance/ReleaseProcess-create-docker-image.md
+[Docker Image Creation]:               https://github.com/zonemaster/zonemaster/blob/master/docs/internal/maintenance/ReleaseProcess-create-docker-image.md
 [Docker]:                              https://www.docker.com/get-started/
 [prerequisites]:                       prerequisites.md
 [Using the CLI]:                       ../using/cli.md

--- a/docs/public/installation/docker.md
+++ b/docs/public/installation/docker.md
@@ -8,6 +8,6 @@ Zonemaster-CLI on [Docker].
 To build your own Docker image, see the [Docker Image Creation] documentation.
 
 [Docker Hub]:                          https://hub.docker.com/u/zonemaster
-[Docker Image Creation]:               ../../internal/maintenance/ReleaseProcess-create-docker-image.md
+[Docker Image Creation]:               https://github.com/zonemaster/zonemaster/blob/master/docs/internal/maintenance/ReleaseProcess-create-docker-image.md
 [Docker]:                              https://www.docker.com/get-started/
 [USING]:                               ../using/cli.md

--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -54,8 +54,8 @@ continue with this installation document.
 
 ## 2. Prerequisites
 
-Before installing Zonemaster::Backend, you should [install Zonemaster::Engine][
-Zonemaster::Engine installation].
+Before installing Zonemaster::Backend, you should [install Zonemaster::Engine
+][Zonemaster::Engine installation].
 
 > **Note:** [Zonemaster::Engine] and [Zonemaster::LDNS] are dependencies of
 > Zonemaster::Backend. Zonemaster::LDNS has a special installation requirement,

--- a/docs/public/installation/zonemaster-cli.md
+++ b/docs/public/installation/zonemaster-cli.md
@@ -15,7 +15,7 @@
 ## Prerequisites for CPAN installation
 
 Before installing Zonemaster::CLI from CPAN, you should [install
-Zonemaster::Engine][ Zonemaster::Engine installation], unless you are
+Zonemaster::Engine][Zonemaster::Engine installation], unless you are
 to install on Debian using pre-built packages (see below).
 
 > **Note:** [Zonemaster::Engine] and [Zonemaster::LDNS] are dependencies of

--- a/docs/public/installation/zonemaster-gui.md
+++ b/docs/public/installation/zonemaster-gui.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-Before installing Zonemaster Web GUI, you should [install Zonemaster::Engine][
-Zonemaster::Engine installation] and [Zonemaster::Backend][Zonemaster::Backend
+Before installing Zonemaster Web GUI, you should [install Zonemaster::Engine
+][Zonemaster::Engine installation] and [Zonemaster::Backend][Zonemaster::Backend
 installation].
 
 Prerequisite for FreeBSD is that the package system is updated and activated,

--- a/docs/public/installation/zonemaster-ldns.md
+++ b/docs/public/installation/zonemaster-ldns.md
@@ -152,6 +152,8 @@ TEST_WITH_NETWORK=1 make test
 
 [Docker Hub]:                                        https://hub.docker.com/u/zonemaster
 [Docker Image Creation]:                             ../../internal/maintenance/ReleaseProcess-create-docker-image.md
+[IDN]:                                               #idn
 [Installation instructions for Zonemaster::Engine]:  zonemaster-engine.md
+[Internal LDNS]:                                     #internal-ldns
 [Net::LibIDN]:                                       https://metacpan.org/pod/Net::LibIDN
 [USING]:                                             ../using/

--- a/docs/public/specifications/test-zones/README.md
+++ b/docs/public/specifications/test-zones/README.md
@@ -147,4 +147,4 @@ below.
 [Test cases]:                                        ../tests/README.md
 [Test-zones]:                                        .
 [Unit tests]:                                        https://github.com/zonemaster/zonemaster-engine/tree/master/t
-[Test-zone-data]:                                    ../../../../test-zone-data
+[Test-zone-data]:                                    https://github.com/zonemaster/zonemaster/tree/master/test-zone-data

--- a/docs/public/specifications/tests/Address-TP/address02.md
+++ b/docs/public/specifications/tests/Address-TP/address02.md
@@ -10,7 +10,7 @@ In order to prevent name servers to be blocked or blacklisted, DNS
 administrators should publish PTR records associated to name server
 addresses.
 
-[technical reference to be found]
+TODO: Technical reference to be found
 
 ### Inputs
 

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity01.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity01.md
@@ -20,7 +20,7 @@
 ## Objective
 
 UDP is the fundamental protocol to reach a general purpose name server hosting
-a zone, "DNS servers MUST be able to service UDP [...]" ([RFC 1123], section
+a zone, "DNS servers MUST be able to service UDP \[...]" ([RFC 1123], section
 6.1.3.2, page 75), also restated in [RFC 7766][RFC 7766#5], section 5.
 
 This Test Case will verify if the name servers of *Child Zone* are reachable over

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity02.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity02.md
@@ -20,7 +20,7 @@
 ## Objective
 
 TCP is a protocol to reach a general purpose name server hosting a zone, "All
-general-purpose DNS implementations MUST support [...] TCP transport"
+general-purpose DNS implementations MUST support \[...] TCP transport"
 ([RFC 7766][RFC 7766#5], section 5).
 
 This Test Case will verify if the name servers of *Child Zone* are reachable over

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec13.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec13.md
@@ -23,8 +23,8 @@
 From [RFC 6840][RFC 6840#section-5.11], section 5.11:
 
 > The DS RRset and DNSKEY RRset are used to signal which algorithms are used to
-> sign a zone. [...] The zone MUST also be signed with each algorithm (though
-> not each key) present in the DNSKEY RRset. [...]
+> sign a zone. \[...] The zone MUST also be signed with each algorithm (though
+> not each key) present in the DNSKEY RRset. \[...]
 
 To verify that the whole zone is signed with all algorithms require access to the
 complete zone, which is generally not possible for public zones. This test case

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec18.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec18.md
@@ -82,7 +82,7 @@ DS18_NO_MATCH_CDNSKEY_RRSIG_DS | ERROR | CDNSKEY RRset is not signed with a DNSK
 
 7. Else, do (*Test Type* is "normal"):
    1. Retrieve all name server IP addresses for the parent zone of
-      *Child Zone* using [Get-Parent-Zone] ("Parent NS IP").
+      *Child Zone* using [Get-Parent-NS-IP] ("Parent NS IP").
    2. For each IP address in *Parent NS IP* do:
       1. Send the DS query over UDP to the name server IP.
       2. If no DNS response is returned, then go to next name server
@@ -216,6 +216,7 @@ None.
 [DS18_NO_MATCH_CDS_RRSIG_DS]:            #summary
 [Default level]:                         ../SeverityLevelDefinitions.md
 [ERROR]:                                 ../SeverityLevelDefinitions.md#error
+[Get-Parent-NS-IP]:                      ../MethodsV2.md#method-get-parent-ns-ip-addresses
 [INFO]:                                  ../SeverityLevelDefinitions.md#info
 [Method1]:                               ../Methods.md#method-1-obtain-the-parent-domain
 [Method4]:                               ../Methods.md#method-4-obtain-glue-address-records-from-parent
@@ -223,6 +224,6 @@ None.
 [NOTICE]:                                ../SeverityLevelDefinitions.md#notice
 [RFC 4035#2.4]:                          https://datatracker.ietf.org/doc/html/rfc4035#section-2.4
 [RFC 7344#4.1]:                          https://datatracker.ietf.org/doc/html/rfc7344#section-4.1
-[RFC 7344]:                              https://datatracker.ietf.org/doc/html/rfc7344
-[RFC 8078]:                              https://datatracker.ietf.org/doc/html/rfc8078
+[RFC 7344]: https://datatracker.ietf.org/doc/html/rfc7344
+[RFC 8078]: https://datatracker.ietf.org/doc/html/rfc8078
 [WARNING]:                               ../SeverityLevelDefinitions.md#warning

--- a/docs/public/specifications/tests/DNSSEC-TP/dnssec18.md
+++ b/docs/public/specifications/tests/DNSSEC-TP/dnssec18.md
@@ -82,7 +82,7 @@ DS18_NO_MATCH_CDNSKEY_RRSIG_DS | ERROR | CDNSKEY RRset is not signed with a DNSK
 
 7. Else, do (*Test Type* is "normal"):
    1. Retrieve all name server IP addresses for the parent zone of
-      *Child Zone* using [Get-Parent-NS-IP] ("Parent NS IP").
+      *Child Zone* using Get-Parent-NS-IP ("Parent NS IP").
    2. For each IP address in *Parent NS IP* do:
       1. Send the DS query over UDP to the name server IP.
       2. If no DNS response is returned, then go to next name server
@@ -216,7 +216,6 @@ None.
 [DS18_NO_MATCH_CDS_RRSIG_DS]:            #summary
 [Default level]:                         ../SeverityLevelDefinitions.md
 [ERROR]:                                 ../SeverityLevelDefinitions.md#error
-[Get-Parent-NS-IP]:                      ../MethodsV2.md#method-get-parent-ns-ip-addresses
 [INFO]:                                  ../SeverityLevelDefinitions.md#info
 [Method1]:                               ../Methods.md#method-1-obtain-the-parent-domain
 [Method4]:                               ../Methods.md#method-4-obtain-glue-address-records-from-parent
@@ -224,6 +223,6 @@ None.
 [NOTICE]:                                ../SeverityLevelDefinitions.md#notice
 [RFC 4035#2.4]:                          https://datatracker.ietf.org/doc/html/rfc4035#section-2.4
 [RFC 7344#4.1]:                          https://datatracker.ietf.org/doc/html/rfc7344#section-4.1
-[RFC 7344]: https://datatracker.ietf.org/doc/html/rfc7344
-[RFC 8078]: https://datatracker.ietf.org/doc/html/rfc8078
+[RFC 7344]:                              https://datatracker.ietf.org/doc/html/rfc7344
+[RFC 8078]:                              https://datatracker.ietf.org/doc/html/rfc8078
 [WARNING]:                               ../SeverityLevelDefinitions.md#warning

--- a/docs/public/specifications/tests/MasterTestPlan.md
+++ b/docs/public/specifications/tests/MasterTestPlan.md
@@ -361,7 +361,7 @@ The technical review team must approve any changes made to the test
 cases.
 
 
-[Test requirements]:            ../../../internal/test-requirements/TestRequirements.md
+[Test requirements]:            https://github.com/zonemaster/zonemaster/blob/master/docs/internal/test-requirements/TestRequirements.md
 [Basic]:                        Basic-TP/README.md
 [Delegation]:                   Delegation-TP/README.md
 [Consistency]:                  Consistency-TP/README.md

--- a/docs/public/specifications/tests/MethodsV2.md
+++ b/docs/public/specifications/tests/MethodsV2.md
@@ -951,6 +951,7 @@ None.
 [Referral]:                                          #terminology
 [Requirements and normalization]:                    RequirementsAndNormalizationOfDomainNames.md
 [Send]:                                              #terminology
+[undelegated test]:                                  ../test-types/undelegated-test.md
 [Valid Domain Name]:                                 #terminology
 [Valid Name Server Name]:                            #terminology
 [Valid IP Address]:                                  #terminology

--- a/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
+++ b/docs/public/specifications/tests/Nameserver-TP/nameserver15.md
@@ -174,6 +174,7 @@ None
 [N15_ERROR_ON_VERSION_QUERY]:                                   #summary
 [N15_NO_VERSION_REVEALED]:                                      #summary
 [N15_SOFTWARE_VERSION]:                                         #summary
+[N15_WRONG_CLASS]:                                              #summary
 [NOTICE]:                                                       ../SeverityLevelDefinitions.md#notice
 [RCODE Name]:                                                   https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 [RFC2929]:                                                      https://datatracker.ietf.org/doc/html/rfc2929#section-3.2

--- a/docs/public/specifications/tests/README.md
+++ b/docs/public/specifications/tests/README.md
@@ -90,7 +90,7 @@ Test Case specifications:
 [Requirements and normalization of domain names in input]:   RequirementsAndNormalizationOfDomainNames.md
 [Severity Level Definitions]:                                SeverityLevelDefinitions.md
 [Syntax-TP]:                                                 Syntax-TP/README.md
-[Test requirements]:                                         ../../../internal/test-requirements/TestRequirements.md
+[Test requirements]:                                         https://github.com/zonemaster/zonemaster/blob/master/docs/internal/test-requirements/TestRequirements.md
 [Zone-TP]:                                                   Zone-TP/README.md
 [Zonemaster Master Test Plan]:                               MasterTestPlan.md
 

--- a/docs/public/specifications/tests/RequirementsAndNormalizationOfDomainNames.md
+++ b/docs/public/specifications/tests/RequirementsAndNormalizationOfDomainNames.md
@@ -45,8 +45,7 @@ specifications.
 To be valid, *Domain Name* must be one of two:
 
 1. a valid ASCII domain name, or
-2. a valid IDN name (Internationalized Domain Name) as of
-   [IDNA2008][RFC 5890#1.1].
+2. a valid IDN name (Internationalized Domain Name) as of [IDNA2008].
 
 The process defined in this specification will normalize *Domain Name* and output
 a normalized form to be used by all Zonemaster test cases. The objectives of the
@@ -190,8 +189,7 @@ Tables 1, 2, 3 and 4 are found in the [Detailed requirements] section below.
           "[Upper case](#upper-case)" below.
        3. Normalize *Label* to NFC as specified in [Unicode TR 15]. Also see
           section "[Unicode normalization](#unicode-normalization)" below.
-       3. Convert *Label* to an A-label as specified by
-          [IDNA2008][RFC 5890#1.1].
+       3. Convert *Label* to an A-label as specified by [IDNA2008].
           1. If the conversion failed, then output *[INVALID_U_LABEL]*
              and *Label*, and terminate these test procedures.
           2. Else, replace the U-label in *Domain Labels* with the A-label from
@@ -441,7 +439,7 @@ U+0130 ([LATIN CAPITAL LETTER I WITH DOT ABOVE]).
 DNS can only handle A-labels, not U-label. In the test core suite of Zonemaster
 only A-labels are used. For normalization, all U-labels are converted to
 A-labels. Test cases will only handle an ASCII-only *Domain Name*. Conversion
-from U-label to A-label should be done as specified for [IDNA2008][RFC 5890#1.1],
+from U-label to A-label should be done as specified for [IDNA2008],
 not IDNA2003.
 
 
@@ -451,7 +449,7 @@ No special terminology for this specification.
 
 
 [AMBIGUOUS_DOWNCASING]:                  #summary
-[Argument list]:                         ../ArgumentsForTestCaseMessages.md
+[Argument list]:                         ArgumentsForTestCaseMessages.md
 [CHARACTER TABULATION]:                  https://codepoints.net/U+0009
 [DOMAIN_NAME_TOO_LONG]:                  #summary
 [Detailed requirements]:                 #detailed-requirements
@@ -469,6 +467,7 @@ No special terminology for this specification.
 [HYPHEN-MINUS]:                          https://codepoints.net/U+002D
 [IDEOGRAPHIC FULL STOP]:                 https://codepoints.net/U+3002
 [IDEOGRAPHIC SPACE]:                     https://codepoints.net/U+3000
+[IDNA2008]:                              https://datatracker.ietf.org/doc/html/rfc5890#section-1.1
 [INITIAL_DOT]:                           #summary
 [INVALID_ASCII]:                         #summary
 [INVALID_U_LABEL]:                       #summary

--- a/docs/public/using/backend/rpcapi-reference.md
+++ b/docs/public/using/backend/rpcapi-reference.md
@@ -93,7 +93,7 @@ When a method expects an integer arguments, numbers encoded in strings are also 
 and numbers with fractions are rounded to the nearest integer.
 
 For details on when a *test* are performed after it's been requested,
-see the [architecture documentation](Architecture.md).
+see the [architecture documentation].
 
 
 ## Error reporting
@@ -272,7 +272,7 @@ regex `/^[a-z0-9]$|^[a-z0-9][a-z0-9_-]{0,30}[a-z0-9]$/i` which must be predefine
 in the configuration file as specified in the Configuration document
 [profile sections].
 
-The name of a [*profile*](Architecture.md#profile).
+The name of a *[profile]*.
 
 ### Progress percentage
 
@@ -1473,6 +1473,7 @@ There are also some experimental API methods documented only by name:
 [API system_versions]:                #api-method-system_versions
 [API user_create]:                    #api-method-user_create
 [API v10.0.0]:                        https://github.com/zonemaster/zonemaster-backend/blob/v10.0.0/docs/API.md
+[Architecture documentation]:         https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Architecture.md
 [Batch id]:                           #batch-id
 [Client id]:                          #client-id
 [Client version]:                     #client-version
@@ -1493,6 +1494,7 @@ There are also some experimental API methods documented only by name:
 [Non-negative integer]:               #non-negative-integer
 [Priority]:                           #priority
 [Privilege levels]:                   #privilege-levels
+[Profile]:                            https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Architecture.md#profile
 [Profile name]:                       #profile-name
 [Profile sections]:                   ../../configuration/backend.md#public-profiles-and-private-profiles-sections
 [Progress percentage]:                #progress-percentage
@@ -1503,7 +1505,7 @@ There are also some experimental API methods documented only by name:
 [Severity Level Definitions]:         ../../specifications/tests/SeverityLevelDefinitions.md
 [Severity level]:                     #severity-level
 [Test Cases]:                         ../../specifications/tests#list-of-defined-test-cases
-[Test Case Identifiers]:              ../../../internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
+[Test Case Identifiers]:              https://github.com/zonemaster/zonemaster/blob/master/docs/internal/templates/specifications/tests/TestCaseIdentifierSpecification.md
 [Test id]:                            #test-id
 [Test result]:                        #test-result
 [Timestamp]:                          #timestamp


### PR DESCRIPTION
## Purpose

This PR makes `mdbook build` automatically check for broken links.

## Context

This builds on #1249 so that one should be merged before this.

## Changes

 * The mdbook configuration is updated automatically check links, including web links.
 * Lots of broken links are fixed in order to make `mdbook build` work again.

## How to test this PR

Run `mdbook build` in the `docs/public` directory. (You need to have the mdbook-linkcheck plugin installed, as mentioned in the README.)