### PR TITLE
Install DBD::SQLite from CPAN on Rocky 8

### DIFF
--- a/docs/public/installation/zonemaster-backend.md
+++ b/docs/public/installation/zonemaster-backend.md
@@ -89,6 +89,12 @@ Install dependencies not available from binary packages:
 sudo cpanm --notest Daemon::Control JSON::RPC JSON::Validator Log::Any Log::Any::Adapter::Dispatch Net::IP::XS Router::Simple Starman
 ```
 
+For Rocky Linux 8 only, install DBD::SQLite from CPAN as the one in the system packages repository is too old:
+
+```sh
+sudo cpanm --notest DBD::SQLite
+```
+
 Install Zonemaster::Backend:
 
 ```sh


### PR DESCRIPTION
## Purpose

This PR updates the installation instruction so that only Zonemaster::CLI and no dependencies are installed by the cpanm Zonemaster::CLI command on Rocky 8.

## Context

Partial fix for zonemaster/zonemaster-backend#1172

## Changes

The installation instruction for Zonemaster CLI on Rocky Linux is updated.

## How to test this PR

Follow the installation instruction for Rocky and examine the output of the cpanm Zonemaster::CLI command and make sure that it doesn't include anything about other dependencies being installed.