### PR TITLE
Update CNAME test scenarios

### DIFF
--- a/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
+++ b/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
@@ -47,8 +47,9 @@ TOO-LONG-CNAME-CHAIN         | Undefined and tags `CNAME_START`, `CNAME_CHAIN_TO
 TOO-MANY-CNAME               | Undefined and tags `CNAME_START`, `CNAME_RECORDS_TOO_MANY`
 TARGET-NO-MATCH-CNAME        | Undefined and tags `CNAME_START`, `CNAME_NO_MATCH`
 BROKEN-CNAME-CHAIN           | Undefined and tags `CNAME_START`, `CNAME_RECORDS_CHAIN_BROKEN`
-WRONG-CNAME-OWNER-NAME       | False and no tags
-EXTRA-CNAME-IN-ANSWER        | False and no tags
+WRONG-CNAME-OWNER-NAME       | True and no tags
+EXTRA-CNAME-IN-ANSWER        | True and no tags
+CNAME-CHAIN-TO-NODATA        | True and tags `CNAME_START`, `CNAME_TO_NODATA`
 UNRESOLVABLE-CNAME           | Undefined and tags `CNAME_START`, `CNAME_UNRESOLVABLE`
 
 ## Zone setup for test scenarios
@@ -279,12 +280,14 @@ above the limit.
 
 ### TARGET-NO-MATCH-CNAME
 The CNAME target name does not match the owner name of the `A` record.
+Note that this scenario also purposefully use varying case in names for
+additionnal testing purposes, but it is not strictly needed.
 
 * Query name: "target-no-match-cname.cname.recursor.engine.xa"
   * To be found in the answer section:
 ```
-   target-no-match-cname         CNAME  target-no-match-cname-two
-   target-no-match-cname-target  A      127.0.0.1
+   TARGET-no-match-cname         CNAME  target-NO-match-cname-two
+   target-no-MATCH-cname-target  A      127.0.0.1
 ```
 
 ### BROKEN-CNAME-CHAIN
@@ -333,10 +336,12 @@ cname-chain-to-nodata            CNAME target.cname-chain-to-nodata
     gives a NODATA response
 
 ### UNRESOLVABLE-CNAME
-The target in the CNAME record can not be resolved because
-of an issue with the zone.
-Currently this scenario considers a FORMERR response to an
-in-bailiwick CNAME target name.
+The target in the CNAME record can not be resolved due to a resolution failure
+with the name servers of the zone.
+This scenario involves a FORMERR response to a query for the target of a CNAME
+resource record when the target is a subdomain of the resource record’s owner name.
+It purposefully considers a FORMERR response (as opposed to e.g. SERVFAIL) as this is
+required to trigger the behavior in Zonemaster's recursive lookup implementation.
 
 * Query name: "unresolvable-cname.cname.recursor.engine.xa"
   * To be found in the answer section:

--- a/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
+++ b/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
@@ -43,11 +43,13 @@ LOOPED-CNAME-IN-ZONE-1       | Undefined and tags `CNAME_START`, `CNAME_LOOP_INN
 LOOPED-CNAME-IN-ZONE-2       | Undefined and tags `CNAME_START`, `CNAME_LOOP_INNER`
 LOOPED-CNAME-IN-ZONE-3       | Undefined and tags `CNAME_START`, `CNAME_LOOP_INNER`
 LOOPED-CNAME-OUT-OF-ZONE     | Undefined and tags `CNAME_START`, `CNAME_LOOP_OUTER`
-TOO-LONG-CNAME-CHAIN         | Undefined and tags `CNAME_START`, `CNAME_RECORDS_TOO_MANY`
+TOO-LONG-CNAME-CHAIN         | Undefined and tags `CNAME_START`, `CNAME_CHAIN_TOO_LONG`
+TOO-MANY-CNAME               | Undefined and tags `CNAME_START`, `CNAME_RECORDS_TOO_MANY`
 TARGET-NO-MATCH-CNAME        | Undefined and tags `CNAME_START`, `CNAME_NO_MATCH`
 BROKEN-CNAME-CHAIN           | Undefined and tags `CNAME_START`, `CNAME_RECORDS_CHAIN_BROKEN`
 WRONG-CNAME-OWNER-NAME       | False and no tags
 EXTRA-CNAME-IN-ANSWER        | False and no tags
+UNRESOLVABLE-CNAME           | Undefined and tags `CNAME_START`, `CNAME_UNRESOLVABLE`
 
 ## Zone setup for test scenarios
 
@@ -249,23 +251,29 @@ and the target name of the second CNAME record will point at the first.
 ```
 
 ### TOO-LONG-CNAME-CHAIN
+The query name will follow a CNAME chain and reach the maximum lookup limit
+in different, unique zones.
+
+* Query name: "too-long-cname-chain.sub2.cname.recursor.engine.xa"
+
+### TOO-MANY-CNAME
 The query name will resolve to one `A` record via ten CNAME records which is
 above the limit.
 
-* Query name: "too-long-cname-chain.cname.recursor.engine.xa"
+* Query name: "too-many-cname.cname.recursor.engine.xa"
   * To be found in the answer section:
 ```
-   too-long-cname-chain              CNAME too-long-cname-chain-two
-   too-long-cname-chain-two          CNAME too-long-cname-chain-three
-   too-long-cname-chain-three        CNAME too-long-cname-chain-four
-   too-long-cname-chain-four         CNAME too-long-cname-chain-five
-   too-long-cname-chain-five         CNAME too-long-cname-chain-six
-   too-long-cname-chain-six          CNAME too-long-cname-chain-seven
-   too-long-cname-chain-seven        CNAME too-long-cname-chain-eight
-   too-long-cname-chain-eight        CNAME too-long-cname-chain-nine
-   too-long-cname-chain-nine         CNAME too-long-cname-chain-ten
-   too-long-cname-chain-ten          CNAME too-long-cname-chain-target
-   too-long-cname-chain-target       A     127.0.0.1
+   too-many-cname              CNAME too-many-cname-two
+   too-many-cname-two          CNAME too-many-cname-three
+   too-many-cname-three        CNAME too-many-cname-four
+   too-many-cname-four         CNAME too-many-cname-five
+   too-many-cname-five         CNAME too-many-cname-six
+   too-many-cname-six          CNAME too-many-cname-seven
+   too-many-cname-seven        CNAME too-many-cname-eight
+   too-many-cname-eight        CNAME too-many-cname-nine
+   too-many-cname-nine         CNAME too-many-cname-ten
+   too-many-cname-ten          CNAME too-many-cname-target
+   too-many-cname-target       A     127.0.0.1
 ```
 
 ### TARGET-NO-MATCH-CNAME
@@ -312,6 +320,11 @@ besides the `A` record matching query name.
    extra-cname-in-answer-1       CNAME extra-cname-in-answer-2
 ```
 
+### UNRESOLVABLE-CNAME
+The target in the CNAME record can not be resolved because
+of an unidentified issue with the zone.
+
+* Query name: "unresolvable-cname.cname.recursor.engine.xa"
 
 
 [RCODE Name]:                                                     https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6

