### PR TITLE
file mode 644 for tmpfiles.d/zonemaster.conf

### DIFF
--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -111,7 +111,7 @@ cd `perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")'`
 sudo install -v -m 755 -d /etc/zonemaster
 sudo install -v -m 640 -g zonemaster ./backend_config.ini /etc/zonemaster/
 sudo install -v -m 775 -g zonemaster -d /var/log/zonemaster
-sudo install -v -m 755 ./tmpfiles.conf /usr/lib/tmpfiles.d/zonemaster.conf
+sudo install -v -m 644 ./tmpfiles.conf /usr/lib/tmpfiles.d/zonemaster.conf
 sudo install -v -m 644 ./zm-rpcapi.service /etc/systemd/system/
 sudo install -v -m 644 ./zm-testagent.service /etc/systemd/system/
 ```
@@ -240,7 +240,7 @@ sudo install -v -m 775 -g zonemaster -d /var/log/zonemaster
 sudo install -v -m 640 -g zonemaster ./backend_config.ini /etc/zonemaster/
 sudo install -v -m 755 ./zm-rpcapi.lsb /etc/init.d/zm-rpcapi
 sudo install -v -m 755 ./zm-testagent.lsb /etc/init.d/zm-testagent
-sudo install -v -m 755 ./tmpfiles.conf /usr/lib/tmpfiles.d/zonemaster.conf
+sudo install -v -m 644 ./tmpfiles.conf /usr/lib/tmpfiles.d/zonemaster.conf
 ```
 
 > If this is an update of Zonemaster-Backend, you should remove any


### PR DESCRIPTION
## Purpose

The tmpfiles config file itself should just be `644` - no need for it to be executable.

## Changes

Very small change that updates two `install` commands in the documentation.
