### PR TITLE
Update ubuntu node.js build environment doc

### DIFF
--- a/docs/internal/distrib-testing/Ubuntu-Node.js-build-environment.md
+++ b/docs/internal/distrib-testing/Ubuntu-Node.js-build-environment.md
@@ -9,7 +9,7 @@ Node.js and npm are available from the [Node.js] official website. The required
 Node.js version is 18. The process has been tested on Ubuntu 22.04, which we use
 here.
 
-1. Make a clean installation of Ubuntu 20.04.
+1. Make a clean installation of Ubuntu 22.04.
 
 2. Update the package database.
    ```sh


### PR DESCRIPTION
## Purpose

In one place (three lines up) it says version "22.04" but in the second "20.04". I think it should be "22.04" in both places.

## How to test this PR

Review.
