### PR TITLE
Change supported way of extracting default profile in Engine

### DIFF
--- a/docs/public/configuration/backend.md
+++ b/docs/public/configuration/backend.md
@@ -306,10 +306,7 @@ Keys must not be duplicated between or within the sections, and the key
 
 There is a `default` profile that is special. It is always available even
 if not specified. If it is not explicitly mapped to a profile JSON file, it is implicitly
-mapped to the *Zonemaster Engine default profile*.
-
-The *Zonemaster Engine default profile* is created by what is specified in
-[Zonemaster::Engine::Profile] and by loading the [Default JSON profile file].
+mapped to the [Zonemaster Engine default profile].
 
 Each profile JSON file contains a (possibly empty) set of overrides to
 the *Zonemaster Engine default profile*. Specifying a profile JSON file
@@ -382,7 +379,6 @@ Otherwise a new test request is enqueued.
 
 [API documentation]:                  ../using/backend/api.md
 [DBD::mysql documentation]:           https://metacpan.org/pod/DBD::mysql#host
-[Default JSON profile file]:          https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
 [Environement Variables]:             backend-environment-variables.md
 [File format]:                        https://metacpan.org/pod/Config::IniFiles#FILE-FORMAT
 [ISO 3166-1 alpha-2]:                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
@@ -406,3 +402,4 @@ Otherwise a new test request is enqueued.
 [US ASCII printable characters]:      https://en.wikipedia.org/wiki/ASCII#Printable_characters
 [Zonemaster-Engine share directory]:  https://github.com/zonemaster/zonemaster-engine/tree/master/share
 [Zonemaster::Engine::Profile]:        https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
+[Zonemaster Engine default profile]:  profiles.md#default-profile

--- a/docs/public/configuration/global-cache.md
+++ b/docs/public/configuration/global-cache.md
@@ -69,14 +69,14 @@ To be added.
 
 ### Debian and Ubuntu
 ```
-test -d /etc/zonemaster  || sudo mkdir -v /etc/zonemaster
-sudo cp -v $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Engine")')/profile.json /etc/zonemaster
+test -d /etc/zonemaster || sudo mkdir -v /etc/zonemaster
+perl -MZonemaster::Engine::Test -E 'say Zonemaster::Engine::Profile->default->to_json' | jq -S . | sudo tee /etc/zonemaster/profile.json > /dev/null
 ```
 
 ### FreeBSD
 ```
-test -d /usr/local/etc/zonemaster  || mkdir -v /usr/local/etc/zonemaster
-cp -v $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Engine")')/profile.json /usr/local//etc/zonemaster
+test -d /usr/local/etc/zonemaster || mkdir -v /usr/local/etc/zonemaster
+perl -MZonemaster::Engine::Test -E 'say Zonemaster::Engine::Profile->default->to_json' | jq -S . > /usr/local/etc/zonemaster/profile.json
 ```
 
 ## Enable global cache

--- a/docs/public/configuration/profiles.md
+++ b/docs/public/configuration/profiles.md
@@ -5,8 +5,11 @@
 The default profile is documented in the [profile properties] section
 of the Zonemaster::Engine::Profile module.
 
-The default profile is stored in a default profile file, [profile.json],
-always loaded by Zonemaster-Engine.
+The default profile can be extracted from Zonemaster-Engine to a file using this command.
+
+```sh
+perl -MZonemaster::Engine::Test -E 'say Zonemaster::Engine::Profile->default->to_json' | jq -S . > profile.json
+```
 
 ## Creating profiles
 
@@ -19,14 +22,9 @@ The content of the two files, as-is or modified, can be merged into a custom
 profile file that can be loaded by Zonemaster-Engine. Both Zonemaster-CLI and
 Zonemaster-Backend have direct options for loading a custom profile file.
 
-A custom profile file only has to contain those properties that are changed
-in comparison to the default profile file.
-
-You are adviced not to modify the default profile file in the default path on
-installed Zonemaster, since such modifications will be overwritten by updates
-of Zonemaster.
+A custom profile file only has to contain those [properties][profile properties]
+that it should override.
 
 
-[profile.json]:                        https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
 [profile_additional_properties.json]:  https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile_additional_properties.json
 [Profile properties]:                  https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES


### PR DESCRIPTION
## Purpose

This PR replaces the supported method of extracting the default profile from Zonemaster Engine.

## Context

Together with zonemaster/zonemaster-engine#1339 this PR fixes zonemaster/zonemaster-engine#1333, which is a step towards zonemaster/zonemaster-engine#1337.

## Changes

This is a breaking change in Zonemaster Engine because it removes the installed `profile.json` file from the public interface. Instead of copying or inspecting this file directly, users are instructed to extract it from Zonemaster::Engine.

## How to test this PR

Test the commands to extract the default profile in `docs/public/configuration/profiles.md` and `docs/public/configuration/global-cache.md`.