--- a/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
+++ b/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
@@ -320,17 +320,30 @@ besides the `A` record matching query name.
    extra-cname-in-answer-1       CNAME extra-cname-in-answer-2
 ```
 
+### CNAME-CHAIN-TO-NODATA
+There is a NODATA response for an in-bailiwick CNAME target name.
+
+* Query name: "unresolvable-cname.cname.recursor.engine.xa"
+  * To be found in the answer section:
+```
+cname-chain-to-nodata            CNAME target.cname-chain-to-nodata
+```
+  * The CNAME target "target.cname-chain-to-nodata..cname.recursor.engine.xa"
+    gives a NODATA response
+
 ### UNRESOLVABLE-CNAME
 The target in the CNAME record can not be resolved because
 of an issue with the zone.
+Currently this scenario considers a FORMERR response to an
+in-bailiwick CNAME target name.
 
 * Query name: "unresolvable-cname.cname.recursor.engine.xa"
   * To be found in the answer section:
 ```
 unresolvable-cname            CNAME target.unresolvable-cname
-*.target.unresolvable-cname   TXT   "Breaks"
 ```
-
+  * The CNAME target "target.unresolvable-cname.cname.recursor.engine.xa"
+    gives a FORMERR response
 
 [RCODE Name]:                                                     https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 [Test zone README file]:                                          ../../README.md

--- a/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
+++ b/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
@@ -63,6 +63,7 @@ specific scenario:
 * In the zone, the query name always has a `CNAME` record.
 * The zone is set up on one NS, ns1.
 * The [RCODE Name] in the response is NoError.
+* The maximum lookup limit is set to 10.
 
 ### GOOD-CNAME-1
 The query name will resolve to one `A` record via one CNAME.

--- a/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
+++ b/docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
@@ -322,9 +322,14 @@ besides the `A` record matching query name.
 
 ### UNRESOLVABLE-CNAME
 The target in the CNAME record can not be resolved because
-of an unidentified issue with the zone.
+of an issue with the zone.
 
 * Query name: "unresolvable-cname.cname.recursor.engine.xa"
+  * To be found in the answer section:
+```
+unresolvable-cname            CNAME target.unresolvable-cname
+*.target.unresolvable-cname   TXT   "Breaks"
+```
 
 
 [RCODE Name]:                                                     https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6

--- a/test-zone-data/Engine/Recursor-PM/README.md
+++ b/test-zone-data/Engine/Recursor-PM/README.md
@@ -598,70 +598,72 @@ cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa.
 
 Scenario name                | Expected output
 :----------------------------|:---------------------------------------------------------------------------------------------
-TARGET-NO-MATCH-CNAME        | ??
+TARGET-NO-MATCH-CNAME        | Undefined and tags `CNAME_START`, `CNAME_NO_MATCH`
 ```
-; <<>> DiG 9.18.18-0ubuntu0.22.04.1-Ubuntu <<>> @127.30.1.31 target-no-match-cname.cname.recursor.engine.xa
+; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> @127.30.1.31 target-no-match-cname.cname.recursor.engine.xa
 ; (1 server found)
 ;; global options: +cmd
 ;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 51040
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 22052
 ;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 1
 ;; WARNING: recursion requested but not available
 
 ;; OPT PSEUDOSECTION:
 ; EDNS: version: 0, flags:; udp: 1232
-; COOKIE: 51f0cfb680ea5015 (echoed)
+; COOKIE: 117ae2814d65858a (echoed)
 ;; QUESTION SECTION:
-;target-no-match-cname.cname.recursor.engine.xa.	IN A
+;target-no-match-cname.cname.recursor.engine.xa.        IN A
 
 ;; ANSWER SECTION:
-target-no-match-cname.cname.recursor.engine.xa.	3600 IN	CNAME target-no-match-cname-two.cname.recursor.engine.xa.
-target-no-match-cname-target.cname.recursor.engine.xa. 3600 IN A 127.0.0.1
+TARGET-no-match-cname.cname.recursor.engine.xa. 3600 IN CNAME target-NO-match-cname-two.cname.recursor.engine.xa.
+target-no-MATCH-cname-target.cname.recursor.engine.xa. 3600 IN A 127.0.0.1
 
 ;; AUTHORITY SECTION:
-cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa.
+cname.recursor.engine.xa. 3600  IN      NS      ns1.cname.recursor.engine.xa.
 
 ;; Query time: 0 msec
 ;; SERVER: 127.30.1.31#53(127.30.1.31) (UDP)
-;; WHEN: Thu Nov 30 16:40:31 UTC 2023
-;; MSG SIZE  rcvd: 332
+;; WHEN: Tue Sep 01 18:52:24 CEST 2026
+;; MSG SIZE  rcvd: 33
 ```
 --> OK
 
 Scenario name                | Expected output
 :----------------------------|:---------------------------------------------------------------------------------------------
-BROKEN-CNAME-CHAIN           | ??
+BROKEN-CNAME-CHAIN           | Undefined and tags `CNAME_START`, `CNAME_RECORDS_CHAIN_BROKEN`
 ```
-; <<>> DiG 9.18.18-0ubuntu0.22.04.1-Ubuntu <<>> @127.30.1.31 target-no-match-cname.cname.recursor.engine.xa
+; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> @127.30.1.31 broken-cname-chain.cname.recursor.engine.xa
 ; (1 server found)
 ;; global options: +cmd
 ;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 51040
-;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 1
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 9666
+;; flags: qr aa rd; QUERY: 1, ANSWER: 3, AUTHORITY: 1, ADDITIONAL: 1
 ;; WARNING: recursion requested but not available
 
 ;; OPT PSEUDOSECTION:
 ; EDNS: version: 0, flags:; udp: 1232
-; COOKIE: 51f0cfb680ea5015 (echoed)
+; COOKIE: a0c57dba78ac60f0 (echoed)
 ;; QUESTION SECTION:
-;target-no-match-cname.cname.recursor.engine.xa.	IN A
+;broken-cname-chain.cname.recursor.engine.xa. IN        A
 
 ;; ANSWER SECTION:
-target-no-match-cname.cname.recursor.engine.xa.	3600 IN	CNAME target-no-match-cname-two.cname.recursor.engine.xa.
-target-no-match-cname-target.cname.recursor.engine.xa. 3600 IN A 127.0.0.1
+broken-cname-chain.cname.recursor.engine.xa. 3600 IN CNAME broken-cname-chain-two.cname.recursor.engine.xa.
+broken-cname-chain-three.cname.recursor.engine.xa. 3600 IN CNAME broken-cname-chain-target.cname.recursor.engine.xa.
+broken-cname-chain-target.cname.recursor.engine.xa. 3600 IN A 127.0.0.1
 
 ;; AUTHORITY SECTION:
-cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa.
+cname.recursor.engine.xa. 3600  IN      NS      ns1.cname.recursor.engine.xa.
 
 ;; Query time: 0 msec
 ;; SERVER: 127.30.1.31#53(127.30.1.31) (UDP)
-;; WHEN: Thu Nov 30 16:40:31 UTC 2023
-;; MSG SIZE  rcvd: 332
+;; WHEN: Tue Sep 01 18:51:42 CEST 2026
+;; MSG SIZE  rcvd: 43
 ```
+--> OK
 
 Scenario name                | Expected output
 :----------------------------|:---------------------------------------------------------------------------------------------
-WRONG-CNAME-OWNER-NAME       | ??
+WRONG-CNAME-OWNER-NAME       | True and no tags
 ```
 ; <<>> DiG 9.18.18-0ubuntu0.22.04.1-Ubuntu <<>> @127.30.1.31 wrong-cname-owner-name.cname.recursor.engine.xa
 ; (1 server found)
@@ -693,38 +695,39 @@ cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa.
 
 Scenario name                | Expected output
 :----------------------------|:---------------------------------------------------------------------------------------------
