### PR TITLE
Updates CLI installation instruction

### DIFF
--- a/docs/public/installation/zonemaster-cli.md
+++ b/docs/public/installation/zonemaster-cli.md
@@ -45,7 +45,7 @@ Zonemaster::CLI, see the [declaration of prerequisites].
    sudo cpanm -n JSON::Validator
    ```
 
-> Note: Test::Deep Mojolicious are indirect dependencies. They are dependecies
+> Note: Test::Deep and Mojolicious are indirect dependencies. They are dependecies
 > of JSON::Validator
 
 2) Install Zonemaster::CLI

--- a/docs/public/installation/zonemaster-cli.md
+++ b/docs/public/installation/zonemaster-cli.md
@@ -38,7 +38,7 @@ Zonemaster::CLI, see the [declaration of prerequisites].
 1) Install binary dependencies:
 
    ```sh
-   sudo dnf install perl-JSON-XS perl-MooseX-Getopt perl-Try-Tiny
+   sudo dnf install perl-JSON-XS perl-Try-Tiny
    ```
 
 2) Install Zonemaster::CLI
@@ -86,7 +86,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 1) Install dependencies:
 
    ```sh
-   sudo apt-get install locales libmoosex-getopt-perl libmodule-install-perl libtry-tiny-perl
+   sudo apt-get install locales libmodule-install-perl libtry-tiny-perl
    ```
 
 2) Install Zonemaster::CLI:
@@ -123,7 +123,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 2) Install dependencies available from binary packages:
 
    ```sh
-   pkg install devel/gmake p5-JSON-XS p5-Locale-libintl p5-MooseX-Getopt p5-Try-Tiny
+   pkg install devel/gmake p5-JSON-XS p5-Locale-libintl p5-Try-Tiny
    ```
 
 3) Install Zonemaster::CLI:

--- a/docs/public/installation/zonemaster-cli.md
+++ b/docs/public/installation/zonemaster-cli.md
@@ -42,11 +42,11 @@ Zonemaster::CLI, see the [declaration of prerequisites].
    ```
 
    ```sh
-   sudo cpanm -n JSON::Validator
+   sudo cpanm --notest JSON::Validator
    ```
 
-> Note: Test::Deep and Mojolicious are indirect dependencies. They are dependecies
-> of JSON::Validator
+> Note: Test::Deep and Mojolicious are indirect dependencies. They are dependencies
+> of JSON::Validator.
 
 2) Install Zonemaster::CLI
 
@@ -99,7 +99,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 2) Install Zonemaster::CLI:
 
    ```sh
-   sudo cpanm -n Zonemaster::CLI
+   sudo cpanm --notest Zonemaster::CLI
    ```
 3) Update configuration of "locale"
 
@@ -136,7 +136,7 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 3) Install Zonemaster::CLI:
 
    ```sh
-   cpanm -n Zonemaster::CLI
+   cpanm --notest Zonemaster::CLI
    ```
 
 ## Post-installation sanity check

--- a/docs/public/installation/zonemaster-cli.md
+++ b/docs/public/installation/zonemaster-cli.md
@@ -41,6 +41,13 @@ Zonemaster::CLI, see the [declaration of prerequisites].
    sudo dnf install perl-JSON-XS perl-Try-Tiny
    ```
 
+   ```sh
+   sudo cpanm -n JSON::Validator
+   ```
+
+> Is binary packet available for Rocky Linux (JSON::Validator)?
+
+
 2) Install Zonemaster::CLI
 
    ```sh
@@ -86,13 +93,13 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 1) Install dependencies:
 
    ```sh
-   sudo apt-get install locales libmodule-install-perl libtry-tiny-perl
+   sudo apt-get install locales libmodule-install-perl libtry-tiny-perl libjson-validator-perl
    ```
 
 2) Install Zonemaster::CLI:
 
    ```sh
-   sudo cpanm Zonemaster::CLI
+   sudo cpanm -n Zonemaster::CLI
    ```
 3) Update configuration of "locale"
 
@@ -123,13 +130,13 @@ Using pre-built packages is the preferred method for Debian and Ubuntu.
 2) Install dependencies available from binary packages:
 
    ```sh
-   pkg install devel/gmake p5-JSON-XS p5-Locale-libintl p5-Try-Tiny
+   pkg install gmake p5-JSON-XS p5-Locale-libintl p5-Try-Tiny p5-JSON-Validator
    ```
 
 3) Install Zonemaster::CLI:
 
    ```sh
-   cpanm Zonemaster::CLI
+   cpanm -n Zonemaster::CLI
    ```
 
 ## Post-installation sanity check

--- a/docs/public/installation/zonemaster-cli.md
+++ b/docs/public/installation/zonemaster-cli.md
@@ -35,18 +35,18 @@ Zonemaster::CLI, see the [declaration of prerequisites].
 
 ### Installation on Rocky Linux
 
-1) Install binary dependencies:
+1) Install dependencies:
 
    ```sh
-   sudo dnf install perl-JSON-XS perl-Try-Tiny
+   sudo dnf install perl-JSON-XS perl-Try-Tiny perl-Test-Deep perl-Mojolicious
    ```
 
    ```sh
    sudo cpanm -n JSON::Validator
    ```
 
-> Is binary packet available for Rocky Linux (JSON::Validator)?
-
+> Note: Test::Deep Mojolicious are indirect dependencies. They are dependecies
+> of JSON::Validator
 
 2) Install Zonemaster::CLI
 


### PR DESCRIPTION
## Purpose

1. Moose has been removed from CLI, which means that it is no longer a dependency.
2. JSON::Validator is a new dependency.
3. User installation should be done without testing, by default.

## Context

1. https://github.com/zonemaster/zonemaster-cli/pull/371

## How to test this PR

1. Review
4. Use the instruction and verify
   1. that no extra dependencies are pulled in by `cpanm` from CPAN
   2. that CLI works.
