### PR TITLE
Update mdbook configuration

### DIFF
--- a/docs/README-for-doc.zonemaster.net.md
+++ b/docs/README-for-doc.zonemaster.net.md
@@ -49,5 +49,5 @@ The public documentation is divided into the following main categories:
 [The Swedish Internet Foundation]:                  https://internetstiftelsen.se/en/
 [Zonemaster.net]:                                   https://zonemaster.net
 
-<!-- Location on doc.zonemaster.net: --> 
+<!-- Location on doc.zonemaster.net: -->
 [Zonemaster-logo]:                                  ../zonemaster_logo_2021_color.png

--- a/docs/public/book.toml
+++ b/docs/public/book.toml
@@ -4,6 +4,10 @@ description = "Zonemaster documentation"
 language = "en"
 src = "./"
 
+[build]
+create-missing = false
+use-default-preprocessors = false
+
 [output.html]
 no-section-label = true
 
@@ -11,7 +15,9 @@ no-section-label = true
 enable = true
 level = 1
 
-[preprocessor.index]
-
 [output.linkcheck]
+optional = true
+warning-policy= "warn"
 follow-web-links = false
+traverse-parent-directories = false
+exclude = [ 'SUMMARY.md', 'LICENSE.md', 'zonemaster_logo_2021_color.png', 'localhost' ]


### PR DESCRIPTION
## Purpose

This PR proposes to explicitly set many configuration options for the mdbook generation. See commit message(s) for an explanation of each option.

## Context

Follow-up on v2024.2.1 release

## Changes

- `docs/public/book.toml`

## How to test this PR

Locally serving the book in `docs/public` should work without warnings/errors :
```
$ cd docs/public; rm -rf book && mdbook serve
2025-03-11 15:28:47 [INFO] (mdbook::book): Book building has started
2025-03-11 15:28:47 [INFO] (mdbook::book): Running the html backend
2025-03-11 15:28:48 [INFO] (mdbook::book): Running the linkcheck backend
2025-03-11 15:28:48 [INFO] (mdbook::renderer): Invoking the "linkcheck" renderer
2025-03-11 15:28:48 [INFO] (mdbook::cmd::serve): Serving on: http://localhost:3000
2025-03-11 15:28:48 [INFO] (warp::server): Server::run; addr=127.0.0.1:3000
2025-03-11 15:28:48 [INFO] (warp::server): listening on http://127.0.0.1:3000
2025-03-11 15:28:48 [INFO] (mdbook::cmd::watch): Listening for changes...
```
Also, `mdbook-linkcheck` should not complain and present an empty output:
`$ mdbook-linkcheck -s --no-cache`

Finally, I've tested and deployed it on https://doc.zonemaster.net using https://gitlab.rd.nic.fr/zonemaster/zonemaster-docs/-/blob/55ea0cb1143c3c9a8f78feeb4051a14ef3bf9beb/build.sh.