-EXTRA-CNAME-IN-ANSWER        | ??
+EXTRA-CNAME-IN-ANSWER        | True and no tags
 ```
-; <<>> DiG 9.18.18-0ubuntu0.22.04.1-Ubuntu <<>> @127.30.1.31 wrong-cname-owner-name.cname.recursor.engine.xa
+; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> @127.30.1.31 extra-cname-in-answer.cname.recursor.engine.xa
 ; (1 server found)
 ;; global options: +cmd
 ;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 18339
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 43314
 ;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 1
 ;; WARNING: recursion requested but not available
 
 ;; OPT PSEUDOSECTION:
 ; EDNS: version: 0, flags:; udp: 1232
-; COOKIE: f300bad89af70d8b (echoed)
+; COOKIE: 3225679dbd4a891e (echoed)
 ;; QUESTION SECTION:
-;wrong-cname-owner-name.cname.recursor.engine.xa. IN A
+;extra-cname-in-answer.cname.recursor.engine.xa.        IN A
 
 ;; ANSWER SECTION:
-wrong-cname-owner-name-1.cname.recursor.engine.xa. 3600	IN CNAME wrong-cname-owner-name-target.cname.recursor.engine.xa.
-wrong-cname-owner-name-target.cname.recursor.engine.xa.	3600 IN	A 127.0.0.1
+extra-cname-in-answer.cname.recursor.engine.xa. 3600 IN A 127.0.0.1
+extra-cname-in-answer-1.cname.recursor.engine.xa. 3600 IN CNAME extra-cname-in-answer-2.cname.recursor.engine.xa.
 
 ;; AUTHORITY SECTION:
-cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa.
+cname.recursor.engine.xa. 3600  IN      NS      ns1.cname.recursor.engine.xa.
 
 ;; Query time: 0 msec
 ;; SERVER: 127.30.1.31#53(127.30.1.31) (UDP)
-;; WHEN: Fri Dec 01 11:07:20 UTC 2023
-;; MSG SIZE  rcvd: 341
+;; WHEN: Tue Sep 01 18:55:28 CEST 2026
+;; MSG SIZE  rcvd: 32
 ```
+--> OK
 
 Scenario name                | Expected output
 :----------------------------|:---------------------------------------------------------------------------------------------
-CNAME-CHAIN-TO-NODATA              | True and tag `CNAME_TO_NODATA`
+CNAME-CHAIN-TO-NODATA        | True and tag `CNAME_TO_NODATA`
 ```
 ; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> cname-chain-to-nodata.cname.recursor.engine.xa @127.30.1.31
 ;; global options: +cmd
@@ -750,6 +753,7 @@ cname.recursor.engine.xa. 3600  IN      NS      ns1.cname.recursor.engine.xa.
 ;; WHEN: Tue Jun 09 17:18:47 CEST 2026
 ;; MSG SIZE  rcvd: 266
 ```
+--> OK
 
 Scenario name                | Expected output
 :----------------------------|:---------------------------------------------------------------------------------------------
@@ -798,6 +802,7 @@ cname.recursor.engine.xa. 3600  IN      NS      ns1.cname.recursor.engine.xa.
 ;; WHEN: Tue Jun 09 17:22:29 CEST 2026
 ;; MSG SIZE  rcvd: 9
 ```
+--> OK
 
 [CNAME.md]:                            ../../../docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
 [Recursor.pm]:                         https://github.com/zonemaster/zonemaster-engine/blob/master/lib/Zonemaster/Engine/Recursor.pm

--- a/test-zone-data/Engine/Recursor-PM/README.md
+++ b/test-zone-data/Engine/Recursor-PM/README.md
@@ -16,10 +16,12 @@ CNAME function in [Recursor.pm].
 * LOOPED-CNAME-IN-ZONE-3
 * LOOPED-CNAME-OUT-OF-ZONE
 * TOO-LONG-CNAME-CHAIN
+* TOO-MANY-CNAME
 * TARGET-NO-MATCH-CNAME
 * BROKEN-CNAME-CHAIN
 * WRONG-CNAME-OWNER-NAME
 * EXTRA-CNAME-IN-ANSWER
+* UNRESOLVABLE-CNAME
 
 See [CNAME.md] for specification of the scenarios.
 
@@ -519,13 +521,44 @@ sub3.cname.recursor.engine.xa. 3600 IN	NS	ns1.sub3.cname.recursor.engine.xa.
 ```
 --> OK
 
+Scenario name                | Expected output
+:----------------------------|:---------------------------------------------------------------------------------------------
+TOO-LONG-CNAME-CHAIN         | Undefined and tag `CNAME_CHAIN_TOO_LONG`
 
+```
+; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> A @127.30.1.31 too-long-cname-chain.sub2.cname.recursor.engine.xa
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 13393
+;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 3
+;; WARNING: recursion requested but not available
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 1232
+; COOKIE: aec9669fb1897aae (echoed)
+;; QUESTION SECTION:
+;too-long-cname-chain.sub2.cname.recursor.engine.xa. IN A
+
+;; AUTHORITY SECTION:
+sub2.cname.recursor.engine.xa. 3600 IN  NS      ns1.sub2.cname.recursor.engine.xa.
+
+;; ADDITIONAL SECTION:
+ns1.sub2.cname.recursor.engine.xa. 3600 IN A    127.30.1.32
+ns1.sub2.cname.recursor.engine.xa. 3600 IN AAAA fda1:b2:c3:0:127:30:1:32
+
+;; Query time: 3 msec
+;; SERVER: 127.30.1.31#53(127.30.1.31) (UDP)
+;; WHEN: Tue Apr 07 10:59:15 CEST 2026
+;; MSG SIZE  rcvd: 27
+```
+--> OK
 
 Scenario name                | Expected output
 :----------------------------|:---------------------------------------------------------------------------------------------
