### PR TITLE
Delete duplicate paragraph on front page of https://doc.zonemaster.net

### DIFF
--- a/docs/README-for-doc.zonemaster.net.md
+++ b/docs/README-for-doc.zonemaster.net.md
@@ -16,10 +16,6 @@ Zonemaster consists of several modules or components. The components will help
 different types of users to check domain servers for configuration errors and
 generate a report that will assist in fixing the errors.
 
-Zonemaster consists of several modules or components. The components will help
-different types of users to check domain servers for configuration errors and
-generate a report that will assist in fixing the errors.
-
 Zonemaster is developed by [Afnic] and [The Swedish Internet Foundation].
 
 A public instance is running on [zonemaster.net].


### PR DESCRIPTION
## Purpose

This PR deletes a paragraph that appears in duplicate on the front page of https://doc.zonemaster.net.

This section should be in sync with the README.md file at the top of the repository. But the error only appears in one place, so no further action is required.

## Context

N/A

## Changes

* Remove a paragraph that was included twice.

## How to test this PR

Review.
