### PR TITLE
Documentation : Rocky Linux 8 locales installation instruction

### DIFF
--- a/docs/public/installation/zonemaster-engine.md
+++ b/docs/public/installation/zonemaster-engine.md
@@ -33,7 +33,10 @@
 3) Install locales:
 
    ```sh
+   # For Rocky Linux 9
    sudo dnf install --assumeyes glibc-all-langpacks
+   # For Rocky Linux 8
+   sudo dnf --assumeyes install langpacks-da.noarch langpacks-en.noarch langpacks-es.noarch langpacks-fi.noarch langpacks-fr.noarch langpacks-nb.noarch  langpacks-sv.noarch
    ```
 
 4) Install binary packages:


### PR DESCRIPTION
## Purpose

Add locale installation instructions for Rocky Linux 8

## Context

Fixes #1325 

## Changes

Add instruction to correctly install locales for Rocky Linux 8

## How to test this PR

Install zonemaster-{ldns, engine, cli} on Rocky Linux 8 and run a test with another locale:
```
$ zonemaster-cli --test basic zonemaster.net --locale=da_DK.UTF-8
```
there should be no error like this:

```
Warning: setting locale category LC_MESSAGES to da_DK.UTF-8 failed -- is it installed on this system?
Warning: setting locale category LC_CTYPE to da_DK.UTF-8 failed -- is it installed on this system?
```
