### PR TITLE
Updates Connectivity04

### DIFF
--- a/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
@@ -178,10 +178,10 @@ origin6.asnlookup.zonemaster.net
       extract the subnet specification.
       1. If it was not possible to parse the string, ignore it and go to next TXT
          record.
-   4. If *Input IP* does not match the extracted subnet, output
+   3. If *Input IP* does not match the extracted subnet, output
       *[CN04_ERROR_PREFIX_DATABASE]*, break the processing of TXT records and
       exit this loop without returning any prefix.
-   5. Store the extracted prefix.
+   4. Store the extracted prefix.
 
 10. If more than one IP prefix was stored from the loop above, keep the most
     specific and discard the rest.

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
@@ -176,16 +176,19 @@ origin6.asnlookup.zonemaster.net
       the strings into one string.
    2. Using the format of such string parse the string into its parts and
       extract the subnet specification.
-      1. If it was not possible to parse the string, output
-         *[CN04_ERROR_PREFIX_DATABASE]* and go to next TXT record.
-   4. If *Input IP* does not match the subnet output
-      *[CN04_ERROR_PREFIX_DATABASE]* and go to next TXT record.
+      1. If it was not possible to parse the string, ignore it and go to next TXT
+         record.
+   4. If *Input IP* does not match the extracted subnet, output
+      *[CN04_ERROR_PREFIX_DATABASE]*, break the processing of TXT records and
+      exit this loop without returning any prefix.
    5. Store the extracted prefix.
 
 10. If more than one IP prefix was stored from the loop above, keep the most
     specific and discard the rest.
 
-11. Return the IP prefix, or an empty string if no IP prefix was extracted.
+11. If no IP prefix was stored, output *[CN04_EMPTY_PREFIX_SET]*.
+
+12. Return the IP prefix, or an empty string if no IP prefix was stored.
 
 
 ### RIPE prefix lookup

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
@@ -52,10 +52,10 @@ CN04_EMPTY_PREFIX_SET       | NOTICE  | ns_ip                       | Prefix dat
 CN04_ERROR_PREFIX_DATABASE  | NOTICE  | ns_ip                       | Prefix database error for IP address {ns_ip}.
 CN04_IPV4_DIFFERENT_PREFIX  | INFO    | ns_list                     | The following name server(s) are announced in unique IPv4 prefix(es): "{ns_list}"
 CN04_IPV4_SAME_PREFIX       | NOTICE  | ns_list, ip_prefix          | The following name server(s) are announced in the same IPv4 prefix ({ip_prefix}): "{ns_list}"
-CN04_IPV4_SINGLE_PREFIX     | WARNING |                             | All name server(s) (IPv4) are announced in the same IPv4 prefix.
+CN04_IPV4_SINGLE_PREFIX     | WARNING |                             | All name server(s) IPv4 address(es) are announced in the same IPv4 prefix.
 CN04_IPV6_DIFFERENT_PREFIX  | INFO    | ns_list                     | The following name server(s) are announced in unique IPv6 prefix(es): "{ns_list}"
 CN04_IPV6_SAME_PREFIX       | NOTICE  | ns_list, ip_prefix          | The following name server(s) are announced in the same IPv6 prefix ({ip_prefix}): "{ns_list}"
-CN04_IPV6_SINGLE_PREFIX     | WARNING |                             | All name server(s) (IPv6) are announced in the same IPv6 prefix.
+CN04_IPV6_SINGLE_PREFIX     | WARNING |                             | All name server(s) IPv6 address(es) are announced in the same IPv6 prefix.
 
 The value in the Level column is the default severity level of the message. The
 severity level can be changed in the [Zonemaster-Engine Profile]. Also see the

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
@@ -99,8 +99,8 @@ message. The argument names are defined in the [Argument List].
    2. For each IP prefix in the set that have exactly one member, output
       *[CN04_IPV6_DIFFERENT_PREFIX]* with the combined set of their associated
       members (name server names and IP addresses).
-   3. If all members of *NS Ipv6* are members of the same IP prefix in
-      *Ipv6 Prefix* then output *[CN04_IPV6_SINGLE_PREFIX]*.
+   3. If all members of *NS IPv6* are members of the same IP prefix in
+      *IPv6 Prefix* then output *[CN04_IPV6_SINGLE_PREFIX]*.
 
 ## Outcome(s)
 
@@ -124,9 +124,9 @@ The *Child Zone* must be a valid name meeting
 
 ## Prefix lookup methods
 
