### PR TITLE
Lowers the level of the ASN lookup related messages in Connectivity03

### DIFF
--- a/docs/public/specifications/tests/Connectivity-TP/connectivity03.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity03.md
@@ -72,8 +72,8 @@ In other cases the outcome of this Test Case is "pass".
 
 Message            |Default severity level
 :------------------|:------------
-EMPTY_ASN_SET      |ERROR
-ERROR_ASN_DATABASE |ERROR
+EMPTY_ASN_SET      |NOTICE
+ERROR_ASN_DATABASE |NOTICE
 IPV4_ONE_ASN       |WARNING
 IPV4_SAME_ASN      |NOTICE
 IPV4_DIFFERENT_ASN |INFO


### PR DESCRIPTION
## Purpose

There are two messages from Connectivity03 that are related to the ASN lookup database rather than the domain name (zone) tested. Those two messages have too high level (ERROR) and that does not match ["Severity Level Definitions"](https://github.com/zonemaster/zonemaster/blob/master/docs/public/specifications/tests/SeverityLevelDefinitions.md). By this PR the level is lowered to NOTICE.

If this PR is approved then the default level in the implementation must be changed in Zonemaster-Engine.

## Changes

Default level of messages (message tags).

## How to test this PR

Review. 