-TOO-LONG-CNAME-CHAIN         | ??
+TOO-MANY-CNAME               | Undefined and tag `CNAME_RECORDS_TOO_MANY`
 ```
-; <<>> DiG 9.18.18-0ubuntu0.22.04.1-Ubuntu <<>> @127.30.1.31 too-long-cname-chain.cname.recursor.engine.xa
+; <<>> DiG 9.18.18-0ubuntu0.22.04.1-Ubuntu <<>> @127.30.1.31 too-many-cname.cname.recursor.engine.xa
 ; (1 server found)
 ;; global options: +cmd
 ;; Got answer:
@@ -537,20 +570,20 @@ TOO-LONG-CNAME-CHAIN         | ??
 ; EDNS: version: 0, flags:; udp: 1232
 ; COOKIE: 5b12662406062bc6 (echoed)
 ;; QUESTION SECTION:
-;too-long-cname-chain.cname.recursor.engine.xa. IN A
+;too-many-cname.cname.recursor.engine.xa. IN A
 
 ;; ANSWER SECTION:
-too-long-cname-chain.cname.recursor.engine.xa. 3600 IN CNAME too-long-cname-chain-two.cname.recursor.engine.xa.
-too-long-cname-chain-two.cname.recursor.engine.xa. 3600	IN CNAME too-long-cname-chain-three.cname.recursor.engine.xa.
-too-long-cname-chain-three.cname.recursor.engine.xa. 3600 IN CNAME too-long-cname-chain-four.cname.recursor.engine.xa.
-too-long-cname-chain-four.cname.recursor.engine.xa. 3600 IN CNAME too-long-cname-chain-five.cname.recursor.engine.xa.
-too-long-cname-chain-five.cname.recursor.engine.xa. 3600 IN CNAME too-long-cname-chain-six.cname.recursor.engine.xa.
-too-long-cname-chain-six.cname.recursor.engine.xa. 3600	IN CNAME too-long-cname-chain-seven.cname.recursor.engine.xa.
-too-long-cname-chain-seven.cname.recursor.engine.xa. 3600 IN CNAME too-long-cname-chain-eight.cname.recursor.engine.xa.
-too-long-cname-chain-eight.cname.recursor.engine.xa. 3600 IN CNAME too-long-cname-chain-nine.cname.recursor.engine.xa.
-too-long-cname-chain-nine.cname.recursor.engine.xa. 3600 IN CNAME too-long-cname-chain-ten.cname.recursor.engine.xa.
-too-long-cname-chain-ten.cname.recursor.engine.xa. 3600	IN CNAME too-long-cname-chain-target.cname.recursor.engine.xa.
-too-long-cname-chain-target.cname.recursor.engine.xa. 3600 IN A	127.0.0.1
+too-many-cname.cname.recursor.engine.xa. 3600 IN CNAME too-many-cname-two.cname.recursor.engine.xa.
+too-many-cname-two.cname.recursor.engine.xa. 3600	IN CNAME too-many-cname-three.cname.recursor.engine.xa.
+too-many-cname-three.cname.recursor.engine.xa. 3600 IN CNAME too-many-cname-four.cname.recursor.engine.xa.
+too-many-cname-four.cname.recursor.engine.xa. 3600 IN CNAME too-many-cname-five.cname.recursor.engine.xa.
+too-many-cname-five.cname.recursor.engine.xa. 3600 IN CNAME too-many-cname-six.cname.recursor.engine.xa.
+too-many-cname-six.cname.recursor.engine.xa. 3600	IN CNAME too-many-cname-seven.cname.recursor.engine.xa.
+too-many-cname-seven.cname.recursor.engine.xa. 3600 IN CNAME too-many-cname-eight.cname.recursor.engine.xa.
+too-many-cname-eight.cname.recursor.engine.xa. 3600 IN CNAME too-many-cname-nine.cname.recursor.engine.xa.
+too-many-cname-nine.cname.recursor.engine.xa. 3600 IN CNAME too-many-cname-ten.cname.recursor.engine.xa.
+too-many-cname-ten.cname.recursor.engine.xa. 3600	IN CNAME too-many-cname-target.cname.recursor.engine.xa.
+too-many-cname-target.cname.recursor.engine.xa. 3600 IN A	127.0.0.1
 
 ;; AUTHORITY SECTION:
 cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa.
@@ -689,7 +722,10 @@ cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa.
 ;; MSG SIZE  rcvd: 341
 ```
 
-
+Scenario name                | Expected output
+:----------------------------|:---------------------------------------------------------------------------------------------
+UNRESOLVABLE-CNAME           | ??
+--> Untested
 
 
 [CNAME.md]:                            ../../../docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md

--- a/test-zone-data/Engine/Recursor-PM/README.md
+++ b/test-zone-data/Engine/Recursor-PM/README.md
@@ -724,9 +724,32 @@ cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa.
 
 Scenario name                | Expected output
 :----------------------------|:---------------------------------------------------------------------------------------------
-UNRESOLVABLE-CNAME           | ??
---> Untested
+UNRESOLVABLE-CNAME           | Undefined and tag `CNAME_UNRESOLVABLE`
+```
+; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> A unresolvable-cname.cname.recursor.engine.xa @127.30.1.31
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 25446
+;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 1
+;; WARNING: recursion requested but not available
 
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 1232
+; COOKIE: cfd83b80ec1432a2 (echoed)
+;; QUESTION SECTION:
+;unresolvable-cname.cname.recursor.engine.xa. IN        A
+
+;; ANSWER SECTION:
+unresolvable-cname.cname.recursor.engine.xa. 3600 IN CNAME target.unresolvable-cname.cname.recursor.engine.xa.
+
+;; AUTHORITY SECTION:
+cname.recursor.engine.xa. 3600  IN      NS      ns1.cname.recursor.engine.xa.
+
+;; Query time: 0 msec
+;; SERVER: 127.30.1.31#53(127.30.1.31) (UDP)
+;; WHEN: Tue May 12 15:24:03 CEST 2026
+;; MSG SIZE  rcvd: 25
+```
 
 [CNAME.md]:                            ../../../docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md
 [Recursor.pm]:                         https://github.com/zonemaster/zonemaster-engine/blob/master/lib/Zonemaster/Engine/Recursor.pm

--- a/test-zone-data/Engine/Recursor-PM/README.md
+++ b/test-zone-data/Engine/Recursor-PM/README.md
@@ -724,18 +724,47 @@ cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa.
 
 Scenario name                | Expected output
 :----------------------------|:---------------------------------------------------------------------------------------------
-UNRESOLVABLE-CNAME           | Undefined and tag `CNAME_UNRESOLVABLE`
+CNAME-CHAIN-TO-NODATA              | True and tag `CNAME_TO_NODATA`
 ```
-; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> A unresolvable-cname.cname.recursor.engine.xa @127.30.1.31
+; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> cname-chain-to-nodata.cname.recursor.engine.xa @127.30.1.31
 ;; global options: +cmd
 ;; Got answer:
-;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 25446
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 63670
 ;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 1
 ;; WARNING: recursion requested but not available
 
 ;; OPT PSEUDOSECTION:
 ; EDNS: version: 0, flags:; udp: 1232
-; COOKIE: cfd83b80ec1432a2 (echoed)
+; COOKIE: c687f14b61093ebf (echoed)
+;; QUESTION SECTION:
+;cname-chain-to-nodata.cname.recursor.engine.xa.        IN A
+
+;; ANSWER SECTION:
+cname-chain-to-nodata.cname.recursor.engine.xa. 3600 IN CNAME target.cname-chain-to-nodata.cname.recursor.engine.xa.
+
+;; AUTHORITY SECTION:
+cname.recursor.engine.xa. 3600  IN      NS      ns1.cname.recursor.engine.xa.
+
+;; Query time: 0 msec
+;; SERVER: 127.30.1.31#53(127.30.1.31) (UDP)
+;; WHEN: Tue Jun 09 17:18:47 CEST 2026
+;; MSG SIZE  rcvd: 266
+```
+
+Scenario name                | Expected output
+:----------------------------|:---------------------------------------------------------------------------------------------
+UNRESOLVABLE-CNAME           | Undefined and tag `CNAME_UNRESOLVABLE`
+```
+; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> unresolvable-cname.cname.recursor.engine.xa @127.30.1.31
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 16583
+;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 1
+;; WARNING: recursion requested but not available
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 1232
+; COOKIE: 7a75cf7418f8cfa6 (echoed)
 ;; QUESTION SECTION:
 ;unresolvable-cname.cname.recursor.engine.xa. IN        A
 
@@ -745,10 +774,29 @@ unresolvable-cname.cname.recursor.engine.xa. 3600 IN CNAME target.unresolvable-c
 ;; AUTHORITY SECTION:
 cname.recursor.engine.xa. 3600  IN      NS      ns1.cname.recursor.engine.xa.
 
+;; Query time: 3 msec
+;; SERVER: 127.30.1.31#53(127.30.1.31) (UDP)
+;; WHEN: Tue Jun 09 17:19:08 CEST 2026
+;; MSG SIZE  rcvd: 257
+```
+```
+; <<>> DiG 9.18.33-1~deb12u2-Debian <<>> target.unresolvable-cname.cname.recursor.engine.xa @127.30.1.31
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: FORMERR, id: 11669
+;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
+;; WARNING: recursion requested but not available
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 1232
+; COOKIE: 5d15536cbcfaab20 (echoed)
+;; QUESTION SECTION:
+;target.unresolvable-cname.cname.recursor.engine.xa. IN A
+
 ;; Query time: 0 msec
 ;; SERVER: 127.30.1.31#53(127.30.1.31) (UDP)
-;; WHEN: Tue May 12 15:24:03 CEST 2026
-;; MSG SIZE  rcvd: 25
+;; WHEN: Tue Jun 09 17:22:29 CEST 2026
+;; MSG SIZE  rcvd: 9
 ```
 
 [CNAME.md]:                            ../../../docs/public/specifications/test-zones/Engine/Recursor-PM/CNAME.md