-Use the prefix method set in *Prefix Database* in "Inputs" and the IP address
-in the call to this section. Refer to the appropriate section below with the
-IP address as input.
+Use the prefix method set in *Prefix Database* and the IP address in the call to
+this section. Refer to the appropriate section below with the IP address as
+input.
 
 ### Cymru prefix lookup
 
@@ -137,7 +137,7 @@ in England and Wales) and is continuously being mapped into
 <https://bgp.tools/table.txt>. The Cymru source can also be used, if
 requested.
 
-1. Input is the IP address in the call to this section.
+1. Input is the IP address in the call to this section ("Input IP").
 
 2. Prepend the *Cymru Base Name* with the label "origin" (IPv4) or
    "origin6" (IPv6) ("Expanded Base Name"). Example of expanded basenames :
@@ -147,9 +147,9 @@ origin.asnlookup.zonemaster.net
 origin6.asnlookup.zonemaster.net
 ```
 
-3. Reverse the IP address in the input with the same method as is used for
-   reverse lookup ("Reverse IP"). For description see [RFC 1035][RFC 1035#3.5],
-   section 3.5, for IPv4 and [RFC 3596][RFC 3596#2.5], section 2.5, for IPv6.
+3. Reverse *Input IP* with the same method as is used for reverse lookup
+   ("Reverse IP"). For description see [RFC 1035][RFC 1035#3.5], section 3.5, for
+   IPv4 and [RFC 3596][RFC 3596#2.5], section 2.5, for IPv6.
  
 4. Prepend the *Expanded Base Name* with *Reverse IP* ("Query Name").
    See [IP to ASN Mapping] for details.
@@ -178,7 +178,7 @@ origin6.asnlookup.zonemaster.net
       extract the subnet specification.
       1. If it was not possible to parse the string, output
          *[CN04_ERROR_PREFIX_DATABASE]* and go to next TXT record.
-   4. If the IP address in the input does not match the subnet output
+   4. If *Input IP* does not match the subnet output
       *[CN04_ERROR_PREFIX_DATABASE]* and go to next TXT record.
    5. Store the extracted prefix.
 
@@ -229,11 +229,11 @@ None
   7208, section 3.3][RFC7208#3.3].
 
 * "DNS Lookup" - The term is used when a recursive lookup is used, though
-any changes to the DNS tree introduced by an [undelegated test] must be
-respected. Compare with "[Send]".
+  any changes to the DNS tree introduced by an [undelegated test] must be
+  respected. Compare with "[Send]".
 
 * "Send" - The term "send" (to an IP address) is used when a DNS query is sent to
-a specific name server IP address. Compare with "[DNS Lookup]".
+  a specific name server IP address. Compare with "[DNS Lookup]".
 
 
 

--- a/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
+++ b/docs/public/specifications/tests/Connectivity-TP/connectivity04.md
@@ -86,7 +86,7 @@ message. The argument names are defined in the [Argument List].
    1. For each IP prefix in the set that has two or more members, output
       *[CN04_IPV4_SAME_PREFIX]* with the prefix and list of all members (name
       server names and IP addresses) for that prefix.
-   2. For each IP prefix in the set that have exactly one member, output
+   2. For all IP prefixes in the set that have exactly one member, output
       *[CN04_IPV4_DIFFERENT_PREFIX]* with the combined set of their associated
       members (name server names and IP addresses).
    3. If all members of *NS IPv4* are members of the same IP prefix in
@@ -96,7 +96,7 @@ message. The argument names are defined in the [Argument List].
    1. For each IP prefix in the set that has two or more members, output
       *[CN04_IPV6_SAME_PREFIX]* with the prefix and list of all members (name
       server names and IP addresses) for that prefix.
-   2. For each IP prefix in the set that have exactly one member, output
+   2. For all IP prefixes in the set that have exactly one member, output
       *[CN04_IPV6_DIFFERENT_PREFIX]* with the combined set of their associated
       members (name server names and IP addresses).
    3. If all members of *NS IPv6* are members of the same IP prefix in


### PR DESCRIPTION
## Purpose

The test case outputs a warning if more than one name server has its IP address on the same prefix even if other name servers has IP addresses on other prefixes. This PR lower that warning to a notice. To capture the case when all name servers has IP addresses in the prefix a new message tag has been added, and that tag has a warning level.

Today the test case will not capture the case when there is a single name server. That has been fixed.

If this PR is approved, test scenarios and updated implementation must be provided.

## Context

#1289, #1174, #1299

## How to test this PR

Review.