### PR TITLE
MethodsV2: fix mistake in CHILD-NS-CNAME-4 spec

### DIFF
--- a/test-zone-data/MethodsV2/README.md
+++ b/test-zone-data/MethodsV2/README.md
@@ -1260,6 +1260,7 @@ child.parent.child-ns-cname-4.methodsv2.xa
   * ns2.parent.child-ns-cname-4.methodsv2.xa/fda1:b2:c3:0:127:40:1:42
 * Get delegation NS names and IP addresses
   * ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51
+  * ns2-cname.child.parent.child-ns-cname-4.methodsv2.xa
 * Get zone NS names and IP addresses
   * ns1-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.51
   * ns2-cname.child.parent.child-ns-cname-4.methodsv2.xa/127.40.1.52


### PR DESCRIPTION
## Purpose

This PR fixes an error in the CHILD-NS-CNAME-4 test scenario for MethodsV2.

In that scenario, the zone under test is delegated to two in-domain name servers, one of which has glue records while the other one does not.

In other words, the delegation to the zone contains `ns1-cname/127.40.1.51` and `ns2-cname`.

But if we look at Get-Del-NS-Names-and-IPs, Step 1 instructs to use Get-Delegation to “get the set of name servers where each unique name server name is linked *to a possibly empty set of its IP addresses*” (emphasis mine). Yet `ns2-cname`, which is one of those names without IP addresses linked to it, is missing from the expected data. That name server should be returned as a bare name in Get-Delegation, and therefore Get-Del-NS-Names-and-IPs as well.

## Context

Discovered while addressing zonemaster/zonemaster-engine#1545.

Implemented in zonemaster/zonemaster-engine#1546.

## Changes

 * Expected output of Get-Del-NS-Names-and-IPs for CHILD-NS-CNAME-4.

## How to test this PR

Review.