--- a/test-zone-data/Engine/Recursor-PM/cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/cname.recursor.engine.xa
@@ -148,6 +148,12 @@ extra-cname-in-answer         A     127.0.0.1
 extra-cname-in-answer-1       CNAME extra-cname-in-answer-2
 
 
+; For scenario CNAME-CHAIN-TO-NODATA
+cname-chain-to-nodata            CNAME target.cname-chain-to-nodata
+target.cname-chain-to-nodata     TXT   "NODATA response"
+
+
 ; For scenario UNRESOLVABLE-CNAME
-unresolvable-cname            CNAME target.unresolvable-cname
-*.target.unresolvable-cname   TXT   "Breaks"
+unresolvable-cname           CNAME target.unresolvable-cname
+target.unresolvable-cname    TXT   "Unresolvable"
+

--- a/test-zone-data/Engine/Recursor-PM/cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/cname.recursor.engine.xa
@@ -62,7 +62,7 @@ looped-cname-in-zone-1        CNAME looped-cname-in-zone-1
 looped-cname-in-zone-3        CNAME looped-cname-in-zone-3-next
 looped-cname-in-zone-3-next   CNAME looped-cname-in-zone-3
 
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
+; For scenarios LOOPED-CNAME-OUT-OF-ZONE and TOO-LONG-CNAME-CHAIN
 sub2                          NS    ns1.sub2
 ns1.sub2                      A     127.30.1.32
 ns1.sub2                      AAAA  fda1:b2:c3:0:127:30:1:32
@@ -72,18 +72,55 @@ ns1.sub3                      A     127.30.1.33
 ns1.sub3                      AAAA  fda1:b2:c3:0:127:30:1:33
 
 ; For scenario TOO-LONG-CNAME-CHAIN
+sub4                          NS    ns1.sub4
+ns1.sub4                      A     127.30.1.35
+ns1.sub4                      AAAA  fda1:b2:c3:0:127:30:1:35
+
+sub5                          NS    ns1.sub5
+ns1.sub5                      A     127.30.1.36
+ns1.sub5                      AAAA  fda1:b2:c3:0:127:30:1:36
+
+sub6                          NS    ns1.sub6
+ns1.sub6                      A     127.30.1.37
+ns1.sub6                      AAAA  fda1:b2:c3:0:127:30:1:37
+
+sub7                          NS    ns1.sub7
+ns1.sub7                      A     127.30.1.38
+ns1.sub7                      AAAA  fda1:b2:c3:0:127:30:1:38
+
+sub8                          NS    ns1.sub8
+ns1.sub8                      A     127.30.1.39
+ns1.sub8                      AAAA  fda1:b2:c3:0:127:30:1:39
+
+sub9                          NS    ns1.sub9
+ns1.sub9                      A     127.30.1.40
+ns1.sub9                      AAAA  fda1:b2:c3:0:127:30:1:40
+
+sub10                         NS    ns1.sub10
+ns1.sub10                     A     127.30.1.41
+ns1.sub10                     AAAA  fda1:b2:c3:0:127:30:1:41
+
+sub11                         NS    ns1.sub11
+ns1.sub11                     A     127.30.1.42
+ns1.sub11                     AAAA  fda1:b2:c3:0:127:30:1:42
+
+sub12                         NS    ns1.sub12
+ns1.sub12                     A     127.30.1.43
+ns1.sub12                     AAAA  fda1:b2:c3:0:127:30:1:43
+
+; For scenario TOO-MANY-CNAME
 ; Defined in the cfg file
-; too-long-cname-chain              CNAME too-long-cname-chain-two
-; too-long-cname-chain-two          CNAME too-long-cname-chain-three
-; too-long-cname-chain-three        CNAME too-long-cname-chain-four
-; too-long-cname-chain-four         CNAME too-long-cname-chain-five
-; too-long-cname-chain-five         CNAME too-long-cname-chain-six
-; too-long-cname-chain-six          CNAME too-long-cname-chain-seven
-; too-long-cname-chain-seven        CNAME too-long-cname-chain-eight
-; too-long-cname-chain-eight        CNAME too-long-cname-chain-nine
-; too-long-cname-chain-nine         CNAME too-long-cname-chain-ten
-; too-long-cname-chain-ten          CNAME too-long-cname-chain-target
-; too-long-cname-chain-target       A     127.0.0.1
+; too-many-cname              CNAME too-many-cname-two
+; too-many-cname-two          CNAME too-many-cname-three
+; too-many-cname-three        CNAME too-many-cname-four
+; too-many-cname-four         CNAME too-many-cname-five
+; too-many-cname-five         CNAME too-many-cname-six
+; too-many-cname-six          CNAME too-many-cname-seven
+; too-many-cname-seven        CNAME too-many-cname-eight
+; too-many-cname-eight        CNAME too-many-cname-nine
+; too-many-cname-nine         CNAME too-many-cname-ten
+; too-many-cname-ten          CNAME too-many-cname-target
+; too-many-cname-target       A     127.0.0.1
 
 
 ; For scenario TARGET-NO-MATCH-CNAME

--- a/test-zone-data/Engine/Recursor-PM/cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/cname.recursor.engine.xa
@@ -146,3 +146,8 @@ wrong-cname-owner-name-target  A     127.0.0.1
 ; Also defined in the cfg file
 extra-cname-in-answer         A     127.0.0.1
 extra-cname-in-answer-1       CNAME extra-cname-in-answer-2
+
+
+; For scenario UNRESOLVABLE-CNAME
+unresolvable-cname            CNAME target.unresolvable-cname
+*.target.unresolvable-cname   TXT   "Breaks"

--- a/test-zone-data/Engine/Recursor-PM/recursor.cfg
+++ b/test-zone-data/Engine/Recursor-PM/recursor.cfg
@@ -45,26 +45,26 @@ cname.recursor.engine.xa:53 {
    }
 
    # For scenario LOOPED-CNAME-IN-ZONE-2
-   template IN ANY looped-cname-in-zone-2.cname.recursor.engine.xa {
+   template IN A looped-cname-in-zone-2.cname.recursor.engine.xa {
       answer     "looped-cname-in-zone-2.cname.recursor.engine.xa. 3600 IN CNAME looped-cname-in-zone-2-a.cname.recursor.engine.xa."
       answer     "looped-cname-in-zone-2-a.cname.recursor.engine.xa. 3600	IN CNAME looped-cname-in-zone-2-b.cname.recursor.engine.xa."
       answer     "looped-cname-in-zone-2-b.cname.recursor.engine.xa. 3600	IN CNAME looped-cname-in-zone-2-a.cname.recursor.engine.xa."
       authority  "cname.recursor.engine.xa. 3600	IN	NS	ns1.cname.recursor.engine.xa."
     }
 
-   # For scenario TOO-LONG-CNAME-CHAIN
-   template IN A too-long-cname-chain.cname.recursor.engine.xa {
-      answer     "too-long-cname-chain.cname.recursor.engine.xa.         3600 IN CNAME too-long-cname-chain-two.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-two.cname.recursor.engine.xa.     3600 IN CNAME too-long-cname-chain-three.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-three.cname.recursor.engine.xa.   3600 IN CNAME too-long-cname-chain-four.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-four.cname.recursor.engine.xa.    3600 IN CNAME too-long-cname-chain-five.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-five.cname.recursor.engine.xa.    3600 IN CNAME too-long-cname-chain-six.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-six.cname.recursor.engine.xa.     3600 IN CNAME too-long-cname-chain-seven.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-seven.cname.recursor.engine.xa.   3600 IN CNAME too-long-cname-chain-eight.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-eight.cname.recursor.engine.xa.   3600 IN CNAME too-long-cname-chain-nine.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-nine.cname.recursor.engine.xa.    3600 IN CNAME too-long-cname-chain-ten.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-ten.cname.recursor.engine.xa.     3600 IN CNAME too-long-cname-chain-target.cname.recursor.engine.xa."
-      answer     "too-long-cname-chain-target.cname.recursor.engine.xa.  3600 IN A     127.0.0.1"
+   # For scenario TOO-MANY-CNAME
+   template IN A too-many-cname.cname.recursor.engine.xa {
+      answer     "too-many-cname.cname.recursor.engine.xa.         3600 IN CNAME too-many-cname-two.cname.recursor.engine.xa."
+      answer     "too-many-cname-two.cname.recursor.engine.xa.     3600 IN CNAME too-many-cname-three.cname.recursor.engine.xa."
+      answer     "too-many-cname-three.cname.recursor.engine.xa.   3600 IN CNAME too-many-cname-four.cname.recursor.engine.xa."
+      answer     "too-many-cname-four.cname.recursor.engine.xa.    3600 IN CNAME too-many-cname-five.cname.recursor.engine.xa."
+      answer     "too-many-cname-five.cname.recursor.engine.xa.    3600 IN CNAME too-many-cname-six.cname.recursor.engine.xa."
+      answer     "too-many-cname-six.cname.recursor.engine.xa.     3600 IN CNAME too-many-cname-seven.cname.recursor.engine.xa."
+      answer     "too-many-cname-seven.cname.recursor.engine.xa.   3600 IN CNAME too-many-cname-eight.cname.recursor.engine.xa."
+      answer     "too-many-cname-eight.cname.recursor.engine.xa.   3600 IN CNAME too-many-cname-nine.cname.recursor.engine.xa."
+      answer     "too-many-cname-nine.cname.recursor.engine.xa.    3600 IN CNAME too-many-cname-ten.cname.recursor.engine.xa."
+      answer     "too-many-cname-ten.cname.recursor.engine.xa.     3600 IN CNAME too-many-cname-target.cname.recursor.engine.xa."
+      answer     "too-many-cname-target.cname.recursor.engine.xa.  3600 IN A     127.0.0.1"
       authority  "cname.recursor.engine.xa.                              3600 IN NS    ns1.cname.recursor.engine.xa."
    }
 
@@ -122,3 +122,74 @@ goodsub.cname.recursor.engine.xa:53 {
    file Engine/Recursor-PM/goodsub.cname.recursor.engine.xa goodsub.cname.recursor.engine.xa.
 }
 
+# ns1 sub4.cname.recursor.engine.xa
+sub4.cname.recursor.engine.xa:53 {
+   bind 127.30.1.35
+   bind fda1:b2:c3:0:127:30:1:35
+   log
+   file Engine/Recursor-PM/sub4.cname.recursor.engine.xa sub4.cname.recursor.engine.xa.
+}
+
+# ns1 sub5.cname.recursor.engine.xa
+sub5.cname.recursor.engine.xa:53 {
+   bind 127.30.1.36
+   bind fda1:b2:c3:0:127:30:1:36
+   log
+   file Engine/Recursor-PM/sub5.cname.recursor.engine.xa sub5.cname.recursor.engine.xa.
+}
+
+# ns1 sub6.cname.recursor.engine.xa
+sub6.cname.recursor.engine.xa:53 {
+   bind 127.30.1.37
+   bind fda1:b2:c3:0:127:30:1:37
+   log
+   file Engine/Recursor-PM/sub6.cname.recursor.engine.xa sub6.cname.recursor.engine.xa.
+}
+
+# ns1 sub7.cname.recursor.engine.xa
+sub7.cname.recursor.engine.xa:53 {
+   bind 127.30.1.38
+   bind fda1:b2:c3:0:127:30:1:38
+   log
+   file Engine/Recursor-PM/sub7.cname.recursor.engine.xa sub7.cname.recursor.engine.xa.
+}
+
+# ns1 sub8.cname.recursor.engine.xa
+sub8.cname.recursor.engine.xa:53 {
+   bind 127.30.1.39
+   bind fda1:b2:c3:0:127:30:1:39
+   log
+   file Engine/Recursor-PM/sub8.cname.recursor.engine.xa sub8.cname.recursor.engine.xa.
+}
+
+# ns1 sub9.cname.recursor.engine.xa
+sub9.cname.recursor.engine.xa:53 {
+   bind 127.30.1.40
+   bind fda1:b2:c3:0:127:30:1:40
+   log
+   file Engine/Recursor-PM/sub9.cname.recursor.engine.xa sub9.cname.recursor.engine.xa.
+}
+
+# ns1 sub10.cname.recursor.engine.xa
+sub10.cname.recursor.engine.xa:53 {
+   bind 127.30.1.41
+   bind fda1:b2:c3:0:127:30:1:41
+   log
+   file Engine/Recursor-PM/sub10.cname.recursor.engine.xa sub10.cname.recursor.engine.xa.
+}
+
+# ns1 sub11.cname.recursor.engine.xa
+sub11.cname.recursor.engine.xa:53 {
+   bind 127.30.1.42
+   bind fda1:b2:c3:0:127:30:1:42
+   log
+   file Engine/Recursor-PM/sub11.cname.recursor.engine.xa sub11.cname.recursor.engine.xa.
+}
+
+# ns1 sub12.cname.recursor.engine.xa
+sub12.cname.recursor.engine.xa:53 {
+   bind 127.30.1.43
+   bind fda1:b2:c3:0:127:30:1:43
+   log
+   file Engine/Recursor-PM/sub12.cname.recursor.engine.xa sub12.cname.recursor.engine.xa.
+}

--- a/test-zone-data/Engine/Recursor-PM/recursor.cfg
+++ b/test-zone-data/Engine/Recursor-PM/recursor.cfg
@@ -45,7 +45,7 @@ cname.recursor.engine.xa:53 {
    }
 
    # For scenario LOOPED-CNAME-IN-ZONE-2
-   template IN A looped-cname-in-zone-2.cname.recursor.engine.xa {
+   template IN ANY looped-cname-in-zone-2.cname.recursor.engine.xa {
       answer     "looped-cname-in-zone-2.cname.recursor.engine.xa. 3600 IN CNAME looped-cname-in-zone-2-a.cname.recursor.engine.xa."
       answer     "looped-cname-in-zone-2-a.cname.recursor.engine.xa. 3600	IN CNAME looped-cname-in-zone-2-b.cname.recursor.engine.xa."
       answer     "looped-cname-in-zone-2-b.cname.recursor.engine.xa. 3600	IN CNAME looped-cname-in-zone-2-a.cname.recursor.engine.xa."

--- a/test-zone-data/Engine/Recursor-PM/recursor.cfg
+++ b/test-zone-data/Engine/Recursor-PM/recursor.cfg
@@ -70,8 +70,8 @@ cname.recursor.engine.xa:53 {
 
    # For scenario TARGET-NO-MATCH-CNAME
    template IN A target-no-match-cname.cname.recursor.engine.xa {
-      answer     "target-no-match-cname.cname.recursor.engine.xa.        3600 IN CNAME target-no-match-cname-two.cname.recursor.engine.xa."
-      answer     "target-no-match-cname-target.cname.recursor.engine.xa. 3600 IN A     127.0.0.1"
+      answer     "TARGET-no-match-cname.cname.recursor.engine.xa.        3600 IN CNAME target-NO-match-cname-two.cname.recursor.engine.xa."
+      answer     "target-no-MATCH-cname-target.cname.recursor.engine.xa. 3600 IN A     127.0.0.1"
       authority  "cname.recursor.engine.xa.                              3600 IN NS    ns1.cname.recursor.engine.xa."
    }
 

--- a/test-zone-data/Engine/Recursor-PM/recursor.cfg
+++ b/test-zone-data/Engine/Recursor-PM/recursor.cfg
@@ -96,6 +96,11 @@ cname.recursor.engine.xa:53 {
       answer     "extra-cname-in-answer-1.cname.recursor.engine.xa.         3600 IN CNAME extra-cname-in-answer-2.cname.recursor.engine.xa."
       authority  "cname.recursor.engine.xa.                                 3600 IN NS    ns1.cname.recursor.engine.xa."
    }
+
+   # For scenario UNRESOLVABLE-CNAME
+   template IN A target.unresolvable-cname.cname.recursor.engine.xa {
+      rcode FORMERR
+   }
 }
 
 # ns1 sub2.cname.recursor.engine.xa

--- a/test-zone-data/Engine/Recursor-PM/sub10.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub10.cname.recursor.engine.xa
@@ -1,5 +1,5 @@
 $TTL 3600
-$ORIGIN sub2.cname.recursor.engine.xa.
+$ORIGIN sub10.cname.recursor.engine.xa.
 
 @                          SOA  (
                                    ns1
@@ -12,11 +12,8 @@ $ORIGIN sub2.cname.recursor.engine.xa.
                                  )
 
 @                          NS    ns1
-ns1                        A     127.30.1.32
-ns1                        AAAA  fda1:b2:c3:0:127:30:1:32
-
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
-looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub3.cname.recursor.engine.xa.
+ns1                        A     127.30.1.41
+ns1                        AAAA  fda1:b2:c3:0:127:30:1:41
 
 ; For scenario TOO-LONG-CNAME-CHAIN
-too-long-cname-chain   CNAME   too-long-cname-chain.sub3.cname.recursor.engine.xa.
+too-long-cname-chain   CNAME   too-long-cname-chain.sub11.cname.recursor.engine.xa.

--- a/test-zone-data/Engine/Recursor-PM/sub11.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub11.cname.recursor.engine.xa
@@ -1,5 +1,5 @@
 $TTL 3600
-$ORIGIN sub2.cname.recursor.engine.xa.
+$ORIGIN sub11.cname.recursor.engine.xa.
 
 @                          SOA  (
                                    ns1
@@ -12,11 +12,8 @@ $ORIGIN sub2.cname.recursor.engine.xa.
                                  )
 
 @                          NS    ns1
-ns1                        A     127.30.1.32
-ns1                        AAAA  fda1:b2:c3:0:127:30:1:32
-
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
-looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub3.cname.recursor.engine.xa.
+ns1                        A     127.30.1.42
+ns1                        AAAA  fda1:b2:c3:0:127:30:1:42
 
 ; For scenario TOO-LONG-CNAME-CHAIN
-too-long-cname-chain   CNAME   too-long-cname-chain.sub3.cname.recursor.engine.xa.
+too-long-cname-chain   CNAME   too-long-cname-chain.sub12.cname.recursor.engine.xa.

--- a/test-zone-data/Engine/Recursor-PM/sub12.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub12.cname.recursor.engine.xa
@@ -1,5 +1,5 @@
 $TTL 3600
-$ORIGIN sub2.cname.recursor.engine.xa.
+$ORIGIN sub12.cname.recursor.engine.xa.
 
 @                          SOA  (
                                    ns1
@@ -12,11 +12,8 @@ $ORIGIN sub2.cname.recursor.engine.xa.
                                  )
 
 @                          NS    ns1
-ns1                        A     127.30.1.32
-ns1                        AAAA  fda1:b2:c3:0:127:30:1:32
-
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
-looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub3.cname.recursor.engine.xa.
+ns1                        A     127.30.1.43
+ns1                        AAAA  fda1:b2:c3:0:127:30:1:43
 
 ; For scenario TOO-LONG-CNAME-CHAIN
-too-long-cname-chain   CNAME   too-long-cname-chain.sub3.cname.recursor.engine.xa.
+too-long-cname-chain   CNAME   too-long-cname-chain.sub13.cname.recursor.engine.xa.

--- a/test-zone-data/Engine/Recursor-PM/sub3.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub3.cname.recursor.engine.xa
@@ -15,7 +15,8 @@ $ORIGIN sub3.cname.recursor.engine.xa.
 ns1                        A     127.30.1.33
 ns1                        AAAA  fda1:b2:c3:0:127:30:1:33
 
-
 ; For scenario LOOPED-CNAME-OUT-OF-ZONE
 looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub2.cname.recursor.engine.xa.
 
+; For scenario TOO-LONG-CNAME-CHAIN
+too-long-cname-chain   CNAME   too-long-cname-chain.sub4.cname.recursor.engine.xa.

--- a/test-zone-data/Engine/Recursor-PM/sub4.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub4.cname.recursor.engine.xa
@@ -1,5 +1,5 @@
 $TTL 3600
-$ORIGIN sub2.cname.recursor.engine.xa.
+$ORIGIN sub4.cname.recursor.engine.xa.
 
 @                          SOA  (
                                    ns1
@@ -12,11 +12,8 @@ $ORIGIN sub2.cname.recursor.engine.xa.
                                  )
 
 @                          NS    ns1
-ns1                        A     127.30.1.32
-ns1                        AAAA  fda1:b2:c3:0:127:30:1:32
-
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
-looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub3.cname.recursor.engine.xa.
+ns1                        A     127.30.1.35
+ns1                        AAAA  fda1:b2:c3:0:127:30:1:35
 
 ; For scenario TOO-LONG-CNAME-CHAIN
-too-long-cname-chain   CNAME   too-long-cname-chain.sub3.cname.recursor.engine.xa.
+too-long-cname-chain   CNAME   too-long-cname-chain.sub5.cname.recursor.engine.xa.

--- a/test-zone-data/Engine/Recursor-PM/sub5.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub5.cname.recursor.engine.xa
@@ -1,5 +1,5 @@
 $TTL 3600
-$ORIGIN sub2.cname.recursor.engine.xa.
+$ORIGIN sub5.cname.recursor.engine.xa.
 
 @                          SOA  (
                                    ns1
@@ -12,11 +12,8 @@ $ORIGIN sub2.cname.recursor.engine.xa.
                                  )
 
 @                          NS    ns1
-ns1                        A     127.30.1.32
-ns1                        AAAA  fda1:b2:c3:0:127:30:1:32
-
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
-looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub3.cname.recursor.engine.xa.
+ns1                        A     127.30.1.36
+ns1                        AAAA  fda1:b2:c3:0:127:30:1:36
 
 ; For scenario TOO-LONG-CNAME-CHAIN
-too-long-cname-chain   CNAME   too-long-cname-chain.sub3.cname.recursor.engine.xa.
+too-long-cname-chain   CNAME   too-long-cname-chain.sub6.cname.recursor.engine.xa.

--- a/test-zone-data/Engine/Recursor-PM/sub6.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub6.cname.recursor.engine.xa
@@ -1,5 +1,5 @@
 $TTL 3600
-$ORIGIN sub2.cname.recursor.engine.xa.
+$ORIGIN sub6.cname.recursor.engine.xa.
 
 @                          SOA  (
                                    ns1
@@ -12,11 +12,8 @@ $ORIGIN sub2.cname.recursor.engine.xa.
                                  )
 
 @                          NS    ns1
-ns1                        A     127.30.1.32
-ns1                        AAAA  fda1:b2:c3:0:127:30:1:32
-
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
-looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub3.cname.recursor.engine.xa.
+ns1                        A     127.30.1.37
+ns1                        AAAA  fda1:b2:c3:0:127:30:1:37
 
 ; For scenario TOO-LONG-CNAME-CHAIN
-too-long-cname-chain   CNAME   too-long-cname-chain.sub3.cname.recursor.engine.xa.
+too-long-cname-chain   CNAME   too-long-cname-chain.sub7.cname.recursor.engine.xa.

--- a/test-zone-data/Engine/Recursor-PM/sub7.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub7.cname.recursor.engine.xa
@@ -1,5 +1,5 @@
 $TTL 3600
-$ORIGIN sub2.cname.recursor.engine.xa.
+$ORIGIN sub7.cname.recursor.engine.xa.
 
 @                          SOA  (
                                    ns1
@@ -12,11 +12,8 @@ $ORIGIN sub2.cname.recursor.engine.xa.
                                  )
 
 @                          NS    ns1
-ns1                        A     127.30.1.32
-ns1                        AAAA  fda1:b2:c3:0:127:30:1:32
-
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
-looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub3.cname.recursor.engine.xa.
+ns1                        A     127.30.1.38
+ns1                        AAAA  fda1:b2:c3:0:127:30:1:38
 
 ; For scenario TOO-LONG-CNAME-CHAIN
-too-long-cname-chain   CNAME   too-long-cname-chain.sub3.cname.recursor.engine.xa.
+too-long-cname-chain   CNAME   too-long-cname-chain.sub8.cname.recursor.engine.xa.

--- a/test-zone-data/Engine/Recursor-PM/sub8.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub8.cname.recursor.engine.xa
@@ -1,5 +1,5 @@
 $TTL 3600
-$ORIGIN sub2.cname.recursor.engine.xa.
+$ORIGIN sub8.cname.recursor.engine.xa.
 
 @                          SOA  (
                                    ns1
@@ -12,11 +12,8 @@ $ORIGIN sub2.cname.recursor.engine.xa.
                                  )
 
 @                          NS    ns1
-ns1                        A     127.30.1.32
-ns1                        AAAA  fda1:b2:c3:0:127:30:1:32
-
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
-looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub3.cname.recursor.engine.xa.
+ns1                        A     127.30.1.39
+ns1                        AAAA  fda1:b2:c3:0:127:30:1:39
 
 ; For scenario TOO-LONG-CNAME-CHAIN
-too-long-cname-chain   CNAME   too-long-cname-chain.sub3.cname.recursor.engine.xa.
+too-long-cname-chain   CNAME   too-long-cname-chain.sub9.cname.recursor.engine.xa.

--- a/test-zone-data/Engine/Recursor-PM/sub9.cname.recursor.engine.xa
+++ b/test-zone-data/Engine/Recursor-PM/sub9.cname.recursor.engine.xa
@@ -1,5 +1,5 @@
 $TTL 3600
-$ORIGIN sub2.cname.recursor.engine.xa.
+$ORIGIN sub9.cname.recursor.engine.xa.
 
 @                          SOA  (
                                    ns1
@@ -12,11 +12,8 @@ $ORIGIN sub2.cname.recursor.engine.xa.
                                  )
 
 @                          NS    ns1
-ns1                        A     127.30.1.32
-ns1                        AAAA  fda1:b2:c3:0:127:30:1:32
-
-; For scenario LOOPED-CNAME-OUT-OF-ZONE
-looped-cname-out-of-zone   CNAME   looped-cname-out-of-zone.sub3.cname.recursor.engine.xa.
+ns1                        A     127.30.1.40
+ns1                        AAAA  fda1:b2:c3:0:127:30:1:40
 
 ; For scenario TOO-LONG-CNAME-CHAIN
-too-long-cname-chain   CNAME   too-long-cname-chain.sub3.cname.recursor.engine.xa.
+too-long-cname-chain   CNAME   too-long-cname-chain.sub10.cname.recursor.engine.xa.

--- a/test-zone-data/address-plan.md
+++ b/test-zone-data/address-plan.md
@@ -616,6 +616,15 @@ Follow the same pattern as in use by adding the address without prefix, e.g. as
 | 127.30.1.32     | ns1.sub2.cname.recursor.engine.xa                           |
 | 127.30.1.33     | ns1.sub3.cname.recursor.engine.xa                           |
 | 127.30.1.34     | ns1.goodsub.cname.recursor.engine.xa                        |
+| 127.30.1.35     | ns1.sub4.cname.recursor.engine.xa                           |
+| 127.30.1.36     | ns1.sub5.cname.recursor.engine.xa                           |
+| 127.30.1.37     | ns1.sub6.cname.recursor.engine.xa                           |
+| 127.30.1.38     | ns1.sub7.cname.recursor.engine.xa                           |
+| 127.30.1.39     | ns1.sub8.cname.recursor.engine.xa                           |
+| 127.30.1.40     | ns1.sub9.cname.recursor.engine.xa                           |
+| 127.30.1.41     | ns1.sub10.cname.recursor.engine.xa                          |
+| 127.30.1.42     | ns1.sub11.cname.recursor.engine.xa                          |
+| 127.30.1.43     | ns1.sub12.cname.recursor.engine.xa                          |
 | 127.30.2.0/24   | (not in use)                                                |
 | (...)           |                                                             |
 | 127.30.255.0/24 | (not in use)                                                |


### PR DESCRIPTION
## Purpose

This PR updates test scenarios related to CNAME. See the `Changes` section below for more details.

## Context

N/A

## Changes

- Move content of scenario `TOO-LONG-CNAME-CHAIN` to a new scenario `TOO-MANY-CNAME`
- Update scenario `TOO-LONG-CNAME-CHAIN` to test for abnormally long chained CNAME lookups (tag `CNAME_CHAIN_TOO_LONG`)
- Add scenario `UNRESOLVABLE-CNAME`
- Add scenario `CNAME-CHAIN-TO-NODATA`

## How to test this PR

N/A. Review.
